### PR TITLE
Enable Firebase crashylitics

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     //id("org.jetbrains.kotlin.kapt")
     id("io.realm.kotlin")
     id("com.google.gms.google-services")
-}
+    id("com.google.firebase.crashlytics")}
 
 android {
     namespace = "org.scottishtecharmy.soundscape"
@@ -164,5 +164,6 @@ dependencies {
 
     // Firebase
     implementation(platform("com.google.firebase:firebase-bom:33.1.2"))
+    implementation("com.google.firebase:firebase-crashlytics")
     implementation("com.google.firebase:firebase-analytics")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
     id("io.realm.kotlin") version "1.13.0" apply false
     id("com.google.devtools.ksp") version "1.9.22-1.0.17" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
+    id("com.google.firebase.crashlytics") version "3.0.2" apply false
 }


### PR DESCRIPTION
This requires a valid google-services.json. This is provided as a GitHub secret for release builds, but is a mock one for all other builds.