### PR TITLE
Remove screenshots from docs but build them everywhere else

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -105,6 +105,18 @@ jobs:
       - name: Run gradle tests
         run: ./gradlew test
 
+      # Generate the screenshots from the Preview code
+      - name: Generate screenshots
+        run : ./gradlew  updateDebugScreenshotTest
+
+      # Upload screenshots as an artifact
+      # Noted For Output [main_project_module]/build/outputs/apk/debug/
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshot-previews
+          path: ${{ env.main_project_module }}/src/debug/screenshotTest/reference/org/scottishtecharmy/soundscape/
+
       # Run Build Project
       - name: Build gradle project
         env:

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -31,23 +31,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
-
-      - name: Set Up JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu' # See 'Supported distributions' for available options
-          java-version: '17'
-
-      - name: Generate screenshots
-        run : ./gradlew  updateDebugScreenshotTest
-
-      - name: Copy screenshots into docs directory and generate HTML
-        run : |
-          cp -r ./app/src/debug/screenshotTest/reference/org/scottishtecharmy/soundscape/* ./docs
-          cd ./docs
-          ./image.sh
+#   These steps built the screenshots from the application, but it means that the docs build
+#   takes much longer and the output isn't that great. I'm going to move the screenshots to be an
+#   artifact from the nightly and release actions instead.
+#
+#      - name: Setup Gradle
+#        uses: gradle/actions/setup-gradle@v3
+#
+#      - name: Set Up JDK
+#        uses: actions/setup-java@v4
+#        with:
+#          distribution: 'zulu' # See 'Supported distributions' for available options
+#          java-version: '17'
+#
+#      - name: Generate screenshots
+#        run : ./gradlew  updateDebugScreenshotTest
+#
+#      - name: Copy screenshots into docs directory and generate HTML
+#        run : |
+#          cp -r ./app/src/debug/screenshotTest/reference/org/scottishtecharmy/soundscape/* ./docs
+#          cd ./docs
+#          ./image.sh
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -73,6 +73,18 @@ jobs:
       - name: Run gradle tests
         run: ./gradlew test
 
+      # Generate the screenshots from the Preview code
+      - name: Generate screenshots
+        run : ./gradlew  updateDebugScreenshotTest
+
+      # Upload screenshots as an artifact
+      # Noted For Output [main_project_module]/build/outputs/apk/debug/
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshot-previews
+          path: ${{ env.main_project_module }}/src/debug/screenshotTest/reference/org/scottishtecharmy/soundscape/
+
       # Create APK Debug
       - name: Build apk debug project (APK)
         run: |

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: Run tests
         run: ./gradlew test
 
+      - name: Generate screenshots
+        run : ./gradlew  updateDebugScreenshotTest
+
       - name: Build debug version
         run: ./gradlew assembleDebug
 


### PR DESCRIPTION
Putting the screenshots in the docs increased the overhead of docs compilation by a factor of 10 and the result wasn't that readable. This change removes that and instead we build screenshots during all of the other actions. Release and nightly builds both upload them as artifacts which should make them easily accessible for developeres.