### PR TITLE
Move onboarding screen ViewModels into their own files

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/components/LanguageSelectionBox.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/components/LanguageSelectionBox.kt
@@ -22,13 +22,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.core.os.LocaleListCompat
-import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
-import org.scottishtecharmy.soundscape.screens.onboarding.LanguageViewModel
 import org.scottishtecharmy.soundscape.ui.theme.Primary
 
 data class Language(

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/AudioBeacons.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/AudioBeacons.kt
@@ -41,53 +41,13 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewModelScope
-import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.stateIn
 import org.scottishtecharmy.soundscape.R
-import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
 import org.scottishtecharmy.soundscape.components.OnboardButton
 import org.scottishtecharmy.soundscape.ui.theme.IntroTypography
 import org.scottishtecharmy.soundscape.ui.theme.IntroductionTheme
 import org.scottishtecharmy.soundscape.ui.theme.Primary
-import javax.inject.Inject
-
-@HiltViewModel
-class AudioBeaconsViewModel @Inject constructor(private val audioEngine : NativeAudioEngine): ViewModel() {
-
-    data class AudioBeaconsUiState(
-        // Data for the ViewMode that affects the UI
-        var beaconTypes : List<String> = emptyList()
-    )
-    private var beacon : Long = 0
-
-    val state: StateFlow<AudioBeaconsUiState> = flow {
-        val audioEngineBeaconTypes = audioEngine.getListOfBeaconTypes()
-        val beaconTypes = mutableListOf<String>()
-        for (type in audioEngineBeaconTypes) {
-            beaconTypes.add(type)
-        }
-        emit(AudioBeaconsUiState(beaconTypes = beaconTypes))
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AudioBeaconsUiState())
-
-    fun setAudioBeaconType(type: String) {
-        audioEngine.setBeaconType(type)
-        if(beacon != 0L)
-            audioEngine.destroyBeacon(beacon)
-        beacon = audioEngine.createBeacon(0.0, 0.0)
-    }
-
-    fun silenceBeacon() {
-        if(beacon != 0L)
-            audioEngine.destroyBeacon(beacon)
-    }
-}
-
+import org.scottishtecharmy.soundscape.viewmodels.AudioBeaconsViewModel
 
 @Composable
 fun AudioBeacons(onNavigate: (String) -> Unit, mockData : MockHearingPreviewData?) {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Hearing.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Hearing.kt
@@ -32,28 +32,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.ViewModel
-import dagger.hilt.android.lifecycle.HiltViewModel
 import org.scottishtecharmy.soundscape.R
-import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
 import org.scottishtecharmy.soundscape.components.OnboardButton
 import org.scottishtecharmy.soundscape.ui.theme.IntroTypography
 import org.scottishtecharmy.soundscape.ui.theme.IntroductionTheme
-import javax.inject.Inject
-
-@HiltViewModel
-class HearingViewModel @Inject constructor(private val audioEngine : NativeAudioEngine): ViewModel() {
-
-    fun playSpeech(speechText: String) {
-        // Set our listener position, and play the speech
-        // TODO: If updateGeometry isn't called, then the audioEngine doesn't move on to   the next
-        //  queued text to speech. That resulted in the Listen button only working one time.
-        //  Calling updateGeometry (which in the service is called every 30ms) sorts this out.
-        //  We should consider another way of doing this.
-        audioEngine.updateGeometry(0.0, 0.0,0.0)
-        audioEngine.createTextToSpeech(0.0,0.0, speechText)
-    }
-}
+import org.scottishtecharmy.soundscape.viewmodels.HearingViewModel
 
 @Composable
 private fun LocalImage() {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Language.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Language.kt
@@ -1,6 +1,5 @@
 package org.scottishtecharmy.soundscape.screens.onboarding
 
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -21,74 +20,14 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewModelScope
-import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.stateIn
 import org.scottishtecharmy.soundscape.R
-import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
 import org.scottishtecharmy.soundscape.components.Language
 import org.scottishtecharmy.soundscape.components.LanguageSelectionBox
 import org.scottishtecharmy.soundscape.components.OnboardButton
-import org.scottishtecharmy.soundscape.screens.onboarding.AudioBeaconsViewModel.AudioBeaconsUiState
 import org.scottishtecharmy.soundscape.ui.theme.IntroTypography
 import org.scottishtecharmy.soundscape.ui.theme.IntroductionTheme
-import javax.inject.Inject
-
-@HiltViewModel
-class LanguageViewModel @Inject constructor(private val audioEngine : NativeAudioEngine): ViewModel() {
-
-    data class LanguageUiState(
-        // Data for the ViewMode that affects the UI
-        var supportedLanguages : List<Language> = emptyList()
-    )
-
-    private fun addIfSpeechSupports(allLanguages: MutableList<Language>, language: Language) {
-        // TODO: The idea here is to add the language only if it's supported by the text to speech
-        //  engine. However, the audioEngine appears to be struggling to initialize the TextToSpeech.
-        //  Not sure why - needs investigation.
-//        val locales = audioEngine.getAvailableSpeechLanguages()
-//        for (locale in locales) {
-//            if (locale.language == language.code) {
-        allLanguages.add(language)
-//                return
-//            }
-//        }
-    }
-
-    private fun getAllLanguages(): List<Language> {
-        val allLanguages = mutableListOf<Language>()
-
-        addIfSpeechSupports(allLanguages, Language("Dansk", "da"))
-        addIfSpeechSupports(allLanguages, Language("Deutsch", "de"))
-        addIfSpeechSupports(allLanguages, Language("Ελληνικά", "el"))
-        addIfSpeechSupports(allLanguages, Language("English", "en"))
-        addIfSpeechSupports(allLanguages, Language("Español", "es"))
-        addIfSpeechSupports(allLanguages, Language("Suomi", "fi"))
-        addIfSpeechSupports(allLanguages, Language("Français", "fr"))
-        addIfSpeechSupports(allLanguages, Language("Italiano", "it"))
-        addIfSpeechSupports(allLanguages, Language("日本語", "ja"))
-        addIfSpeechSupports(allLanguages, Language("Norsk", "nb"))
-        addIfSpeechSupports(allLanguages, Language("Nederlands", "nl"))
-        addIfSpeechSupports(allLanguages, Language("Português (Brasil)", "pt"))
-        addIfSpeechSupports(allLanguages, Language("Svenska", "sv"))
-
-        return allLanguages
-    }
-
-    val state: StateFlow<LanguageUiState> = flow {
-        emit(LanguageUiState(supportedLanguages = getAllLanguages()))
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), LanguageUiState())
-
-    fun updateSpeechLanguage(): Boolean {
-        val languageCode = AppCompatDelegate.getApplicationLocales().toLanguageTags()
-        return audioEngine.setSpeechLanguage(languageCode)
-    }
-}
+import org.scottishtecharmy.soundscape.viewmodels.LanguageViewModel
 
 @Composable
 fun Language(onNavigate: (String) -> Unit, mockData : MockLanguagePreviewData?){

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/AudioBeaconsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/AudioBeaconsViewModel.kt
@@ -1,0 +1,42 @@
+package org.scottishtecharmy.soundscape.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
+import javax.inject.Inject
+
+@HiltViewModel
+class AudioBeaconsViewModel @Inject constructor(private val audioEngine : NativeAudioEngine): ViewModel() {
+
+    data class AudioBeaconsUiState(
+        // Data for the ViewMode that affects the UI
+        var beaconTypes : List<String> = emptyList()
+    )
+    private var beacon : Long = 0
+
+    val state: StateFlow<AudioBeaconsUiState> = flow {
+        val audioEngineBeaconTypes = audioEngine.getListOfBeaconTypes()
+        val beaconTypes = mutableListOf<String>()
+        for (type in audioEngineBeaconTypes) {
+            beaconTypes.add(type)
+        }
+        emit(AudioBeaconsUiState(beaconTypes = beaconTypes))
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AudioBeaconsUiState())
+
+    fun setAudioBeaconType(type: String) {
+        audioEngine.setBeaconType(type)
+        if(beacon != 0L)
+            audioEngine.destroyBeacon(beacon)
+        beacon = audioEngine.createBeacon(0.0, 0.0)
+    }
+
+    fun silenceBeacon() {
+        if(beacon != 0L)
+            audioEngine.destroyBeacon(beacon)
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/HearingViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/HearingViewModel.kt
@@ -1,0 +1,20 @@
+package org.scottishtecharmy.soundscape.viewmodels
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
+import javax.inject.Inject
+
+@HiltViewModel
+class HearingViewModel @Inject constructor(private val audioEngine : NativeAudioEngine): ViewModel() {
+
+    fun playSpeech(speechText: String) {
+        // Set our listener position, and play the speech
+        // TODO: If updateGeometry isn't called, then the audioEngine doesn't move on to   the next
+        //  queued text to speech. That resulted in the Listen button only working one time.
+        //  Calling updateGeometry (which in the service is called every 30ms) sorts this out.
+        //  We should consider another way of doing this.
+        audioEngine.updateGeometry(0.0, 0.0,0.0)
+        audioEngine.createTextToSpeech(0.0,0.0, speechText)
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LanguageViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LanguageViewModel.kt
@@ -1,0 +1,64 @@
+package org.scottishtecharmy.soundscape.viewmodels
+
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
+import org.scottishtecharmy.soundscape.components.Language
+import javax.inject.Inject
+
+@HiltViewModel
+class LanguageViewModel @Inject constructor(private val audioEngine : NativeAudioEngine): ViewModel() {
+
+    data class LanguageUiState(
+        // Data for the ViewMode that affects the UI
+        var supportedLanguages : List<Language> = emptyList()
+    )
+
+    private fun addIfSpeechSupports(allLanguages: MutableList<Language>, language: Language) {
+        // TODO: The idea here is to add the language only if it's supported by the text to speech
+        //  engine. However, the audioEngine appears to be struggling to initialize the TextToSpeech.
+        //  Not sure why - needs investigation.
+//        val locales = audioEngine.getAvailableSpeechLanguages()
+//        for (locale in locales) {
+//            if (locale.language == language.code) {
+        allLanguages.add(language)
+//                return
+//            }
+//        }
+    }
+
+    private fun getAllLanguages(): List<Language> {
+        val allLanguages = mutableListOf<Language>()
+
+        addIfSpeechSupports(allLanguages, Language("Dansk", "da"))
+        addIfSpeechSupports(allLanguages, Language("Deutsch", "de"))
+        addIfSpeechSupports(allLanguages, Language("Ελληνικά", "el"))
+        addIfSpeechSupports(allLanguages, Language("English", "en"))
+        addIfSpeechSupports(allLanguages, Language("Español", "es"))
+        addIfSpeechSupports(allLanguages, Language("Suomi", "fi"))
+        addIfSpeechSupports(allLanguages, Language("Français", "fr"))
+        addIfSpeechSupports(allLanguages, Language("Italiano", "it"))
+        addIfSpeechSupports(allLanguages, Language("日本語", "ja"))
+        addIfSpeechSupports(allLanguages, Language("Norsk", "nb"))
+        addIfSpeechSupports(allLanguages, Language("Nederlands", "nl"))
+        addIfSpeechSupports(allLanguages, Language("Português (Brasil)", "pt"))
+        addIfSpeechSupports(allLanguages, Language("Svenska", "sv"))
+
+        return allLanguages
+    }
+
+    val state: StateFlow<LanguageUiState> = flow {
+        emit(LanguageUiState(supportedLanguages = getAllLanguages()))
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), LanguageUiState())
+
+    fun updateSpeechLanguage(): Boolean {
+        val languageCode = AppCompatDelegate.getApplicationLocales().toLanguageTags()
+        return audioEngine.setSpeechLanguage(languageCode)
+    }
+}


### PR DESCRIPTION
Android Studio does this with a few clicks via Refactor (F6). Moved them next to the PermissionsViewModel.