### PR TITLE
Add Google Firebase support to release action

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -13,14 +13,12 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     environment: development
     permissions:
       contents: write
 
     steps:
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -70,6 +68,15 @@ jobs:
       - name: Set 'git describe --tags' as version
         id: get-version
         run: echo "VERSION=$(git describe --tags)" >> $GITHUB_OUTPUT
+
+      - name: Decode Google services
+        env:
+          ENCODED_STRING: ${{ secrets.GOOGLE_SERVICES }}
+          GOOGLE_SERVICES_PATH: ${{ secrets.GOOGLE_SERVICES_PATH }}
+
+        run: |
+          echo $ENCODED_STRING > google-services-b64.txt
+          base64 -d google-services-b64.txt > ${{ env.main_project_module }}/$GOOGLE_SERVICES_PATH
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -134,31 +141,67 @@ jobs:
       # Upload Artifact Build
       # Noted For Output [main_project_module]/build/outputs/apk/debug/
       - name: Upload APK Debug
-        env:
-          VERSION: ${{ steps.get-version.outputs.VERSION }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.VERSION }} - debug APK
+          name: debug-apk
           path: ${{ env.main_project_module }}/build/outputs/apk/debug/
 
       # Noted For Output [main_project_module]/build/outputs/apk/release/
       - name: Upload APK Release
         uses: actions/upload-artifact@v4
-        env:
-          VERSION: ${{ steps.get-version.outputs.VERSION }}
         with:
-          name: ${{ env.VERSION }} - release APK
+          name: release-apk
           path: |
             ${{ env.main_project_module }}/build/outputs/apk/release/
             ${{ env.main_project_module }}/build/outputs/mapping/release/
 
       # Noted For Output [main_project_module]/build/outputs/bundle/release/
       - name: Upload AAB (App Bundle) Release
-        env:
-          VERSION: ${{ steps.get-version.outputs.VERSION }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.VERSION }} - release AAB
+          name: release-aab
           path: |
             ${{ env.main_project_module }}/build/outputs/bundle/release/
             ${{ env.main_project_module }}/build/outputs/mapping/release/
+
+      # Generate android instrumentation tests APK
+      - name: Assemble Android Instrumentation Tests
+        run: ./gradlew assembleDebugAndroidTest
+      - name: Upload Android Test APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-androidTest
+          path: ${{ env.main_project_module }}/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+
+  firebase:
+    name: Run UI tests with Firebase Test Lab
+    needs: build
+    environment: development
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Download app APK
+        uses: actions/download-artifact@v4
+        with:
+          name: debug-apk
+
+      - name: Download Android test APK
+        uses: actions/download-artifact@v4
+        with:
+          name: debug-androidTest
+
+      - name: Auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCLOUD_CREDENTIALS_JSON }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Set current project
+        run: gcloud config set project ${{ secrets.FIREBASE_PROJECT_ID }}
+
+      - name: Run Instrumentation Tests in Firebase Test Lab
+        run: gcloud firebase test android run --type instrumentation --use-orchestrator --app app-debug.apk --test app-debug-androidTest.apk --device model=shiba,version=34,locale=en,orientation=portrait

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -34,6 +34,15 @@ jobs:
           distribution: 'zulu' # See 'Supported distributions' for available options
           java-version: '17'
 
+      - name: Decode Google services
+        env:
+          ENCODED_STRING: ${{ secrets.GOOGLE_SERVICES }}
+          GOOGLE_SERVICES_PATH: ${{ secrets.GOOGLE_SERVICES_PATH }}
+
+        run: |
+          echo $ENCODED_STRING > google-services-b64.txt
+          base64 -d google-services-b64.txt > ${{ env.main_project_module }}/$GOOGLE_SERVICES_PATH
+
       - name: Run lint over the repo
         run: ./gradlew lint
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("com.google.dagger.hilt.android")
     //id("org.jetbrains.kotlin.kapt")
     id("io.realm.kotlin")
+    id("com.google.gms.google-services")
 }
 
 android {
@@ -160,4 +161,8 @@ dependencies {
 
     // Audio engine
     implementation(files("libs/fmod.jar"))
+
+    // Firebase
+    implementation(platform("com.google.firebase:firebase-bom:33.1.2"))
+    implementation("com.google.firebase:firebase-analytics")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,5 @@ plugins {
     id("com.google.dagger.hilt.android") version "2.50" apply false
     id("io.realm.kotlin") version "1.13.0" apply false
     id("com.google.devtools.ksp") version "1.9.22-1.0.17" apply false
+    id("com.google.gms.google-services") version "4.4.2" apply false
 }


### PR DESCRIPTION
This change does a single Firebase device test after a release build has been tagged and made. It requires some more GitHub secrets so that the action knows how to authenticate with Firebase.