### PR TITLE
Upgrade libraries including maplibre

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -156,7 +156,7 @@ dependencies {
 
     androidTestImplementation(libs.androidx.junit.v121)
     androidTestImplementation(libs.androidx.espresso.core.v351)
-    androidTestImplementation(platform(libs.androidx.compose.bom.v20230800))
+    androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.ui.test.junit4)
     debugImplementation(libs.ui.tooling)
     debugImplementation(libs.ui.test.manifest)
@@ -168,7 +168,6 @@ dependencies {
     implementation(libs.retrofit)
     implementation(libs.okhttp)
     implementation(libs.kotlinx.serialization.json)
-    implementation(libs.okhttp.v500alpha3)
     // logging interceptor
     implementation (libs.logging.interceptor)
 
@@ -176,7 +175,6 @@ dependencies {
     implementation(libs.converter.scalars)
 
     // Location permissions
-    implementation(libs.play.services.location.v2120)
     implementation(libs.accompanist.permissions)
 
     // GeoJSON parsing

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/Home.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/Home.kt
@@ -53,11 +53,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.mapbox.mapboxsdk.Mapbox
-import com.mapbox.mapboxsdk.WellKnownTileServer
-import com.mapbox.mapboxsdk.maps.MapView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import org.maplibre.android.MapLibre
+import org.maplibre.android.WellKnownTileServer
+import org.maplibre.android.maps.MapView
 import org.scottishtecharmy.soundscape.BuildConfig
 import org.scottishtecharmy.soundscape.MainActivity
 import org.scottishtecharmy.soundscape.R
@@ -387,7 +387,7 @@ fun HomeBottomAppBar(
 fun MapContainerLibre(viewModel: HomeViewModel) {
     AndroidView(
         factory = { context ->
-            Mapbox.getInstance(context, BuildConfig.TILE_PROVIDER_API_KEY, WellKnownTileServer.MapTiler)
+            MapLibre.getInstance(context, BuildConfig.TILE_PROVIDER_API_KEY, WellKnownTileServer.MapTiler)
             val mapView = MapView(context)
             mapView.onCreate(null)
             mapView.getMapAsync { map ->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,58 +1,47 @@
 [versions]
 accompanistPermissions = "0.33.2-alpha"
-agp = "8.3.2"
 androidGpxParser = "2.3.1"
-mapLibre = "10.0.2"
+mapLibre = "11.0.0"
 androidxJunit = "1.2.1"
-composeBomVersion = "2023.08.00"
 converterScalars = "2.9.0"
 coreSplashscreen = "1.0.1"
 coreTesting = "2.2.0"
 datastorePreferences = "1.1.1"
-espressoCoreVersion = "3.5.1"
-firebaseBom = "33.1.2"
+espressoCoreVersion = "3.6.1"
+firebaseBom = "33.2.0"
 hiltAndroid = "2.50"
 hiltCompiler = "2.50"
 hiltNavigationCompose = "1.2.0"
 junitJupiter = "5.8.1"
-kotlin = "1.9.22"
 coreKtx = "1.13.1"
 junit = "4.13.2"
-junitVersion = "1.2.0"
-espressoCore = "3.6.0"
 kotlinTestJunit = "1.9.10"
 kotlinxCoroutinesCore = "1.8.0"
 kotlinxCoroutinesTest = "1.8.0"
-kotlinxSerializationJson = "1.6.0"
+kotlinxSerializationJson = "1.7.1"
 libraryBase = "1.16.0"
-lifecycleRuntimeKtx = "2.8.2"
-activityCompose = "1.9.0"
-composeBom = "2024.06.00"
-lifecycleRuntimeKtxVersion = "2.8.0"
-lifecycleService = "2.8.2"
-lifecycleServiceVersion = "2.8.0"
+lifecycleRuntimeKtx = "2.8.5"
+activityCompose = "1.9.2"
+composeBom = "2024.09.00"
+lifecycleService = "2.8.5"
 appcompat = "1.7.0"
 coreKtxVersion = "1.6.1"
-lifecycleViewmodelCompose = "2.8.4"
+lifecycleViewmodelCompose = "2.8.5"
 loggingInterceptor = "4.10.0"
 mapcompose = "2.12.6"
-maplibreAndroidPluginAnnotationV9 = "0.9.0"
 moshi = "1.15.1"
 moshiKotlinCodegen = "1.15.0"
 okhttp = "4.11.0"
-okhttpVersion = "5.0.0-alpha.3"
 playServicesLocation = "21.3.0"
-playServicesLocationVersion = "21.2.0"
 protobufKotlinLite = "4.28.0"
 retrofit = "2.9.0"
-screenshot = "0.0.1-alpha03"
-benchmarkCommon = "1.2.4"
-lifecycleRuntimeComposeAndroid = "2.8.4"
+screenshot = "0.0.1-alpha06"
+benchmarkCommon = "1.3.0"
+lifecycleRuntimeComposeAndroid = "2.8.5"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
 android-gpx-parser = { module = "com.github.ticofab:android-gpx-parser", version.ref = "androidGpxParser" }
-androidx-compose-bom-v20230800 = { module = "androidx.compose:compose-bom", version.ref = "composeBomVersion" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
 androidx-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "coreTesting" }
@@ -61,8 +50,6 @@ androidx-datastore-preferences = { module = "androidx.datastore:datastore-prefer
 androidx-espresso-core-v351 = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCoreVersion" }
 androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 androidx-junit-v121 = { module = "androidx.test.ext:junit", version.ref = "androidxJunit" }
-androidx-lifecycle-runtime-ktx-v280 = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtxVersion" }
-androidx-lifecycle-service-v280 = { module = "androidx.lifecycle:lifecycle-service", version.ref = "lifecycleServiceVersion" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 androidx-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
@@ -73,18 +60,9 @@ firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltAndroid" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hiltCompiler" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
-androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
-androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
-androidx-ui = { group = "androidx.compose.ui", name = "ui" }
-androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
-androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
-androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
-androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-lifecycle-service = { group = "androidx.lifecycle", name = "lifecycle-service", version.ref = "lifecycleService" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 core-ktx = { group = "androidx.test", name = "core-ktx", version.ref = "coreKtxVersion" }
@@ -98,14 +76,11 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 library-base = { module = "io.realm.kotlin:library-base", version.ref = "libraryBase" }
 logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "loggingInterceptor" }
 mapcompose = { module = "ovh.plrapps:mapcompose", version.ref = "mapcompose" }
-maplibre-android-plugin-annotation-v9 = { module = "com.maplibre.maplibresdk:maplibre-android-plugin-annotation-v9", version.ref = "maplibreAndroidPluginAnnotationV9" }
 material3 = { module = "androidx.compose.material3:material3" }
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshiKotlinCodegen" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
-okhttp-v500alpha3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttpVersion" }
 play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "playServicesLocation" }
-play-services-location-v2120 = { module = "com.google.android.gms:play-services-location", version.ref = "playServicesLocationVersion" }
 protobuf-kotlin-lite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobufKotlinLite" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 ui = { module = "androidx.compose.ui:ui" }
@@ -117,7 +92,5 @@ ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 maplibre = { module = "org.maplibre.gl:android-sdk", version.ref = "mapLibre" }
 
 [plugins]
-androidApplication = { id = "com.android.application", version.ref = "agp" }
-jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 screenshot = { id = "com.android.compose.screenshot", version.ref = "screenshot"}
 


### PR DESCRIPTION
Upgrading MapLibre removed all of the outdated MapBox naming so now it's all MapLibre which makes more sense.
Almost all of the warnings in libs.versions.toml were resolved which included:

 * Upgrading libraries
 * Removing duplicate declarations
 * Removing declarations of two different versions of a library (okHttp)

The only remaining out of date library is Realm. If we bump that to 2.x then it doesn't compile (known issues it seems). Otherwise, everything seems to be working the same as before.