### PR TITLE
Implement AudioEngine setBeaconType and add test for it

### DIFF
--- a/app/src/main/cpp/AudioEngine.cpp
+++ b/app/src/main/cpp/AudioEngine.cpp
@@ -335,7 +335,7 @@ const BeaconDescriptor AudioEngine::msc_BeaconDescriptors[] =
 
 extern "C"
 JNIEXPORT jlong JNICALL
-Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_create(JNIEnv *env MAYBE_UNUSED, jobject thiz MAYBE_UNUSED) {
+Java_org_scottishtecharmy_soundscape_audio_NativeAudioEngine_create(JNIEnv *env MAYBE_UNUSED, jobject thiz MAYBE_UNUSED) {
     auto ae = std::make_unique<soundscape::AudioEngine>();
 
     if (not ae) {
@@ -348,7 +348,7 @@ Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_create(JNIEnv *env 
 
 extern "C"
 JNIEXPORT void JNICALL
-Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_destroy(JNIEnv *env MAYBE_UNUSED,
+Java_org_scottishtecharmy_soundscape_audio_NativeAudioEngine_destroy(JNIEnv *env MAYBE_UNUSED,
                                                                      jobject thiz MAYBE_UNUSED,
                                                                      jlong engine_handle) {
     auto* ae =
@@ -358,7 +358,7 @@ Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_destroy(JNIEnv *env
 
 extern "C"
 JNIEXPORT void JNICALL
-Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_updateGeometry(JNIEnv *env MAYBE_UNUSED,
+Java_org_scottishtecharmy_soundscape_audio_NativeAudioEngine_updateGeometry(JNIEnv *env MAYBE_UNUSED,
                                                                            jobject thiz MAYBE_UNUSED,
                                                                            jlong engine_handle,
                                                                            jdouble latitude,
@@ -375,14 +375,22 @@ Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_updateGeometry(JNIE
 }
 extern "C"
 JNIEXPORT void JNICALL
-Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_setBeaconType(JNIEnv *env MAYBE_UNUSED, jobject thiz MAYBE_UNUSED,
+Java_org_scottishtecharmy_soundscape_audio_NativeAudioEngine_setBeaconType(JNIEnv *env MAYBE_UNUSED, jobject thiz MAYBE_UNUSED,
                                                                           jlong engine_handle,
-                                                                          jint beacon_type) {
+                                                                          jstring beacon_type) {
     auto* ae =
             reinterpret_cast<soundscape::AudioEngine*>(engine_handle);
 
     if (ae) {
-        ae->SetBeaconType(beacon_type);
+        const char * name = env->GetStringUTFChars(beacon_type, nullptr);
+        std::string beacon_string(name);
+        env->ReleaseStringUTFChars(beacon_type, name);
+
+        int number_of_beacons = sizeof(soundscape::AudioEngine::msc_BeaconDescriptors)/sizeof(soundscape::BeaconDescriptor);
+        for(auto beacon = 0; beacon < number_of_beacons; ++beacon) {
+            if(beacon_string == soundscape::AudioEngine::msc_BeaconDescriptors[beacon].m_Name)
+            ae->SetBeaconType(beacon);
+        }
     } else {
         TRACE("SetBeaconType failed - no AudioEngine");
     }
@@ -390,7 +398,7 @@ Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_setBeaconType(JNIEn
 
 extern "C"
 JNIEXPORT jobjectArray JNICALL
-Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_getListOfBeacons(JNIEnv *env, jobject thiz MAYBE_UNUSED){
+Java_org_scottishtecharmy_soundscape_audio_NativeAudioEngine_getListOfBeacons(JNIEnv *env, jobject thiz MAYBE_UNUSED){
 
     jobjectArray array_to_return;
 
@@ -407,7 +415,7 @@ Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_getListOfBeacons(JN
 
 extern "C"
 JNIEXPORT jlong JNICALL
-Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_createNativeBeacon(JNIEnv *env MAYBE_UNUSED,
+Java_org_scottishtecharmy_soundscape_audio_NativeAudioEngine_createNativeBeacon(JNIEnv *env MAYBE_UNUSED,
                                                                                jobject thiz MAYBE_UNUSED,
                                                                                jlong engine_handle,
                                                                                jdouble latitude,
@@ -427,7 +435,7 @@ Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_createNativeBeacon(
 
 extern "C"
 JNIEXPORT void JNICALL
-Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_destroyNativeBeacon(JNIEnv *env MAYBE_UNUSED,
+Java_org_scottishtecharmy_soundscape_audio_NativeAudioEngine_destroyNativeBeacon(JNIEnv *env MAYBE_UNUSED,
                                                                                 jobject thiz MAYBE_UNUSED,
                                                                                 jlong beacon_handle) {
     auto beacon = reinterpret_cast<soundscape::Beacon*>(beacon_handle);
@@ -436,7 +444,7 @@ Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_destroyNativeBeacon
 
 extern "C"
 JNIEXPORT jlong JNICALL
-Java_com_scottishtecharmy_soundscape_audio_NativeAudioEngine_createNativeTextToSpeech(JNIEnv *env MAYBE_UNUSED,
+Java_org_scottishtecharmy_soundscape_audio_NativeAudioEngine_createNativeTextToSpeech(JNIEnv *env MAYBE_UNUSED,
                                                                                      jobject thiz MAYBE_UNUSED,
                                                                                      jlong engine_handle,
                                                                                      jdouble latitude,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/audio/AudioEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/audio/AudioEngine.kt
@@ -1,10 +1,15 @@
-package com.scottishtecharmy.soundscape.audio
+package org.scottishtecharmy.soundscape.audio
+
+import android.speech.tts.Voice
+import java.util.Locale
 
 interface AudioEngine {
     fun createBeacon(latitude: Double, longitude: Double) : Long
     fun destroyBeacon(beaconHandle : Long)
     fun createTextToSpeech(latitude: Double, longitude: Double, text: String) : Long
     fun updateGeometry(listenerLatitude: Double, listenerLongitude: Double, listenerHeading: Double)
-    fun setBeaconType(beaconType: Int)
+    fun setBeaconType(beaconType: String)
     fun getListOfBeaconTypes() : Array<String>
+    fun getAvailableSpeechLanguages() : Set<Locale>
+    fun getAvailableSpeechVoices() : Set<Voice>
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -27,7 +27,7 @@ import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationResult
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
-import com.scottishtecharmy.soundscape.audio.NativeAudioEngine
+import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.activityrecognition.ActivityTransition
 import org.scottishtecharmy.soundscape.database.local.RealmConfiguration


### PR DESCRIPTION
AudioEngine.setBeaconType takes a String which is the name of the Beacon type to use. The test loops tests every Beacon type that AudioEngine reports, rotating the listener so that the sound for each of the orientation angles is played. This is done fairly quickly so as not to make the test over long.

Some other mistakes were also fixed - com_scottishtecharmy_soundscape were replaced with org_scottishtecharmy_soundscape.