### PR TITLE
Add getListOfBeaconTypes to AudioEngine and instrumentation test for it

### DIFF
--- a/app/src/androidTest/java/org/scottishtecharmy/soundscape/AudioEngineTest.kt
+++ b/app/src/androidTest/java/org/scottishtecharmy/soundscape/AudioEngineTest.kt
@@ -1,0 +1,75 @@
+package org.scottishtecharmy.soundscape
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.util.Log
+import androidx.test.platform.app.InstrumentationRegistry
+import com.scottishtecharmy.soundscape.audio.AudioEngine
+import com.scottishtecharmy.soundscape.audio.NativeAudioEngine
+import org.junit.Assert
+import org.junit.Test
+
+class AudioEngineTest {
+
+    @Test
+    fun beaconList() {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        val audioEngine = NativeAudioEngine()
+        val beaconTypes = audioEngine.getListOfBeaconTypes()
+        Assert.assertEquals(beaconTypes.size, 13)
+        Assert.assertEquals("Classic", beaconTypes[0])
+        Assert.assertEquals("New", beaconTypes[1])
+        Assert.assertEquals("Tactile", beaconTypes[2])
+        Assert.assertEquals("Flare", beaconTypes[3])
+        Assert.assertEquals("Shimmer", beaconTypes[4])
+        Assert.assertEquals("Ping", beaconTypes[5])
+        Assert.assertEquals("Drop", beaconTypes[6])
+        Assert.assertEquals("Signal", beaconTypes[7])
+        Assert.assertEquals("Signal Slow", beaconTypes[8])
+        Assert.assertEquals("Signal Very Slow", beaconTypes[9])
+        Assert.assertEquals( "Mallet", beaconTypes[10])
+        Assert.assertEquals( "Mallet Slow", beaconTypes[11])
+        Assert.assertEquals( "Mallet Very Slow", beaconTypes[12])
+    }
+
+    private fun moveListener(audioEngine: AudioEngine, latitude: Double, longitude: Double, orientation: Double) {
+        var time = 0
+        while(time < 3000) {
+            audioEngine.updateGeometry(latitude, longitude, orientation)
+            Thread.sleep(100)
+            time += 100
+        }
+    }
+
+    @Test
+    fun soundBeacon() {
+        // Use the instrumentation targetContext for the assets etc.
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        org.fmod.FMOD.init(context)
+
+        val audioEngine = NativeAudioEngine()
+        audioEngine.initialize(context)
+
+        val beacon = audioEngine.createBeacon(1.0, 0.0)
+        moveListener(audioEngine, 0.0, 0.0, 90.0)
+        audioEngine.destroyBeacon(beacon)
+
+        val speech_beacon = audioEngine.createTextToSpeech(1.0, 0.0, "Beacon here!")
+        moveListener(audioEngine, 0.0, 0.0, -90.0)
+
+        val beacon3 = audioEngine.createBeacon(1.0, 0.0)
+        moveListener(audioEngine, 0.0, 0.0, -180.0)
+        audioEngine.destroyBeacon(beacon3)
+
+        audioEngine.destroy()
+        org.fmod.FMOD.close()
+    }
+
+    companion object {
+        init {
+            System.loadLibrary(BuildConfig.FMOD_LIB)
+        }
+    }
+}

