### PR TITLE
Replace button that stops service and exits with sleep toggle

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -169,11 +169,16 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    fun stopServiceAndExit() {
-        // service is already running, stop it
-        soundscapeServiceConnection.stopServiceAndExit()
-        // And exit application
-        finishAndRemoveTask()
+    fun toggleServiceState(newServiceState: Boolean) {
+
+        if(!newServiceState) {
+            soundscapeServiceConnection.soundscapeService?.stopForegroundService()
+            soundscapeServiceConnection.soundscapeService = null
+        }
+        else {
+            startSoundscapeService()
+            soundscapeServiceConnection.tryToBindToServiceIfRunning()
+        }
     }
 
     /**

--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
@@ -73,14 +73,6 @@ class SoundscapeServiceConnection @Inject constructor(@ApplicationContext contex
         }
     }
 
-    fun stopServiceAndExit() {
-        Log.d(TAG, "stopServiceAndExit")
-        // service is already running, stop it
-        soundscapeService?.stopForegroundService()
-
-        destroy()
-    }
-
     fun tryToBindToServiceIfRunning() {
         Log.d(TAG, "tryToBindToServiceIfRunning " + serviceBoundState.value)
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/Home.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/Home.kt
@@ -12,14 +12,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.ExitToApp
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.HelpOutline
 import androidx.compose.material.icons.rounded.Headset
 import androidx.compose.material.icons.rounded.IosShare
+import androidx.compose.material.icons.rounded.LocationOff
+import androidx.compose.material.icons.rounded.LocationOn
 import androidx.compose.material.icons.rounded.MailOutline
 import androidx.compose.material.icons.rounded.Menu
-import androidx.compose.material.icons.rounded.PhonelinkErase
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.Star
 import androidx.compose.material3.BottomAppBar
@@ -29,6 +29,7 @@ import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
@@ -38,6 +39,10 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -222,29 +227,20 @@ fun HomeTopAppBar(
             }
         },
         actions = {
-            IconButton(
-                onClick = {
-                    notAvailableToast()
-                    //onNavigate(Screens.Sleeping.route)
+            var serviceRunning by remember { mutableStateOf(true) }
+            IconToggleButton(
+                checked = serviceRunning,
+                enabled = true,
+                onCheckedChange = { state ->
+                    serviceRunning = state
+                    (context as MainActivity).toggleServiceState(state)
                 },
             ) {
-                Icon(
-                    Icons.Rounded.PhonelinkErase,
-                    contentDescription = "Enable Battery Saver Mode",
-                    tint = Color.White
-                )
-            }
-
-            IconButton(
-                onClick = {
-                    (context as MainActivity).stopServiceAndExit()
-                },
-            ) {
-                Icon(
-                    Icons.AutoMirrored.Outlined.ExitToApp,
-                    contentDescription = "Exit application",
-                    tint = Color.White
-                )
+                if (serviceRunning) {
+                    Icon(Icons.Rounded.LocationOn, contentDescription = "Service running")
+                } else {
+                    Icon(Icons.Rounded.LocationOff, contentDescription = "Service stopped")
+                }
             }
         }
     )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -224,6 +224,7 @@ class SoundscapeService : Service() {
      * Can be called from inside or outside the service.
      */
     fun stopForegroundService() {
+        destroyBeacon()
         stopSelf()
     }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/HomeViewModel.kt
@@ -199,7 +199,19 @@ class HomeViewModel @Inject constructor(@ApplicationContext context: Context, pr
             soundscapeServiceConnection.serviceBoundState.collect {
                 Log.d(TAG, "serviceBoundState $it")
                 if(it) {
+                    // The service has started, so start monitoring the location and heading
                     startMonitoringLocation()
+                }
+                else {
+                    // The service has gone away so remove the current location marker
+                    if(currentLocationMarker != null) {
+                        mapLibreMap?.removeMarker(currentLocationMarker!!)
+                        currentLocationMarker = null
+                    }
+                    // Reset map view variables so that the map re-centers when the service comes back
+                    initialLocation = null
+                    mapCentered = false
+
                 }
             }
         }


### PR DESCRIPTION
The iOS app had a 'sleep' button in the top right and this change moves towards that model. Clicking on the button toggles the running of the foreground service. When the service isn't running, there's no location/heading update and no text to speech. The icon showing the current location on the map is removed, and then when the service is restarted it reappears and the map is recentered.

Not sure what iOS does in this case, need to compare.