### PR TITLE
Initial integration of MapCompose map

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -70,6 +70,12 @@ jobs:
         id: get-version
         run: echo "VERSION=$(git describe --tags)" >> $GITHUB_OUTPUT
 
+      - name: Setup tile provider API key
+        env:
+          TILE_PROVIDER_API_KEY: ${{ secrets.TILE_PROVIDER_API_KEY }}
+        run: |
+          echo tileProviderApiKey=$TILE_PROVIDER_API_KEY > local.properties
+
       - name: Decode Google services
         env:
           ENCODED_STRING: ${{ secrets.GOOGLE_SERVICES }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -48,6 +48,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup tile provider API key
+        env:
+          TILE_PROVIDER_API_KEY: ${{ secrets.TILE_PROVIDER_API_KEY }}
+        run: |
+          echo tileProviderApiKey=$TILE_PROVIDER_API_KEY > local.properties
+
       - name: Decode Google services
         env:
           ENCODED_STRING: ${{ secrets.GOOGLE_SERVICES }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -32,6 +35,19 @@ android {
         targetSdk = 35
         versionCode = 36
         versionName = "0.0.35"
+
+        // Retrieve the tile provider API from local.properties. This is not under version control
+        // and must be configured by each developer locally. GitHb actions fill in local.properties
+        // from a secret.
+        var tileProviderApiKey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        try {
+            val localProperties = Properties()
+            localProperties.load(FileInputStream(rootProject.file("local.properties")))
+            tileProviderApiKey = localProperties["tileProviderApiKey"].toString()
+        } catch (e: Exception) {
+            println("Failed to load local.properties for TILE_PROVIDER_API_KEY: $e")
+        }
+        buildConfigField("String", "TILE_PROVIDER_API_KEY", "\"${tileProviderApiKey}\"")
 
         buildConfigField("String", "VERSION_NAME", "\"${versionName}\"")
         buildConfigField("String", "FMOD_LIB", "\"fmod\"")
@@ -174,6 +190,9 @@ dependencies {
 
     // GPX parser
     implementation (libs.android.gpx.parser)
+
+    // Open Street Map compose library
+    implementation (libs.mapcompose)
 
     // Screenshots for tests
     //screenshotTestImplementation(libs.androidx.compose.ui.tooling)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
@@ -1,0 +1,83 @@
+package org.scottishtecharmy.soundscape
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import android.util.Log
+
+import org.scottishtecharmy.soundscape.services.SoundscapeService
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SoundscapeServiceConnection @Inject constructor(@ApplicationContext context: Context) {
+
+    var soundscapeService: SoundscapeService? = null
+    private val appContext = context
+
+    private var _serviceBoundState = MutableStateFlow(false)
+    val serviceBoundState = _serviceBoundState.asStateFlow()
+
+    // needed to communicate with the service.
+    private val connection = object : ServiceConnection {
+
+        override fun onServiceConnected(className: ComponentName, service: IBinder) {
+            // we've bound to ExampleLocationForegroundService, cast the IBinder and get ExampleLocationForegroundService instance.
+            Log.d(TAG, "onServiceConnected")
+
+            val binder = service as SoundscapeService.LocalBinder
+            soundscapeService = binder.getService()
+            _serviceBoundState.value = true
+        }
+
+        override fun onServiceDisconnected(arg0: ComponentName) {
+            // This is called when the connection with the service has been disconnected. Clean up.
+            Log.d(TAG, "onServiceDisconnected")
+
+            _serviceBoundState.value = false
+        }
+    }
+
+    fun create() {
+        Log.d(TAG, "create")
+        tryToBindToServiceIfRunning()
+    }
+
+    private fun destroy() {
+
+        Log.d(TAG, "destroy")
+
+        // If this was the first launch
+        if(serviceBoundState.value) {
+            appContext.unbindService(connection)
+            _serviceBoundState.value = false
+        }
+    }
+
+    fun stopServiceAndExit() {
+        Log.d(TAG, "stopServiceAndExit")
+        // service is already running, stop it
+        soundscapeService?.stopForegroundService()
+
+        destroy()
+    }
+
+    fun tryToBindToServiceIfRunning() {
+        Log.d(TAG, "tryToBindToServiceIfRunning " + serviceBoundState.value)
+
+        if(!serviceBoundState.value) {
+            Intent(appContext, SoundscapeService::class.java).also { intent ->
+                appContext.bindService(intent, connection, 0)
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "SoundscapeServiceConnection"
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/di/HiltModule.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/di/HiltModule.kt
@@ -1,15 +1,14 @@
 package org.scottishtecharmy.soundscape.di
 
 import android.content.Context
-
-import org.scottishtecharmy.soundscape.datastore.DataStoreManager
-
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import org.scottishtecharmy.soundscape.SoundscapeServiceConnection
 import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
+import org.scottishtecharmy.soundscape.datastore.DataStoreManager
 import javax.inject.Singleton
 
 
@@ -32,5 +31,16 @@ class AppNativeAudioEngine {
         val audioEngine = NativeAudioEngine()
         audioEngine.initialize(context)
         return audioEngine
+    }
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+class AppSoundscapeServiceConnection {
+    @Provides
+    @Singleton
+    fun provideSoundscapeServiceConnection(@ApplicationContext context: Context): SoundscapeServiceConnection {
+        val serviceConnection = SoundscapeServiceConnection(context)
+        return serviceConnection
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/Home.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/Home.kt
@@ -51,18 +51,27 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.scottishtecharmy.soundscape.MainActivity
+import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.components.DrawerMenuItem
 import org.scottishtecharmy.soundscape.components.MainSearchBar
-import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.components.NavigationButton
+import org.scottishtecharmy.soundscape.viewmodels.HomeViewModel
+import ovh.plrapps.mapcompose.ui.MapUI
 
 
-@Preview(showBackground = true)
+@Preview(device = "spec:parent=pixel_5,orientation=landscape")
+@Preview
 @Composable
-fun Home() {
+fun HomePreview() {
+    Home(false)
+}
+
+@Composable
+fun Home(useView : Boolean = true) {
     val coroutineScope = rememberCoroutineScope()
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
 
@@ -95,7 +104,8 @@ fun Home() {
                         onToggleSearch = {  },
                         onItemClick = {  }
                     )
-                }
+                },
+                useView
             )
         }
 
@@ -349,15 +359,28 @@ fun HomeBottomAppBar(
 }
 
 @Composable
+fun MapContainer(
+    modifier: Modifier = Modifier, viewModel: HomeViewModel
+) {
+    MapUI(modifier, state = viewModel.state)
+}
+
+@Composable
 fun HomeContent(
     innerPadding: PaddingValues,
-    searchBar: @Composable () -> Unit
+    searchBar: @Composable () -> Unit,
+    useView : Boolean
 ) {
     val context = LocalContext.current
+    var viewModel : HomeViewModel? = null
     val notAvailableText = "This is not implemented yet."
     val notAvailableToast = {
         Toast.makeText(context, notAvailableText, Toast.LENGTH_SHORT).show()
     }
+
+    if(useView)
+        viewModel = hiltViewModel<HomeViewModel>()
+
     Column(
         modifier = Modifier
             .padding(innerPadding),
@@ -384,6 +407,8 @@ fun HomeContent(
                 onClick = { notAvailableToast() },
                 text = stringResource(R.string.search_use_current_location)
             )
+            if(viewModel != null)
+                MapContainer(viewModel = viewModel)
         }
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/utils/TileUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/utils/TileUtils.kt
@@ -14,10 +14,13 @@ import org.scottishtecharmy.soundscape.geojsonparser.geojson.MultiPolygon
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Polygon
 import com.squareup.moshi.Moshi
+import java.lang.Math.toDegrees
 import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.asinh
+import kotlin.math.atan
 import kotlin.math.floor
+import kotlin.math.sinh
 import kotlin.math.tan
 
 //TODO getFovIntersectionFeatureCollection, getFovRoadsFeatureCollection and getFovPoiFeatureCollection can be rolled into one as just repeating the same thing
@@ -54,6 +57,47 @@ fun getXYTile(
         ytile = (1 shl zoom) - 1
     }
     return Pair(xtile, ytile)
+}
+
+/**
+ * Gets map coordinates from X and Y GPS coordinates. This is the same calculation as above
+ * but returns normalised x and y values scaled between 0 and 1.0. These are what are required
+ * by the mapcompose library to set markers/positions.
+ * @param lat
+ * Latitude in decimal degrees.
+ * @param lon
+ * Longitude in decimal degrees.
+ * @return a Pair(x, y).
+ */
+fun getNormalizedFromGpsMapCoordinates(
+    lat: Double,
+    lon: Double
+): Pair<Double, Double> {
+
+    val latRad = toRadians(lat)
+    var x = (lon + 180.0) / 360.0
+    var y = (1.0 - asinh(tan(latRad)) / PI) / 2
+
+    // Keep result within bounds
+    x = minOf(1.0, maxOf(0.0, x))
+    y = minOf(1.0, maxOf(0.0, y))
+
+    return Pair(x, y)
+}
+
+fun getGpsFromNormalizedMapCoordinates(
+    x: Double,
+    y: Double
+): Pair<Double, Double> {
+
+//    val latRad = toRadians(lat)
+//    var x = (lon + 180.0) / 360.0
+//    var y = (1.0 - asinh(tan(latRad)) / PI) / 2
+
+    val latitude = toDegrees(atan(sinh((1.0 - (2 * y)) * PI)))
+    val longitude = (360.0 * x) - 180.0
+
+    return Pair(latitude, longitude)
 }
 
 /**

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/HomeViewModel.kt
@@ -1,0 +1,177 @@
+package org.scottishtecharmy.soundscape.viewmodels
+
+import android.util.Log
+import androidx.compose.material.icons.Icons
+import androidx.compose.material3.Icon
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import org.scottishtecharmy.soundscape.BuildConfig
+import org.scottishtecharmy.soundscape.R
+import org.scottishtecharmy.soundscape.SoundscapeServiceConnection
+import org.scottishtecharmy.soundscape.utils.getGpsFromNormalizedMapCoordinates
+import org.scottishtecharmy.soundscape.utils.getNormalizedFromGpsMapCoordinates
+import ovh.plrapps.mapcompose.api.addLayer
+import ovh.plrapps.mapcompose.api.addMarker
+import ovh.plrapps.mapcompose.api.centerOnMarker
+import ovh.plrapps.mapcompose.api.enableRotation
+import ovh.plrapps.mapcompose.api.hasMarker
+import ovh.plrapps.mapcompose.api.moveMarker
+import ovh.plrapps.mapcompose.api.onLongPress
+import ovh.plrapps.mapcompose.api.onMarkerLongPress
+import ovh.plrapps.mapcompose.api.removeMarker
+import ovh.plrapps.mapcompose.api.scale
+import ovh.plrapps.mapcompose.core.TileStreamProvider
+import ovh.plrapps.mapcompose.ui.layout.Forced
+import ovh.plrapps.mapcompose.ui.state.MapState
+import java.net.URL
+import javax.inject.Inject
+import kotlin.math.pow
+import androidx.compose.material.icons.rounded.Navigation
+
+@HiltViewModel
+class HomeViewModel @Inject constructor(private val soundscapeServiceConnection : SoundscapeServiceConnection): ViewModel() {
+
+    private val tileStreamProvider = TileStreamProvider { row, col, zoomLvl ->
+        val style = "atlas"
+        val apikey = BuildConfig.TILE_PROVIDER_API_KEY
+
+        try {
+            URL("https://tile.thunderforest.com/$style/$zoomLvl/$col/$row.png?apikey=$apikey").openStream()
+        } catch (e : Exception) {
+            Log.e("TileProvider", "Exception $e")
+            null
+        }
+    }
+
+    private var serviceConnection : SoundscapeServiceConnection? = null
+    private var x : Double = 0.0
+    private var y : Double = 0.0
+    private var heading : Float = 0.0F
+
+    private val maxLevel = 20
+    private val minLevel = 5
+    private val mapSize = mapSizeAtLevel(maxLevel, tileSize = 256)
+
+    private fun mapSizeAtLevel(wmtsLevel: Int, tileSize: Int): Int {
+        return tileSize * 2.0.pow(wmtsLevel).toInt()
+    }
+
+    val state = MapState(levelCount = maxLevel + 1, mapSize, mapSize, workerCount = 16) {
+        minimumScaleMode(Forced((1 / 2.0.pow(maxLevel - minLevel)).toFloat()))
+    }.apply {
+        addLayer(tileStreamProvider)
+        onMarkerLongPress { id, _, _ ->
+            // A long press on the beacon marker will delete it and the audio beacon
+            if(id == "beacon") {
+                soundscapeServiceConnection.soundscapeService?.destroyBeacon()
+                removeMarker("beacon")
+            }
+        }
+        onLongPress { x, y ->
+            // A long press for now will add an audio beacon at that point
+            soundscapeServiceConnection.soundscapeService?.destroyBeacon()
+            removeMarker("beacon")
+
+            val coordinates = getGpsFromNormalizedMapCoordinates(x, y)
+            soundscapeServiceConnection.soundscapeService?.createBeacon(coordinates.first, coordinates.second)
+        }
+        enableRotation()
+        scale = 0.5f
+    }
+
+    private fun startMonitoringLocation() {
+        Log.d(TAG, "ViewModel startMonitoringLocation")
+        viewModelScope.launch {
+            // Observe location updates from the service
+            serviceConnection?.soundscapeService?.locationFlow?.collectLatest { value ->
+                if (value != null) {
+                    val coordinates = getNormalizedFromGpsMapCoordinates(
+                        value.latitude,
+                        value.longitude
+                    )
+                    x = coordinates.first
+                    y = coordinates.second
+
+                    if (!state.hasMarker("position")) {
+                        state.addMarker("position", x, y) {
+                            Icon(
+                                imageVector = Icons.Rounded.Navigation,
+                                contentDescription = null,
+                                modifier = Modifier.rotate(heading),
+                                tint = Color(0xCC2196F3)
+                            )
+                        }
+                        state.centerOnMarker("position")
+                    } else {
+                        state.moveMarker("position", x, y)
+                    }
+                }
+            }
+        }
+        viewModelScope.launch {
+            // Observe orientation updates from the service
+            serviceConnection?.soundscapeService?.orientationFlow?.collectLatest { value ->
+                if (value != null) {
+                    heading = value.headingDegrees
+                    state.removeMarker("position")
+                    state.addMarker("position", x, y) {
+                        Icon(
+                            //painter = painterResource(id = ),
+                            imageVector = Icons.Rounded.Navigation,
+                            contentDescription = null,
+                            modifier = Modifier.rotate(heading),
+                            tint = Color(0xCC2196F3)
+                        )
+                    }
+                }
+            }
+        }
+        viewModelScope.launch {
+            // Observe beacon location update from the service so we can show it on the map
+            serviceConnection?.soundscapeService?.beaconFlow?.collectLatest { value ->
+                if (value != null) {
+                    val coordinates = getNormalizedFromGpsMapCoordinates(
+                        value.latitude,
+                        value.longitude
+                    )
+
+                    if (!state.hasMarker("beacon")) {
+                        state.addMarker("beacon", coordinates.first, coordinates.second) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.nearby_markers_24px),
+                                contentDescription = null,
+                                tint = Color.Red
+                            )
+                        }
+                    }
+                    else {
+                        state.moveMarker("beacon", coordinates.first, coordinates.second)
+                    }
+                }
+            }
+        }
+    }
+
+    init {
+        serviceConnection = soundscapeServiceConnection
+        viewModelScope.launch {
+            soundscapeServiceConnection.serviceBoundState.collect {
+                Log.d(TAG, "serviceBoundState $it")
+                if(it) {
+                    startMonitoringLocation()
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "HomeViewModel"
+    }
+}

--- a/app/src/test/java/org/scottishtecharmy/soundscape/TileUtilsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/TileUtilsTest.kt
@@ -28,6 +28,8 @@ import org.scottishtecharmy.soundscape.utils.polygonContainsCoordinates
 import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
+import org.scottishtecharmy.soundscape.utils.getGpsFromNormalizedMapCoordinates
+import org.scottishtecharmy.soundscape.utils.getNormalizedFromGpsMapCoordinates
 
 class TileUtilsTest {
     private val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
@@ -564,4 +566,29 @@ class TileUtilsTest {
         Assert.assertEquals("Weston Road", nearestIntersectionRoadNames.features[0].properties!!["name"])
     }
 
+    private fun roundtripGpsLocation(latitude: Double, longitude: Double) {
+        val normalized = getNormalizedFromGpsMapCoordinates(latitude, longitude)
+        val gps = getGpsFromNormalizedMapCoordinates(normalized.first, normalized.second)
+        Assert.assertEquals(gps.first, latitude, 0.0000000001)
+        Assert.assertEquals(gps.second, longitude, 0.0000000001)
+    }
+    @Test
+    fun testNormalizingLocation() {
+        // Roundtrip some GPS locations
+        val latitude = -3.1970584
+        val longitude = 55.9412409
+        val normalized = getNormalizedFromGpsMapCoordinates(latitude, longitude)
+        Assert.assertEquals(normalized.first, 0.6553923358333333, 0.0000000001)
+        Assert.assertEquals(normalized.second, 0.5088853297949566, 0.0000000001)
+        val gps = getGpsFromNormalizedMapCoordinates(normalized.first, normalized.second)
+        Assert.assertEquals(gps.first, latitude, 0.0000001)
+        Assert.assertEquals(gps.second, longitude, 0.0000001)
+
+        roundtripGpsLocation(-41.5870134, 162.8204719)      // Christchurch
+        roundtripGpsLocation(64.511925, -165.5752794)       // Nome
+        roundtripGpsLocation(0.0, -179.0)
+        roundtripGpsLocation(0.0, 179.0)
+        roundtripGpsLocation(85.0, -179.0)                  // The projection breaks above 85 degrees
+        roundtripGpsLocation(-85.0, 179.0)
+    }
 }

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -27,6 +27,10 @@ Authenticate for talking to the Firebase servers is done using [google-github-ac
 The `run-test.yaml` action bumps the version number, committing the change back into the repo. The repo has branch protection enabled which requires a pull request for any commits. We pass in a token as described [here](https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#push-to-protected-branches) to allow the pull request to be bypassed:
 * PAT_TOKEN - token generated on an admin account which allows write access to public repos.
 
+### OSM rendered tile API key
+The code is currently hard coded to use [https://www.thunderforest.com/](Thunderforest) to provide the rendered mapping tiles. This requires an API key which for developers is stored in `local.properties` as `tileProviderApiKey`, and for the GitHub actions is
+* TILE_PROVIDER_API_KEY - API key from Thunderforest
+
 ## Actions
 `run-tests.yaml` is the action which is run on each Pull Request. It runs several layers of tests:    
 * Lint of the repo

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ appcompat = "1.7.0"
 coreKtxVersion = "1.6.1"
 lifecycleViewmodelCompose = "2.8.4"
 loggingInterceptor = "4.10.0"
+mapcompose = "2.12.6"
 moshi = "1.15.1"
 moshiKotlinCodegen = "1.15.0"
 okhttp = "4.11.0"
@@ -93,6 +94,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 library-base = { module = "io.realm.kotlin:library-base", version.ref = "libraryBase" }
 logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "loggingInterceptor" }
+mapcompose = { module = "ovh.plrapps:mapcompose", version.ref = "mapcompose" }
 material3 = { module = "androidx.compose.material3:material3" }
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshiKotlinCodegen" }


### PR DESCRIPTION
This code is the initial integration of the MapCompose open street map UI. The soundscape service connection has been moved out into a separate class and then a MapCompose based UI has been added to the Home screen. The service now uses lastLocation to give a much quicker 'lock' on the current position.

The local map is displayed with a marker displaying the current location. The marker is moved whenever the Soundscape service updates the device location. The map can be zoomed in/out and repositioned independently of the marker location.
The map centers on the current location when the location is first updated. The heading is constantly updated so that the location icon rotates to point in the direcion of the phone.
A long press on the map will create an audio beacon at that location. A long press on the marker that appears will destroy that beacon, or a long press elsewhere will move the beacon to the new location. There's obviously a lot more UI that can be done, this is just the very start.

An HTTP cache has been initiated - this likely affects all HTTP and not just the Tiles for open street map. As a result it may be required to mark Tile HTTP requests with a cache-control header if we don't want them to go through the cache?

The API key for thunderforest is stored in local.properties as tileProviderApiKey so must be configured for each developer i.e.

tileProviderApiKey=xxXXxxXXxxXXxxXXxxXXxxXXxxXXxxXX

with an appropriate key. For builds, there's a new GitHub secret TILE_PROVIDER_API_KEY that needs setup.