### PR TITLE
Add the ability to clear the text to speech queued audio

### DIFF
--- a/app/src/main/cpp/AudioBeaconBuffer.h
+++ b/app/src/main/cpp/AudioBeaconBuffer.h
@@ -80,6 +80,7 @@ namespace soundscape {
     private:
         int m_TtsSocket;
         int m_ReadsWithoutData = 0;
+        int m_SourceSocketForDebug;
     };
 
 }

--- a/app/src/main/cpp/AudioEngine.h
+++ b/app/src/main/cpp/AudioEngine.h
@@ -34,6 +34,8 @@ namespace soundscape {
             longitude = m_LastPos.x;
         }
 
+        void ClearQueue();
+
     private:
         FMOD::System * m_pSystem;
         FMOD_VECTOR m_LastPos = {0.0f, 0.0f, 0.0f};

--- a/app/src/main/java/org/scottishtecharmy/soundscape/audio/AudioEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/audio/AudioEngine.kt
@@ -7,6 +7,7 @@ interface AudioEngine {
     fun createBeacon(latitude: Double, longitude: Double) : Long
     fun destroyBeacon(beaconHandle : Long)
     fun createTextToSpeech(latitude: Double, longitude: Double, text: String) : Long
+    fun clearTextToSpeechQueue()
     fun updateGeometry(listenerLatitude: Double, listenerLongitude: Double, listenerHeading: Double)
     fun setBeaconType(beaconType: String)
     fun getListOfBeaconTypes() : Array<String>

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -455,6 +455,8 @@ class SoundscapeService : Service() {
         configuration.setLocale(configLocale)
         val localizedContext = applicationContext.createConfigurationContext(configuration)
 
+        audioEngine.clearTextToSpeechQueue()
+
         if (locationProvider.getCurrentLatitude() == null || locationProvider.getCurrentLongitude() == null) {
             // Should be null but let's check
             //Log.d(TAG, "Airplane mode On and GPS off. Current location: ${locationProvider.getCurrentLatitude()} , ${locationProvider.getCurrentLongitude()}")
@@ -562,6 +564,8 @@ class SoundscapeService : Service() {
         val configuration = Configuration(applicationContext.resources.configuration)
         configuration.setLocale(configLocale)
         val localizedContext = applicationContext.createConfigurationContext(configuration)
+
+        audioEngine.clearTextToSpeechQueue()
 
         // super categories are "information", "object", "place", "landmark", "mobility", "safety"
         val sharedPrefs = PreferenceManager.getDefaultSharedPreferences(applicationContext)
@@ -742,6 +746,7 @@ class SoundscapeService : Service() {
         configuration.setLocale(configLocale)
         val localizedContext = applicationContext.createConfigurationContext(configuration)
 
+        audioEngine.clearTextToSpeechQueue()
         if (locationProvider.getCurrentLatitude() == null || locationProvider.getCurrentLongitude() == null) {
             // Should be null but let's check
             //Log.d(TAG, "Airplane mode On and GPS off. Current location: ${locationProvider.getCurrentLatitude()} , ${locationProvider.getCurrentLongitude()}")


### PR DESCRIPTION
For the service/app this just means that there's now an `AudioEngine` function which can be called named `clearTextToSpeechQueue()`. I've added calls to that at the start of `aheadOfMe`, `myLocation` and `whatsAroundMe` and those now interrupt each other correctly.