### PR TITLE
Add clearing of speech queue to stop text when leaving Hearing screen

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Hearing.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/Hearing.kt
@@ -156,6 +156,7 @@ fun Hearing(onNavigate: (String) -> Unit, useView : Boolean) {
                         OnboardButton(
                             text = stringResource(R.string.ui_continue),
                             onClick = {
+                                viewModel?.silenceSpeech()
                                 onNavigate(OnboardingScreens.AudioBeacons.route)
                             },
                             modifier = Modifier.fillMaxWidth()

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/HearingViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/HearingViewModel.kt
@@ -14,7 +14,12 @@ class HearingViewModel @Inject constructor(private val audioEngine : NativeAudio
         //  queued text to speech. That resulted in the Listen button only working one time.
         //  Calling updateGeometry (which in the service is called every 30ms) sorts this out.
         //  We should consider another way of doing this.
+        audioEngine.clearTextToSpeechQueue()
         audioEngine.updateGeometry(0.0, 0.0,0.0)
         audioEngine.createTextToSpeech(0.0,0.0, speechText)
+    }
+
+    fun silenceSpeech() {
+        audioEngine.clearTextToSpeechQueue()
     }
 }


### PR DESCRIPTION
Now that we can clear the speech queue, call it in the Hearing screen before it exits and before it plays audio. This means that the Listen button can now be hit multiple times to immediately hear the speech.