--- a/app/src/main/cpp/AudioEngine.cpp
+++ b/app/src/main/cpp/AudioEngine.cpp
@@ -14,6 +14,7 @@ namespace soundscape {
 const BeaconDescriptor AudioEngine::msc_BeaconDescriptors[] =
 {
         {
+                "Classic",
                 2,
                 {
                         {"file:///android_asset/Classic/Classic_OnAxis.wav", 22.5},
@@ -21,6 +22,7 @@ const BeaconDescriptor AudioEngine::msc_BeaconDescriptors[] =
                 }
         },
         {
+                "New",
                 6,
                 {
                         {"file:///android_asset/New/Current_A+.wav", 15.0},
@@ -30,6 +32,7 @@ const BeaconDescriptor AudioEngine::msc_BeaconDescriptors[] =
                 }
         },
         {
+                "Tactile",
                 6,
                 {
                         {"file:///android_asset/Tactile/Tactile_OnAxis.wav", 15.0},
@@ -38,6 +41,7 @@ const BeaconDescriptor AudioEngine::msc_BeaconDescriptors[] =
                 }
         },
         {
+                "Flare",
                 6,
                 {
                         {"file:///android_asset/Flare/Flare_A+.wav", 15.0},
@@ -47,6 +51,7 @@ const BeaconDescriptor AudioEngine::msc_BeaconDescriptors[] =
                 }
         },
         {
+                "Shimmer",
                 6,
                 {
                         {"file:///android_asset/Shimmer/Shimmer_A+.wav", 15.0},
@@ -56,6 +61,7 @@ const BeaconDescriptor AudioEngine::msc_BeaconDescriptors[] =
                 }
         },
         {
+                "Ping",
                 6,
                 {
                         {"file:///android_asset/Ping/Ping_A+.wav", 15.0},
@@ -65,6 +71,7 @@ const BeaconDescriptor AudioEngine::msc_BeaconDescriptors[] =
                 }
         },
         {
+                "Drop",
                 6,
                 {
                         {"file:///android_asset/Drop/Drop_A+.wav", 15.0},
@@ -73,6 +80,7 @@ const BeaconDescriptor AudioEngine::msc_BeaconDescriptors[] =
                 }
         },
         {
+                "Signal",
                 6,
                 {
                         {"file:///android_asset/Signal/Signal_A+.wav", 15.0},
@@ -81,6 +89,7 @@ const BeaconDescriptor AudioEngine::msc_BeaconDescriptors[] =
                 }
         },
         {
+                "Signal Slow",
                 12,
                 {
                         {"file:///android_asset/Signal Slow/Signal_Slow_A+.wav", 15.0},
@@ -89,6 +98,7 @@ const BeaconDescriptor AudioEngine::msc_BeaconDescriptors[] =
                 }
         },
         {
+                "Signal Very Slow",
                 18,
                 {
                         {"file:///android_asset/Signal Very Slow/Signal_Very_Slow_A+.wav",
@@ -101,6 +111,7 @@ const BeaconDescriptor AudioEngine::msc_BeaconDescriptors[] =
                 },
         },
         {
+                "Mallet",
                 6,
                 {
                         {"file:///android_asset/Mallet/Mallet_A+.wav", 15.0},
@@ -109,6 +120,7 @@ const BeaconDescriptor AudioEngine::msc_BeaconDescriptors[] =
                 }
         },
         {
+                "Mallet Slow",
                 12,
                 {
                         {"file:///android_asset/Mallet Slow/Mallet_Slow_A+.wav", 15.0},
@@ -117,6 +129,7 @@ const BeaconDescriptor AudioEngine::msc_BeaconDescriptors[] =
                 }
         },
         {
+                "Mallet Very Slow",
                 18,
                 {
                         {"file:///android_asset/Mallet Very Slow/Mallet_Very_Slow_A+.wav", 15.0},
@@ -373,6 +386,23 @@ Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_setBeaconType(JNIEn
     } else {
         TRACE("SetBeaconType failed - no AudioEngine");
     }
+}
+
+extern "C"
+JNIEXPORT jobjectArray JNICALL
+Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_getListOfBeacons(JNIEnv *env, jobject thiz MAYBE_UNUSED){
+
+    jobjectArray array_to_return;
+
+    int number_of_beacons = sizeof(soundscape::AudioEngine::msc_BeaconDescriptors)/sizeof(soundscape::BeaconDescriptor);
+    array_to_return = (jobjectArray)env->NewObjectArray(number_of_beacons,
+                                                        env->FindClass("java/lang/String"), nullptr);
+    for(auto beacon = 0; beacon < number_of_beacons; ++beacon)
+    {
+        env->SetObjectArrayElement(array_to_return, beacon, env->NewStringUTF(soundscape::AudioEngine::msc_BeaconDescriptors[beacon].m_Name.c_str()));
+    }
+
+    return(array_to_return);
 }
 
 extern "C"

--- a/app/src/main/cpp/AudioEngine.h
+++ b/app/src/main/cpp/AudioEngine.h
@@ -25,11 +25,12 @@ namespace soundscape {
         void AddBeacon(PositionedAudio *beacon, bool queued = false);
         void RemoveBeacon(PositionedAudio *beacon);
 
+        const static BeaconDescriptor msc_BeaconDescriptors[];
+
     private:
         FMOD::System * m_pSystem;
         FMOD_VECTOR m_LastPos = {0.0f, 0.0f, 0.0f};
 
-        const static BeaconDescriptor msc_BeaconDescriptors[];
         std::atomic<int> m_BeaconTypeIndex;
 
         std::recursive_mutex m_BeaconsMutex;

--- a/app/src/main/cpp/BeaconDescriptor.h
+++ b/app/src/main/cpp/BeaconDescriptor.h
@@ -19,12 +19,14 @@ namespace soundscape {
 
     class BeaconDescriptor {
     public:
-        BeaconDescriptor(unsigned int beats_in_phrase, const std::vector<BeaconAsset> &beacons)
-        : m_BeatsInPhrase(beats_in_phrase),
+        BeaconDescriptor(const std::string &name, unsigned int beats_in_phrase, const std::vector<BeaconAsset> &beacons)
+        : m_Name(name),
+          m_BeatsInPhrase(beats_in_phrase),
           m_Beacons(beacons)
         {
         }
 
+        std::string m_Name;
         unsigned int m_BeatsInPhrase;
         const std::vector<BeaconAsset> m_Beacons;
     };

--- a/app/src/main/java/org/scottishtecharmy/soundscape/audio/AudioEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/audio/AudioEngine.kt
@@ -6,4 +6,5 @@ interface AudioEngine {
     fun createTextToSpeech(latitude: Double, longitude: Double, text: String) : Long
     fun updateGeometry(listenerLatitude: Double, listenerLongitude: Double, listenerHeading: Double)
     fun setBeaconType(beaconType: Int)
+    fun getListOfBeaconTypes() : Array<String>
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/audio/NativeAudioEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/audio/NativeAudioEngine.kt
@@ -26,6 +26,7 @@ class NativeAudioEngine : AudioEngine, TextToSpeech.OnInitListener {
     private external fun createNativeTextToSpeech(engineHandle: Long, latitude: Double, longitude: Double, ttsSocket: Int) :  Long
     private external fun updateGeometry(engineHandle: Long, latitude: Double, longitude: Double, heading: Double)
     private external fun setBeaconType(engineHandle: Long, beaconType: Int)
+    private external fun getListOfBeacons() : Array<String>
 
     fun destroy()
     {
@@ -56,8 +57,7 @@ class NativeAudioEngine : AudioEngine, TextToSpeech.OnInitListener {
             textToSpeech = TextToSpeech(context, this)
         }
     }
-
-        override fun onInit(status: Int) {
+    override fun onInit(status: Int) {
         if (status == TextToSpeech.SUCCESS) {
 
             Log.e("Soundscape", "Android version " + Build.VERSION.SDK_INT)
@@ -158,6 +158,11 @@ class NativeAudioEngine : AudioEngine, TextToSpeech.OnInitListener {
     }
     override fun setBeaconType(beaconType: Int)
     {
+    }
+
+    override fun getListOfBeaconTypes() : Array<String>
+    {
+        return getListOfBeacons()
     }
 
     companion object {


### PR DESCRIPTION
getListOfBeaconTypes returns a list of the names of the available beacons within the AudioEngine. This is to allow the UI to interrogate the AudioEngine rather than having two separate lists of beacon types. In addition, I didn't understand enough about Instrumentation tests when I wrote the AudioEngine code. Now that I do, I've added a belated set of initial tests.