### PR TITLE
Remove double service start

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -111,17 +111,13 @@ class MainActivity : AppCompatActivity() {
             Log.i("Injection", "HTTP response cache installation failed:$e")
         }
 
-        Log.d(TAG, "Do we ever get here to check permissions?")
         checkAndRequestNotificationPermissions()
-        Log.d(TAG, "Do we try to bind to Soundscape service?")
         soundscapeServiceConnection.tryToBindToServiceIfRunning()
         setContent {
             SoundscapeTheme {
                 Home()
             }
         }
-
-        checkAndRequestNotificationPermissions()
     }
 
     /**


### PR DESCRIPTION
A stray checkAndRequestNotificationPermissions was left in that resulted in the Soundscape service being started twice. That didn't have too much impact except when running teleport where it resulted in the orientation listener being registered twice. Removing the call resolves the issue.