### PR TITLE
Further GpxTest work

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,7 +113,7 @@ dependencies {
     testImplementation ("org.jetbrains.kotlin:kotlin-test-junit:1.9.10")
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
 
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2023.08.00"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -153,7 +153,7 @@ dependencies {
     implementation("androidx.compose.runtime:runtime-livedata")
 
     // Realm for Kotlin
-    implementation("io.realm.kotlin:library-base:1.13.0")
+    implementation("io.realm.kotlin:library-base:1.16.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
 
     // Datastore for onboarding and settings

--- a/app/src/androidTest/java/org/scottishtecharmy/soundscape/GpxTest.kt
+++ b/app/src/androidTest/java/org/scottishtecharmy/soundscape/GpxTest.kt
@@ -1,13 +1,18 @@
 package org.scottishtecharmy.soundscape
 
 import android.util.Log
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import io.realm.kotlin.Realm
 import io.realm.kotlin.RealmConfiguration
+import io.realm.kotlin.ext.copyFromRealm
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Test
+import org.junit.runner.OrderWith
+import org.junit.runner.RunWith
+import org.junit.runner.manipulation.Alphanumeric
 import org.scottishtecharmy.soundscape.database.local.dao.RoutesDao
 import org.scottishtecharmy.soundscape.database.local.model.Location
 import org.scottishtecharmy.soundscape.database.local.model.RouteData
@@ -19,11 +24,16 @@ import org.scottishtecharmy.soundscape.utils.parseGpxFile
 // The GPX parsing code requires various pieces of Android infrastructure, so
 // this is an Instrumentation test rather than a unit test.
 
+@RunWith(AndroidJUnit4::class)
+@OrderWith(Alphanumeric::class)
 class GpxTest {
-    private fun testParsing(filename: String,
-                                    expectedValues: List<RoutePoint>,
-                                    expectedName: String = "",
-                                    expectedDescription: String = "") {
+    private fun testParsing(
+        filename: String,
+        expectedValues: List<RoutePoint>,
+        expectedName: String = "",
+        expectedDescription: String = "",
+        name_override: String? = null
+    ) {
 
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val input = context.assets.open(filename)
@@ -34,15 +44,27 @@ class GpxTest {
         Assert.assertEquals(expectedDescription, routeData.description)
         var index = 0
         for (point in routeData.waypoints) {
-            Log.d("gpxTest", "Point: " + point.name + " " + point.location?.latitude + " " + point.location?.longitude)
+            Log.d(
+                "gpxTest",
+                "Point: " + point.name + " " + point.location?.latitude + " " + point.location?.longitude
+            )
 
             // Lookup the point in the expected values map
             Assert.assertEquals(point, expectedValues[index])
             index += 1
         }
 
-        // The parsing has succeeded, test writing and retrieving from database
-        val config = RealmConfiguration.Builder(schema = setOf(RouteData::class, RoutePoint::class, Location::class))
+        if(name_override != null)
+            routeData.name = name_override
+
+        // The parsing has succeeded, write the result to the database
+        val config = RealmConfiguration.Builder(
+            schema = setOf(
+                RouteData::class,
+                RoutePoint::class,
+                Location::class
+            )
+        )
             .inMemory()
             .build()
         val realm = Realm.open(config)
@@ -61,35 +83,71 @@ class GpxTest {
                 Assert.assertEquals(1, routes.size)
                 //Assert.assertEquals(routeData, routes[0])
 
+            }
+        }
+    }
+
+    private fun testDatabase(
+        name: String,
+        expectedValues: List<RoutePoint>
+    ) {
+        // Open the database
+        val config = RealmConfiguration.Builder(
+            schema = setOf(
+                RouteData::class,
+                RoutePoint::class,
+                Location::class
+            )
+        )
+            .inMemory()
+            .build()
+        val realm = Realm.open(config)
+        Log.d("gpxTest", "Successfully opened an in-memory realm")
+
+        val routesDao = RoutesDao(realm)
+        val routesRepository = RoutesRepository(routesDao)
+        runBlocking {
+            launch {
                 // Query waypoints directly
                 var waypoints = routesRepository.getWaypoints()
+                var waypointCount = waypoints.size
                 Log.d("gpxTest", "Retrieved waypoints: " + waypoints.size)
 
-                // Geospatial test
+                // Geospatial test - pick the first waypoint and get waypoints near it. Should
+                // always be greater than 0 as the first waypoint is itself
                 waypoints = routesRepository.getWaypointsNear(waypoints[0].location, 0.1)
                 Log.d("gpxTest", "Retrieved geo waypoints: " + waypoints.size)
+                Assert.assertTrue(waypoints.size > 0)
+
+                // Get the route for use later
+                val db_routes = routesRepository.getRoute(name)
+                Assert.assertEquals(1, db_routes.size)
+                val routeData = db_routes[0].copyFromRealm()
 
                 // Delete the route and check that it's gone
                 Log.d("gpxTest", "Delete route")
-                routesRepository.deleteRoute(routeData.name)
-                routes = routesRepository.getRoute(routeData.name)
+                routesRepository.deleteRoute(name)
+                waypointCount -= routeData.waypoints.size
+
+                var routes = routesRepository.getRoute(name)
                 Assert.assertEquals(0, routes.size)
                 waypoints = routesRepository.getWaypoints()
                 Log.d("gpxTest", "Post delete waypoints: " + waypoints.size)
-                Assert.assertEquals(0, waypoints.size)
+                Assert.assertEquals(waypointCount, waypoints.size)
 
                 // Check that double insertion is rejected
                 Log.d("gpxTest", "Attempt inserting duplicate route")
                 routesRepository.insertRoute(routeData)
+                waypointCount += routeData.waypoints.size
 
-                if(routesRepository.insertRoute(routeData)) {
+                if (routesRepository.insertRoute(routeData)) {
                     Assert.fail("Duplicate insertion should have failed")
                 } else {
                     Log.d("gpxTest", "Duplicate insertion failed correctly")
                 }
 
                 // Check there's still a route left
-                routes = routesRepository.getRoute(routeData.name)
+                routes = routesRepository.getRoute(name)
                 Assert.assertEquals(1, routes.size)
                 Assert.assertEquals(routeData, routes[0])
 
@@ -102,45 +160,43 @@ class GpxTest {
 
                 // Update the database route with the waypoints reversed
                 routeData.waypoints.clear()
-                for(point in expectedValues.reversed()) {
+                for (point in expectedValues.reversed()) {
                     routeData.waypoints.add(point)
                 }
                 routesRepository.updateRoute(routeData)
 
                 // Get the route back from the database and check that the waypoints are reversed
-                routes = routesRepository.getRoute(routeData.name)
+                routes = routesRepository.getRoute(name)
                 Assert.assertEquals(1, routes.size)
                 Assert.assertEquals(expectedValues.size, routes[0].waypoints.size)
-                index = 0
-                for(point in routes[0].waypoints.reversed()) {
+                var index = 0
+                for (point in routes[0].waypoints.reversed()) {
                     Assert.assertEquals(point, expectedValues[index])
                     index += 1
                 }
 
                 // Delete that route to leave the database empty for the next test
                 routesRepository.deleteRoute(routeData.name)
+                waypointCount -= routeData.waypoints.size
 
                 waypoints = routesRepository.getWaypoints()
-                Assert.assertEquals(0, waypoints.size)
+                Assert.assertEquals(waypointCount, waypoints.size)
             }
         }
     }
 
-    @Test
-    fun handcraftedParsing(){
+    private fun expectedHandcraftedValues(): List<RoutePoint> {
 
         val waypoint1 = RoutePoint("George Square, Glasgow", Location(55.8610697, -4.2499327))
         val waypoint2 = RoutePoint("Edinburgh Castle", Location(55.9488161, -3.2021476))
         val waypoint3 = RoutePoint("Greenwich Prime Meridian, London", Location(51.4779644, 0.0))
         val waypoint4 = RoutePoint("Rock of Gibraltar", Location(36.1636308, -5.392716))
         val waypoint5 = RoutePoint("Inverness", Location(57.4680357, -4.263057))
-        val expectedValues = listOf(waypoint1, waypoint2, waypoint3, waypoint4, waypoint5)
 
-        testParsing("gpx/handcrafted.gpx", expectedValues, "Test", "Test?")
+        return listOf(waypoint1, waypoint2, waypoint3, waypoint4, waypoint5)
     }
 
-    @Test
-    fun rideWithGpsParsing(){
+    private fun expectedRideWithGpsValues(): List<RoutePoint> {
 
         val waypoint1 = RoutePoint("Slight Left", Location(55.94722, -4.30844))
         val waypoint2 = RoutePoint("Right", Location(55.94628, -4.30901))
@@ -152,13 +208,20 @@ class GpxTest {
         val waypoint8 = RoutePoint("Left", Location(55.94229, -4.31637))
         val waypoint9 = RoutePoint("Right", Location(55.94218, -4.31735))
 
-        val expectedValues = listOf(waypoint1, waypoint2, waypoint3, waypoint4, waypoint5, waypoint6, waypoint7, waypoint8, waypoint9)
-
-        testParsing("gpx/rideWithGps.gpx", expectedValues, "Test", "")
+        return listOf(
+            waypoint1,
+            waypoint2,
+            waypoint3,
+            waypoint4,
+            waypoint5,
+            waypoint6,
+            waypoint7,
+            waypoint8,
+            waypoint9
+        )
     }
 
-    @Test
-    fun soundscapeParsing(){
+    private fun expectedSoundscapeValues(): List<RoutePoint> {
 
         val waypoint1 = RoutePoint("Waypoint", Location(55.947256, -4.305852))
         val waypoint2 = RoutePoint("Waypoint", Location(55.946412, -4.305621))
@@ -169,8 +232,91 @@ class GpxTest {
         val waypoint7 = RoutePoint("Waypoint", Location(55.946436, -4.305745))
         val waypoint8 = RoutePoint("Waypoint", Location(55.947286, -4.305696))
 
-        val expectedValues = listOf(waypoint1, waypoint2, waypoint3, waypoint4, waypoint5, waypoint6, waypoint7, waypoint8)
+        return listOf(
+            waypoint1,
+            waypoint2,
+            waypoint3,
+            waypoint4,
+            waypoint5,
+            waypoint6,
+            waypoint7,
+            waypoint8
+        )
+    }
 
-        testParsing("gpx/soundscape.gpx", expectedValues, "Test", "Test?")
+    // The tests are run alphanumerically, so those starting with a are run first
+    @Test
+    fun aHandcraftedParsing() {
+        val expectedValues = expectedHandcraftedValues()
+        testParsing("gpx/handcrafted.gpx", expectedValues, "Handcrafted", "Handcrafted description")
+    }
+
+    @Test
+    fun aRideWithGpsParsing() {
+        val expectedValues = expectedRideWithGpsValues()
+        testParsing("gpx/rideWithGps.gpx", expectedValues, "RideWithGps", "")
+    }
+
+    @Test
+    fun aSoundscapeParsing() {
+        val expectedValues = expectedSoundscapeValues()
+        testParsing("gpx/soundscape.gpx", expectedValues, "Soundscape", "Soundscape description")
+    }
+
+    @Test
+    fun aSoundscapeDuplicateParsing() {
+        // Create a second Soundscape route, the only difference is its name. This is to test
+        // that duplicate waypoints work
+        val expectedValues = expectedSoundscapeValues()
+        testParsing("gpx/soundscape.gpx", expectedValues, "Soundscape", "Soundscape description", "Soundscape2")
+    }
+
+    // We have populated the database with imported GPX, so validate the database access
+    @Test
+    fun bHandcraftedDatabase() {
+        val expectedValues = expectedHandcraftedValues()
+        testDatabase("Handcrafted", expectedValues)
+    }
+    @Test
+    fun bRideWithGpsDatabase() {
+        val expectedValues = expectedRideWithGpsValues()
+        testDatabase("RideWithGps", expectedValues)
+    }
+    @Test
+    fun bSoundscapeDatabase() {
+        val expectedValues = expectedSoundscapeValues()
+        testDatabase("Soundscape", expectedValues)
+    }
+    @Test
+    fun bSoundscapeDuplicateDatabase() {
+        val expectedValues = expectedSoundscapeValues()
+        testDatabase("Soundscape2", expectedValues)
+    }
+
+    // Test that nothing has been left in the database
+    @Test
+    fun cTestEmpty() {
+        // The parsing has succeeded, write the result to the database
+        val config = RealmConfiguration.Builder(
+            schema = setOf(
+                RouteData::class,
+                RoutePoint::class,
+                Location::class
+            )
+        )
+            .inMemory()
+            .build()
+        val realm = Realm.open(config)
+        Log.d("gpxTest", "Successfully opened an in-memory realm")
+
+        val routesDao = RoutesDao(realm)
+        val routesRepository = RoutesRepository(routesDao)
+
+        runBlocking {
+            launch {
+                var waypoints = routesRepository.getWaypoints()
+                Assert.assertEquals(0, waypoints.size)
+            }
+        }
     }
 }

--- a/app/src/main/assets/gpx/handcrafted.gpx
+++ b/app/src/main/assets/gpx/handcrafted.gpx
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxsc="https://microsoft.com/Soundscape" xmlns:gpxtpx="https://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxx="https://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="Microsoft Soundscape Authoring Tool">
   <metadata>
-    <name>Test</name>
-    <desc>Test?</desc>
-    <author>
-      <name>dc</name>
-      <email id="davecraig" domain="unbalancedaudio.com" />
-    </author>
+    <name>Handcrafted</name>
+    <desc>Handcrafted description</desc>
     <time>2024-05-15T16:03:07.574171Z</time>
     <extensions>
       <gpxsc:meta expires="false">

--- a/app/src/main/assets/gpx/rideWithGps.gpx
+++ b/app/src/main/assets/gpx/rideWithGps.gpx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gpx xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.cluetrust.com/XML/GPXDATA/1/0 http://www.cluetrust.com/Schemas/gpxdata10.xsd" version="1.1" creator="http://ridewithgps.com/">
   <metadata>
-    <name>Test</name>
+    <name>RideWithGps</name>
     <link href="https://ridewithgps.com/routes/46694354">
       <text>Test</text>
     </link>

--- a/app/src/main/assets/gpx/soundscape.gpx
+++ b/app/src/main/assets/gpx/soundscape.gpx
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxsc="https://microsoft.com/Soundscape" xmlns:gpxtpx="https://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxx="https://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="Microsoft Soundscape Authoring Tool">
   <metadata>
-    <name>Test</name>
-    <desc>Test?</desc>
-    <author>
-      <name>dc</name>
-      <email id="davecraig" domain="unbalancedaudio.com" />
-    </author>
+    <name>Soundscape</name>
+    <desc>Soundscape description</desc>
     <time>2024-05-15T16:03:07.574171Z</time>
     <extensions>
       <gpxsc:meta expires="false">

--- a/app/src/main/java/org/scottishtecharmy/soundscape/database/local/dao/RoutesDao.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/database/local/dao/RoutesDao.kt
@@ -3,9 +3,15 @@ package org.scottishtecharmy.soundscape.database.local.dao
 import android.util.Log
 import io.realm.kotlin.Realm
 import io.realm.kotlin.UpdatePolicy
+import io.realm.kotlin.annotations.ExperimentalGeoSpatialApi
 import io.realm.kotlin.ext.query
 import io.realm.kotlin.query.RealmResults
+import io.realm.kotlin.types.geo.Distance
+import io.realm.kotlin.types.geo.GeoCircle
+import io.realm.kotlin.types.geo.GeoPoint
+import org.scottishtecharmy.soundscape.database.local.model.Location
 import org.scottishtecharmy.soundscape.database.local.model.RouteData
+import org.scottishtecharmy.soundscape.database.local.model.RoutePoint
 
 class RoutesDao(private val realm: Realm) {
 
@@ -29,10 +35,32 @@ class RoutesDao(private val realm: Realm) {
         return realm.query<RouteData>("name == $0", name).find()
     }
 
+    fun getWaypoints(): List<RoutePoint> {
+        return realm.query<RoutePoint>().find()
+    }
+
+    @OptIn(ExperimentalGeoSpatialApi::class)
+    fun getWaypointsNear(location: Location?, kilometre: Double): RealmResults<RoutePoint> {
+        if(location != null) {
+            val circle1 = GeoCircle.create(
+                center = GeoPoint.create(location.latitude, location.longitude),
+                radius = Distance.fromKilometers(kilometre)
+            )
+            return realm.query<RoutePoint>("location GEOWITHIN $circle1").find()
+        }
+        return realm.query<RoutePoint>().find()
+    }
+
     suspend fun deleteRoute(name: String) = realm.write {
 
         val findRoute = query<RouteData>("name == $0", name).find()
+        Log.d("routeDao", "Deleting route \"" + name + "\" size " + findRoute.size)
         delete(findRoute)
+
+        // Clean up all waypoints which have no route
+        val waypoints = query<RoutePoint>("route.@count == 0").find()
+        Log.d("routeDao", "Deleting waypoints with no route" + waypoints.size)
+        delete(waypoints)
     }
 
     suspend fun updateRoute(route: RouteData) = realm.write {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/database/local/model/RouteData.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/database/local/model/RouteData.kt
@@ -1,22 +1,62 @@
 package org.scottishtecharmy.soundscape.database.local.model
 
+import android.util.Log
+import io.realm.kotlin.ext.backlinks
+import io.realm.kotlin.ext.isManaged
 import io.realm.kotlin.ext.realmListOf
+import io.realm.kotlin.query.RealmResults
+import io.realm.kotlin.types.EmbeddedRealmObject
 import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmObject
+import io.realm.kotlin.types.annotations.Ignore
 import io.realm.kotlin.types.annotations.PrimaryKey
 import kotlin.Double.Companion.NaN
 
-class RoutePoint(var name: String, var latitude: Double, var longitude: Double) : RealmObject
+class Location : EmbeddedRealmObject {
+    constructor(latitude: Double, longitude: Double) {
+        coordinates.apply {
+            add(longitude)
+            add(latitude)
+        }
+    }
+
+    // Empty constructor required by Realm
+    constructor() : this(NaN, NaN)
+
+    // Name and type required by Realm
+    var coordinates: RealmList<Double> = realmListOf()
+
+    // Name, type, and value required by Realm
+    private var type: String = "Point"
+
+    @Ignore
+    var latitude: Double
+        get() = coordinates[1]
+        set(value) {
+            coordinates[1] = value
+        }
+
+    @Ignore
+    var longitude: Double
+        get() = coordinates[0]
+        set(value) {
+            coordinates[0] = value
+        }
+}
+
+class RoutePoint(var name: String, location: Location) : RealmObject
 {
-    constructor() : this("", NaN, NaN)
+    constructor() : this("", Location(NaN, NaN))
+
+    var location: Location? = location
+    val route: RealmResults<RouteData> by backlinks(RouteData::waypoints)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
         other as RoutePoint
-
-        return (name == other.name) && (latitude == other.latitude) && (longitude == other.longitude)
+        return (name == other.name) && (location?.latitude == other.location?.latitude) && (location?.longitude == other.location?.longitude)
     }
 }
 
@@ -31,12 +71,8 @@ class RouteData : RealmObject {
         if (javaClass != other?.javaClass) return false
 
         other as RouteData
-        if ((name != other.name) ||
-            (description != other.description) ||
-            (waypoints != other.waypoints))
-        {
-            return false
-        }
-        return true
+        return !((name != other.name) ||
+                (description != other.description) ||
+                (waypoints != other.waypoints))
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/database/repository/RoutesRepository.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/database/repository/RoutesRepository.kt
@@ -3,9 +3,10 @@ package org.scottishtecharmy.soundscape.database.repository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.scottishtecharmy.soundscape.database.local.dao.RoutesDao
+import org.scottishtecharmy.soundscape.database.local.model.Location
 import org.scottishtecharmy.soundscape.database.local.model.RouteData
 
-class RoutesRepository(val routesDao: RoutesDao) {
+class RoutesRepository(private val routesDao: RoutesDao) {
 
     suspend fun insertRoute(route: RouteData) = withContext(Dispatchers.IO) {
         routesDao.insertRoute(route)
@@ -21,5 +22,13 @@ class RoutesRepository(val routesDao: RoutesDao) {
 
     suspend fun updateRoute(name: RouteData) = withContext(Dispatchers.IO) {
         routesDao.updateRoute(name)
+    }
+
+    suspend fun getWaypoints() = withContext(Dispatchers.IO){
+        routesDao.getWaypoints()
+    }
+
+    suspend fun getWaypointsNear(location: Location?, kilometre: Double) = withContext(Dispatchers.IO){
+        routesDao.getWaypointsNear(location, kilometre)
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/utils/GpxUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/utils/GpxUtils.kt
@@ -3,6 +3,7 @@ package org.scottishtecharmy.soundscape.utils
 import android.util.Log
 import io.ticofab.androidgpxparser.parser.GPXParser
 import io.ticofab.androidgpxparser.parser.domain.Gpx
+import org.scottishtecharmy.soundscape.database.local.model.Location
 import org.scottishtecharmy.soundscape.database.local.model.RouteData
 import org.scottishtecharmy.soundscape.database.local.model.RoutePoint
 import org.xmlpull.v1.XmlPullParserException
@@ -28,14 +29,14 @@ fun parseGpxFile(input : InputStream) : RouteData {
             parsedGpx.routes.forEach { route ->
                 Log.d("gpx", "RoutePoint " + route.routeName)
                 route.routePoints.forEach { waypoint ->
-                    val point = RoutePoint(waypoint.name, waypoint.latitude, waypoint.longitude)
+                    val point = RoutePoint(waypoint.name, Location(waypoint.latitude, waypoint.longitude))
                     routeData.waypoints.add(point)
                 }
             }
             if(routeData.waypoints.isEmpty()) {
                 parsedGpx.wayPoints.forEach { waypoint ->
                     Log.d("gpx", "WayPoint " + waypoint.name)
-                    val point = RoutePoint(waypoint.name, waypoint.latitude, waypoint.longitude)
+                    val point = RoutePoint(waypoint.name, Location(waypoint.latitude, waypoint.longitude))
                     routeData.waypoints.add(point)
                 }
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("com.android.application") version "8.3.1" apply false
     id("org.jetbrains.kotlin.android") version "1.9.22" apply false
     id("com.google.dagger.hilt.android") version "2.50" apply false
-    id("io.realm.kotlin") version "1.13.0" apply false
+    id("io.realm.kotlin") version "1.16.0" apply false
     id("com.google.devtools.ksp") version "1.9.22-1.0.17" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
     id("com.google.firebase.crashlytics") version "3.0.2" apply false


### PR DESCRIPTION
These commits add geospatial database support and extend the scope of the tests to support multiple routes in the database at the same time.