### PR TITLE
Try including screenshots in documentation compilation

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -30,13 +30,34 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu' # See 'Supported distributions' for available options
+          java-version: '17'
+
+      - name: Generate screenshots
+        run : ./gradlew  updateDebugScreenshotTest
+
+      - name: Copy screenshots into docs directory and generate HTML
+        run : |
+          cp -r ./app/src/debug/screenshotTest/reference/org/scottishtecharmy/soundscape/* ./docs
+          cd ./docs
+          ./image.sh
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
           source: ./docs
           destination: ./_site
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 

--- a/app/src/screenshotTest/kotlin/org/scottishtecharmy/soundscape/PreviewTest.kt
+++ b/app/src/screenshotTest/kotlin/org/scottishtecharmy/soundscape/PreviewTest.kt
@@ -40,7 +40,7 @@ annotation class DevicePreviews
 @DevicePreviews
 annotation class CustomPreviews
 
-class PreviewTest {
+class AudioBeaconsPreviewTestClass {
     @CustomPreviews
     @Composable
     fun AudioBeaconsPreviewTest() {
@@ -48,7 +48,9 @@ class PreviewTest {
             IntroductionAudioBeaconPreview()
         }
     }
+}
 
+class FinishPreviewTestClass {
     @CustomPreviews
     @Composable
     fun FinishPreviewTest() {
@@ -56,7 +58,9 @@ class PreviewTest {
             Finish()
         }
     }
+}
 
+class HearingPreviewTestClass {
     @CustomPreviews
     @Composable
     fun HearingPreviewTest() {
@@ -64,7 +68,9 @@ class PreviewTest {
             HearingPreview()
         }
     }
+}
 
+class LanguagePreviewTestClass {
     @CustomPreviews
     @Composable
     fun LanguagePreviewTest() {
@@ -72,7 +78,9 @@ class PreviewTest {
             LanguagePreview()
         }
     }
+}
 
+class ListeningPreviewTestClass {
     @CustomPreviews
     @Composable
     fun ListeningPreviewTest() {
@@ -80,7 +88,9 @@ class PreviewTest {
             ListeningPreview()
         }
     }
+}
 
+class WelcomePreviewTestClass {
     @CustomPreviews
     @Composable
     fun WelcomePreviewTest() {
@@ -88,7 +98,9 @@ class PreviewTest {
             PreviewWelcome()
         }
     }
+}
 
+class HomePreviewTestClass {
     @CustomPreviews
     @Composable
     fun HomePreviewTest() {

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,3 +15,4 @@ See the document [here](actions.md) to learn about the GitHub actions used and h
 * [Audio API](audio-API.md)
 * [Framework choices](framework.md)
 * [Pathway to product](pathway-to-product.md)
+* [Screenshots](screenshots.md)

--- a/docs/image.sh
+++ b/docs/image.sh
@@ -1,0 +1,11 @@
+for directory in */ ;
+do
+  class=${directory::-1}
+  echo "<h1>Screenshots from $class</h1><p>" > $class.html
+  cd $class
+  for filename in *;
+  do
+    echo "<p class=\"image-name\">$filename</p><a href=\"$class/$filename\"><img src=\"$class/$filename\" alt=\"$filename\" width=\"100\"></a>">> ../$class.html
+  done
+  cd ..
+done

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -1,0 +1,14 @@
+# Screenshots
+[AudioBeaconsPreviewTestClass](AudioBeaconsPreviewTestClass.html)
+
+[FinishPreviewTestClass](FinishPreviewTestClass.html)
+
+[HearingPreviewTestClass](HearingPreviewTestClass.html)
+
+[HomePreviewTestClass](HomePreviewTestClass.html)
+
+[LanguagePreviewTestClass](LanguagePreviewTestClass.html)
+
+[ListeningPreviewTestClass](ListeningPreviewTestClass.html)
+
+[WelcomePreviewTestClass](WelcomePreviewTestClass.html)


### PR DESCRIPTION
We could include the report from the preview screenshot validation test, but that requires validating against reference images which we don't have yet. Instead, we build the reference images and use some very basic HTML to display all of the screenshots for each Test. The full resolution test can be saved from the link and so this should give us automatic screenshots of each screen in all locale and a couple of screen sizes.