### PR TITLE
Remove RouteData from RealConfiguration

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/database/local/RealmConfiguration.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/database/local/RealmConfiguration.kt
@@ -3,7 +3,6 @@ package org.scottishtecharmy.soundscape.database.local
 import org.scottishtecharmy.soundscape.database.local.model.TileData
 import io.realm.kotlin.Realm
 import io.realm.kotlin.RealmConfiguration
-import org.scottishtecharmy.soundscape.database.local.model.RouteData
 
 object RealmConfiguration {
     private var realm: Realm? = null
@@ -12,7 +11,7 @@ object RealmConfiguration {
         // has this object been created or opened yet?
         if (realm == null || realm!!.isClosed()) {
             // create the realm db based on the TileData model/schema
-            var config = RealmConfiguration.create(setOf(TileData::class, RouteData::class))
+            val config = RealmConfiguration.create(setOf(TileData::class))
             realm = Realm.open(config)
         }
         return realm!!


### PR DESCRIPTION
Adding RouteData was causing the database opening to fail - possibly because there was already a database file and the schema differed. Once we start using RouteData come up with a migration plan or use a separate database.