### PR TITLE
Deliver onboarding screens' ViewModel data as flows

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,6 +107,8 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation("androidx.core:core-splashscreen:1.0.1")
     implementation(libs.core.ktx)
+    implementation(libs.androidx.benchmark.common)
+    implementation(libs.androidx.lifecycle.runtime.compose.android)
 
 
     testImplementation("junit:junit:4.13.2")

--- a/app/src/main/java/org/scottishtecharmy/soundscape/components/LanguageSelectionBox.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/components/LanguageSelectionBox.kt
@@ -78,15 +78,8 @@ fun LanguageSelectionBoxItem(language: Language){
     )
 }
 
-// An attempt was made here to mock the list of languages to preview LanguageSelectionBox
-// But it didn't work :-(
-class LanguageSelectionMock : PreviewParameterProvider< List<Language> > {
-    override val values = listOf(LanguageViewModel(NativeAudioEngine()).getAllLanguages()).asSequence()
-}
-
-@Preview
 @Composable
-fun LanguageSelectionBox(@PreviewParameter(LanguageSelectionMock::class) allLanguages: List<Language>){
+fun LanguageSelectionBox(allLanguages: List<Language>){
     LazyColumn(modifier = Modifier
         .clip(RoundedCornerShape(5.dp))
         .fillMaxWidth()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,8 @@ lifecycleServiceVersion = "2.8.0"
 appcompat = "1.7.0"
 coreKtxVersion = "1.6.1"
 screenshot = "0.0.1-alpha03"
+benchmarkCommon = "1.2.4"
+lifecycleRuntimeComposeAndroid = "2.8.4"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -35,6 +37,8 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 androidx-lifecycle-service = { group = "androidx.lifecycle", name = "lifecycle-service", version.ref = "lifecycleService" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 core-ktx = { group = "androidx.test", name = "core-ktx", version.ref = "coreKtxVersion" }
+androidx-benchmark-common = { group = "androidx.benchmark", name = "benchmark-common", version.ref = "benchmarkCommon" }
+androidx-lifecycle-runtime-compose-android = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose-android", version.ref = "lifecycleRuntimeComposeAndroid" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Firebase was reporting a test issue:

Your app uses 1 non-SDK interfaces, which are incompatible with Android P+.
   Ljava/lang/invoke/MethodHandles$Lookup;-><init>(Ljava/lang/Class;I)V

It turns out that initializing ViewModel data inside an init function is a bad idea - see
  https://www.droidcon.com/2024/03/22/mastering-android-viewmodels-essential-dos-and-donts-part-1-%f0%9f%9b%a0%ef%b8%8f/

This change removes the init from AudioBeaconsViewModel and instead uses a flow to initialize the list of beacon types. That initialization will now happen when the UI code calls into the ViewModel with collectAsStateWithLifecycle instead of when theAudioBeaconsViewModel was created.

The LanguageViewModel has been changed in the same way. The list of supported languages is now in a flow and is only initialized once.