### PR TITLE
Fix API 30 splash screen to stop crash

### DIFF
--- a/app/src/main/res/values-v30/splash.xml
+++ b/app/src/main/res/values-v30/splash.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="SplashTheme.Soundscape" parent="Theme.AppCompat">
+        <item name="postSplashScreenTheme">@style/Theme.SoundscapeAlpha</item>
+    </style>
+</resources>


### PR DESCRIPTION
Having dropped the SDK level down the splash screen resulted in a crash on API 30 because it didn't inherit from Theme.AppCompat.