### PR TITLE
Make the UI work a bit better on smaller screens and landscape

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/AudioBeacons.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/AudioBeacons.kt
@@ -17,7 +17,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.Done
@@ -115,9 +117,10 @@ fun AudioBeacons(onNavigate: (String) -> Unit, mockData : MockHearingPreviewData
             Column(
                 modifier = Modifier
                     .padding(horizontal = 30.dp)
-                    .padding(top = 60.dp)
+                    .padding(top = 30.dp)
                     .fillMaxWidth()
-                    .fillMaxHeight(),
+                    .fillMaxHeight()
+                    .verticalScroll(rememberScrollState()),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Top
             ) {
@@ -254,6 +257,7 @@ data object MockHearingPreviewData {
     )
 }
 
+@Preview(device = "spec:parent=pixel_5,orientation=landscape")
 @Preview
 @Composable
 fun AudioBeaconPreview() {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Finish.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Finish.kt
@@ -2,20 +2,26 @@ package org.scottishtecharmy.soundscape.screens.onboarding
 
 import android.content.Context
 import android.content.ContextWrapper
+import android.content.res.Configuration
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -34,59 +40,85 @@ fun Context.getActivity(): ComponentActivity? = when (this) {
     else -> null
 }
 
+@Composable
+private fun LocalImage() {
+    Image(
+        painter = painterResource(R.drawable.ic_finish),
+        contentDescription = null,
+        modifier = Modifier
+            .padding(24.dp)
+            .clip(RoundedCornerShape(90.dp))
+    )
+}
+
+@Preview(device = "spec:parent=pixel_5,orientation=landscape")
 @Preview
 @Composable
 fun Finish() {
     val context = LocalContext.current
 
+    val landscape = (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE)
+    val alignment = if(landscape)
+        Alignment.CenterVertically
+    else
+        Alignment.Top
+
     IntroductionTheme {
         MaterialTheme(typography = IntroTypography) {
-            Column(
+            Row(
+                verticalAlignment = alignment,
                 modifier = Modifier
-                    .padding(top = 50.dp)
                     .fillMaxWidth()
-                    .fillMaxHeight(),
-                horizontalAlignment = Alignment.CenterHorizontally
+                    .fillMaxHeight()
+                    .verticalScroll(rememberScrollState()),
             ) {
-                Image(
-                    painter = painterResource(R.drawable.ic_finish),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(2.1f)
-                )
-
-                Spacer(modifier = Modifier.height(50.dp))
-
+                if (landscape) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxHeight(),
+                    ) {
+                        LocalImage()
+                    }
+                }
                 Column(
-                    modifier = Modifier.padding(horizontal = 50.dp)
+                    modifier = Modifier
+                        .fillMaxHeight(),
                 ) {
-                    Text(
-                        text = stringResource(R.string.first_launch_prompt_title),
-                        style = MaterialTheme.typography.titleLarge,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth()
-                    )
+                    if (!landscape) {
+                        LocalImage()
+                        Spacer(modifier = Modifier.height(50.dp))
+                    }
 
-                    Spacer(modifier = Modifier.height(30.dp))
+                    Column(
+                        modifier = Modifier.padding(horizontal = 50.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.first_launch_prompt_title),
+                            style = MaterialTheme.typography.titleLarge,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth()
+                        )
 
-                    Text(
-                        text = stringResource(R.string.first_launch_prompt_message),
-                        style = MaterialTheme.typography.bodyMedium,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth()
-                    )
+                        Spacer(modifier = Modifier.height(30.dp))
 
-                    Spacer(modifier = Modifier.height(50.dp))
+                        Text(
+                            text = stringResource(R.string.first_launch_prompt_message),
+                            style = MaterialTheme.typography.bodyMedium,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth()
+                        )
 
-                    OnboardButton(
-                        text = stringResource(R.string.first_launch_prompt_button),
-                        onClick = {
-                            // Tell our OnboardingActivity that we have completed onboarding
-                            (context.getActivity() as OnboardingActivity).onboardingComplete()
-                        },
-                        modifier = Modifier.fillMaxWidth()
-                    )
+                        Spacer(modifier = Modifier.height(50.dp))
+
+                        OnboardButton(
+                            text = stringResource(R.string.first_launch_prompt_button),
+                            onClick = {
+                                // Tell our OnboardingActivity that we have completed onboarding
+                                (context.getActivity() as OnboardingActivity).onboardingComplete()
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Hearing.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Hearing.kt
@@ -1,17 +1,19 @@
 package org.scottishtecharmy.soundscape.screens.onboarding
 
+import android.content.res.Configuration
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material3.Button
@@ -23,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -53,99 +56,126 @@ class HearingViewModel @Inject constructor(private val audioEngine : NativeAudio
 }
 
 @Composable
+private fun LocalImage() {
+    Image(
+        painter = painterResource(R.drawable.ic_surroundings),
+        contentDescription = null
+    )
+}
+
+@Composable
 fun Hearing(onNavigate: (String) -> Unit, useView : Boolean) {
 
     var viewModel : HearingViewModel? = null
     if(useView)
         viewModel = hiltViewModel<HearingViewModel>()
 
+    val landscape = (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE)
+    val alignment = if(landscape)
+        Alignment.CenterVertically
+    else
+        Alignment.Top
+
     IntroductionTheme {
         MaterialTheme(typography = IntroTypography) {
-            Column(
+            Row(
+                verticalAlignment = alignment,
                 modifier = Modifier
-                    .padding(top = 50.dp)
                     .fillMaxWidth()
-                    .fillMaxHeight(),
-                horizontalAlignment = Alignment.CenterHorizontally
-            )
-            {
-                Image(
-                    painter = painterResource(R.drawable.ic_surroundings),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(2.1f)
-                )
-
-                Spacer(modifier = Modifier.height(50.dp))
-
-                Column(
-                    modifier = Modifier.padding(horizontal = 50.dp)
-                ) {
-                    Text(
-                        text = stringResource(R.string.first_launch_callouts_title),
-                        style = MaterialTheme.typography.titleLarge,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    Spacer(modifier = Modifier.height(50.dp))
-                    Text(
-                        text = stringResource(R.string.first_launch_callouts_message),
-                        style = MaterialTheme.typography.bodyMedium,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    Spacer(modifier = Modifier.height(30.dp))
-                    Text(
-                        text = stringResource(R.string.first_launch_callouts_listen),
-                        style = MaterialTheme.typography.bodyMedium,
-                        textAlign = TextAlign.Center
-                    )
-                    Spacer(modifier = Modifier.height(10.dp))
-
-                    // TODO Strings to send to text-to-speech
-                    // <string name="first_launch_callouts_example_1">Cafe</string>
-                    // <string name="first_launch_callouts_example_3">Main Street goes left</string>
-                    // <string name="first_launch_callouts_example_4">Main Street goes right</string>
-
-                    val speechText = stringResource(R.string.first_launch_callouts_example_4)
-                    Button(
-                        onClick = {
-                            viewModel?.playSpeech(speechText)
-                        },
+                    .fillMaxHeight()
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                if (landscape) {
+                    Column(
                         modifier = Modifier
-                            .fillMaxWidth(),
-                        shape = RoundedCornerShape(3.dp),
-                        colors = ButtonDefaults.buttonColors(containerColor = Color.Black.copy(alpha = 0.2f))
-                    )
-                    {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Start,
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Icon(Icons.Rounded.PlayArrow, contentDescription = null)
-                            Spacer(modifier = Modifier.width(10.dp))
-                            Text(text = stringResource(R.string.first_launch_callouts_listen_accessibility_label))
-                        }
+                            .fillMaxHeight(),
+                    ) {
+                        LocalImage()
                     }
-                    Spacer(modifier = Modifier.height(20.dp))
-
-                    OnboardButton(
-                        text = stringResource(R.string.ui_continue),
-                        onClick = {
-                            onNavigate(Screens.Navigating.route)
-                        },
-                        modifier = Modifier.fillMaxWidth()
-                    )
                 }
+                Column(
+                    modifier = Modifier
+                        .fillMaxHeight(),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                )
+                {
+                    if (!landscape) {
+                        LocalImage()
+                        Spacer(modifier = Modifier.height(50.dp))
+                    }
 
+                    Column(
+                        modifier = Modifier.padding(horizontal = 50.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.first_launch_callouts_title),
+                            style = MaterialTheme.typography.titleLarge,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        Spacer(modifier = Modifier.height(50.dp))
+                        Text(
+                            text = stringResource(R.string.first_launch_callouts_message),
+                            style = MaterialTheme.typography.bodyMedium,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        Spacer(modifier = Modifier.height(30.dp))
+                        Text(
+                            text = stringResource(R.string.first_launch_callouts_listen),
+                            style = MaterialTheme.typography.bodyMedium,
+                            textAlign = TextAlign.Center
+                        )
+                        Spacer(modifier = Modifier.height(10.dp))
+
+                        // TODO Strings to send to text-to-speech
+                        // <string name="first_launch_callouts_example_1">Cafe</string>
+                        // <string name="first_launch_callouts_example_3">Main Street goes left</string>
+                        // <string name="first_launch_callouts_example_4">Main Street goes right</string>
+
+                        val speechText = stringResource(R.string.first_launch_callouts_example_4)
+                        Button(
+                            onClick = {
+                                viewModel?.playSpeech(speechText)
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth(),
+                            shape = RoundedCornerShape(3.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = Color.Black.copy(
+                                    alpha = 0.2f
+                                )
+                            )
+                        )
+                        {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.Start,
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Icon(Icons.Rounded.PlayArrow, contentDescription = null)
+                                Spacer(modifier = Modifier.width(10.dp))
+                                Text(text = stringResource(R.string.first_launch_callouts_listen_accessibility_label))
+                            }
+                        }
+                        Spacer(modifier = Modifier.height(20.dp))
+
+                        OnboardButton(
+                            text = stringResource(R.string.ui_continue),
+                            onClick = {
+                                onNavigate(Screens.Navigating.route)
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                }
             }
         }
     }
 
 }
 
+@Preview(device = "spec:parent=pixel_5,orientation=landscape")
 @Preview
 @Composable
 fun HearingPreview() {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Language.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Language.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -108,7 +110,8 @@ fun Language(onNavigate: (String) -> Unit, mockData : MockLanguagePreviewData?){
                 modifier = Modifier
                     .padding(horizontal = 20.dp, vertical = 50.dp)
                     .fillMaxWidth()
-                    .fillMaxHeight(),
+                    .fillMaxHeight()
+                    .verticalScroll(rememberScrollState()),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Top
             ) {
@@ -168,6 +171,7 @@ data object MockLanguagePreviewData {
     )
 }
 
+@Preview(device = "spec:parent=pixel_5,orientation=landscape")
 @Preview
 @Composable
 fun LanguagePreview(){

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Listening.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Listening.kt
@@ -1,18 +1,22 @@
 package org.scottishtecharmy.soundscape.screens.onboarding
 
+import android.content.res.Configuration
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -24,58 +28,80 @@ import org.scottishtecharmy.soundscape.ui.theme.IntroTypography
 import org.scottishtecharmy.soundscape.ui.theme.IntroductionTheme
 
 @Composable
+private fun LocalImage() {
+    Image(
+        painter = painterResource(R.drawable.ic_listening),
+        contentDescription = null,
+    )
+}
+
+@Composable
 fun Listening(onNavigate: (String) -> Unit) {
+
+    val landscape = (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE)
+    val alignment = if(landscape)
+        Alignment.CenterVertically
+    else
+        Alignment.Top
+
     IntroductionTheme {
         MaterialTheme(typography = IntroTypography) {
-            Column(
+            Row(
+                verticalAlignment = alignment,
                 modifier = Modifier
-                    .padding(top = 50.dp)
                     .fillMaxWidth()
-                    .fillMaxHeight(),
-                horizontalAlignment = Alignment.CenterHorizontally
-            )
-            {
-                Image(
-                    painter = painterResource(R.drawable.ic_listening),
-                    contentDescription = null,
+                    .fillMaxHeight()
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                if (landscape) {
+                    Column(modifier = Modifier.fillMaxHeight()) {
+                        LocalImage()
+                    }
+                }
+                Column(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(2.1f)
+                        .padding(top = 30.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
                 )
+                {
+                    if (!landscape) {
+                        LocalImage()
+                        Spacer(modifier = Modifier.height(50.dp))
+                    }
 
-                Spacer(modifier = Modifier.height(50.dp))
+                    Column(modifier = Modifier.padding(horizontal = 30.dp)) {
+                        Text(
+                            text = stringResource(R.string.first_launch_headphones_title),
+                            style = MaterialTheme.typography.titleLarge,
+                            textAlign = TextAlign.Center
+                        )
+                        Spacer(modifier = Modifier.height(50.dp))
+                        Text(
+                            text = stringResource(R.string.first_launch_headphones_message_1),
+                            style = MaterialTheme.typography.bodyMedium,
+                            textAlign = TextAlign.Center
+                        )
+                        Spacer(modifier = Modifier.height(10.dp))
+                        Text(
+                            text = stringResource(R.string.first_launch_headphones_message_2),
+                            style = MaterialTheme.typography.bodyMedium,
+                            textAlign = TextAlign.Center
+                        )
+                        Spacer(modifier = Modifier.height(50.dp))
 
-                Column(modifier = Modifier.padding(horizontal = 50.dp)) {
-                    Text(
-                        text = stringResource(R.string.first_launch_headphones_title),
-                        style = MaterialTheme.typography.titleLarge,
-                        textAlign = TextAlign.Center
-                    )
-                    Spacer(modifier = Modifier.height(50.dp))
-                    Text(
-                        text = stringResource(R.string.first_launch_headphones_message_1),
-                        style = MaterialTheme.typography.bodyMedium,
-                        textAlign = TextAlign.Center
-                    )
-                    Spacer(modifier = Modifier.height(10.dp))
-                    Text(
-                        text = stringResource(R.string.first_launch_headphones_message_2),
-                        style = MaterialTheme.typography.bodyMedium,
-                        textAlign = TextAlign.Center
-                    )
-                    Spacer(modifier = Modifier.height(50.dp))
-
-                    OnboardButton(
-                        text = stringResource(R.string.ui_continue),
-                        onClick = { onNavigate(Screens.Hearing.route) },
-                        modifier = Modifier.fillMaxWidth()
-                    )
+                        OnboardButton(
+                            text = stringResource(R.string.ui_continue),
+                            onClick = { onNavigate(Screens.Hearing.route) },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
                 }
             }
         }
     }
 }
 
+@Preview(device = "spec:parent=pixel_5,orientation=landscape")
 @Preview
 @Composable
 fun ListeningPreview() {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Navigating.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Navigating.kt
@@ -55,9 +55,10 @@ fun Navigating(onNavigate: (String) -> Unit) {
 
             Column(
                 modifier = Modifier
-                    .padding(horizontal = 30.dp, vertical = 100.dp)
+                    .padding(horizontal = 30.dp, vertical = 30.dp)
                     .fillMaxWidth()
-                    .fillMaxHeight(),
+                    .fillMaxHeight()
+                    .verticalScroll(rememberScrollState()),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Top
             )
@@ -78,7 +79,6 @@ fun Navigating(onNavigate: (String) -> Unit) {
                 Column(
                     modifier = Modifier
                         .clip(RoundedCornerShape(5.dp))
-                        .verticalScroll(rememberScrollState())
                         .fillMaxWidth()
                         .height(200.dp)
                         .background(Color.Black.copy(alpha = 0.4f))
@@ -167,7 +167,7 @@ fun Navigating(onNavigate: (String) -> Unit) {
                     }
                 }
 
-                Spacer(modifier = Modifier.height(150.dp))
+                Spacer(modifier = Modifier.height(30.dp))
 
                 Column(modifier = Modifier.padding(horizontal = 20.dp)) {
                     OnboardButton(
@@ -185,6 +185,7 @@ fun Navigating(onNavigate: (String) -> Unit) {
     }
 }
 
+@Preview(device = "spec:parent=pixel_5,orientation=landscape")
 @Preview
 @Composable
 fun NavigatingPreview() {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Terms.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Terms.kt
@@ -13,7 +13,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -57,9 +59,10 @@ fun Terms(onNavigate: (String) -> Unit) {
         MaterialTheme(typography = IntroTypography) {
             Column(
                 modifier = Modifier
-                    .padding(horizontal = 20.dp, vertical = 50.dp)
+                    .padding(horizontal = 20.dp, vertical = 30.dp)
                     .fillMaxWidth()
-                    .fillMaxHeight(),
+                    .fillMaxHeight()
+                    .verticalScroll(rememberScrollState()),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Top
             ) {
@@ -108,7 +111,7 @@ fun Terms(onNavigate: (String) -> Unit) {
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(top = 60.dp)
+                        .padding(top = 30.dp)
                 ) {
                     if (checkedState.value){
                         OnboardButton(
@@ -148,6 +151,7 @@ fun TermsItem(text: String) {
 
 
 
+@Preview(device = "spec:parent=pixel_5,orientation=landscape")
 @Preview
 @Composable
 fun TermsPreview() {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Welcome.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Welcome.kt
@@ -4,18 +4,22 @@ import android.content.res.Configuration
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -28,64 +32,81 @@ import org.scottishtecharmy.soundscape.ui.theme.IntroductionTheme
 import org.scottishtecharmy.soundscape.ui.theme.SoundscapeTheme
 
 @Composable
+private fun LocalImage() {
+    Image(
+        painter = painterResource(R.drawable.soundscape_alpha_1024),
+        contentDescription = stringResource(R.string.first_launch_welcome_title_accessibility_label),
+        modifier = Modifier
+            .clip(RoundedCornerShape(90.dp))
+    )
+}
+@Composable
 fun Welcome(onNavigate: (String) -> Unit) {
     IntroductionTheme {
         MaterialTheme(typography = IntroTypography) {
-            Column(
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .fillMaxHeight(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
+                    .fillMaxHeight()
+                    .verticalScroll(rememberScrollState()),
             ) {
-                Image(
-                    painter = painterResource(R.drawable.soundscape_alpha_1024),
-                    contentDescription = stringResource(R.string.first_launch_welcome_title_accessibility_label),
-                    modifier = Modifier
-                        .padding(24.dp)
-                        .clip(RoundedCornerShape(90.dp))
-                )
-
-                Spacer(modifier = Modifier.height(50.dp))
-
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier.padding(horizontal = 50.dp)
-                ) {
-                    Text(
-                        text = stringResource(R.string.first_launch_welcome_title),
-                        style = MaterialTheme.typography.titleLarge,
-                        textAlign = TextAlign.Center
-                    )
-                    Spacer(modifier = Modifier.height(10.dp))
-                    Text(
-                        text = stringResource(R.string.first_launch_welcome_description),
-                        style = MaterialTheme.typography.bodyMedium,
-                        textAlign = TextAlign.Center
-                    )
-
-                    Spacer(modifier = Modifier.height(50.dp))
-
-                    Column(modifier = Modifier.padding(horizontal = 50.dp)) {
-                        OnboardButton(
-                            text = stringResource(R.string.first_launch_welcome_button),
-                            onClick = { onNavigate(Screens.Language.route) },
-                            modifier = Modifier.fillMaxWidth()
-                        )
+                if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxHeight(),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        LocalImage()
                     }
                 }
+                Column(
+                    modifier = Modifier
+                        .fillMaxHeight(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT) {
+                        LocalImage()
 
+                        Spacer(modifier = Modifier.height(30.dp))
+                    }
+
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.padding(horizontal = 30.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.first_launch_welcome_title),
+                            style = MaterialTheme.typography.titleLarge,
+                            textAlign = TextAlign.Center
+                        )
+                        Spacer(modifier = Modifier.height(10.dp))
+                        Text(
+                            text = stringResource(R.string.first_launch_welcome_description),
+                            style = MaterialTheme.typography.bodyMedium,
+                            textAlign = TextAlign.Center
+                        )
+
+                        Spacer(modifier = Modifier.height(50.dp))
+
+                        Column(modifier = Modifier.padding(horizontal = 50.dp)) {
+                            OnboardButton(
+                                text = stringResource(R.string.first_launch_welcome_button),
+                                onClick = { onNavigate(Screens.Language.route) },
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+                    }
+
+                }
             }
         }
     }
 }
 
-@Preview(name = "Light Mode")
-@Preview(
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-    showBackground = true,
-    name = "Dark Mode"
-)
+@Preview(device = "spec:parent=pixel_5,orientation=landscape")
+@Preview
 @Composable
 fun PreviewWelcome() {
     SoundscapeTheme {


### PR DESCRIPTION
Two main changes here:

1. Any screen with a large image at the top in portrait now has two columns when in landscape. The image appears in the left hand column.

2. Vertical scrolling enabled on parent Column/Row so that any off the screen UI can be accessed.

Various padding changes - but I'm less confident in those.