### PR TITLE
Add dokka support for auto-generation of code documentation

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -34,6 +34,21 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu' # See 'Supported distributions' for available options
+          java-version: '17'
+
+      - name: Dokka build
+        run: |
+          ./gradlew dokkaHtml
+          mkdir ./docs/dokka
+          cp -rf app/build/dokka/html/* ./docs/dokka 
+
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     id("com.google.firebase.crashlytics")
     alias(libs.plugins.screenshot)
     id("com.google.protobuf")
+    id("org.jetbrains.dokka")
 }
 
 android {
@@ -231,4 +232,8 @@ dependencies {
     // Library for preferences in compose
     implementation(libs.composepreferencelibrary)
     implementation(libs.androidx.preference.ktx)
+
+    // Dokka plugin
+    dokkaPlugin(libs.html.mermaid.dokka.plugin)
+
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,5 @@ plugins {
     id("com.google.gms.google-services") version "4.4.2" apply false
     id("com.google.firebase.crashlytics") version "3.0.2" apply false
     id("com.google.protobuf") version "0.9.4" apply false
+    id("org.jetbrains.dokka") version "1.9.20" apply false
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,3 +28,4 @@ See the document [here](mapping.md) for information about how we configure and u
 ## Code documentation
 * [App architecture](architecture.md) is an introduction to the app structure and its UI.
 * [Audio API](audio-API.md) describes the interface with the audio engine for beacon and text to speech play out.
+* [Dokka generated docs](dokka/index.html) contains docs auto-generated from comments in the code.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 accompanistPermissions = "0.33.2-alpha"
 androidGpxParser = "2.3.1"
 composePreferenceLibrary = "1.1.1"
+htmlMermaidDokkaPlugin = "0.6.0"
 mapLibre = "11.0.0"
 androidxJunit = "1.2.1"
 converterScalars = "2.9.0"
@@ -65,6 +66,7 @@ firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "fir
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltAndroid" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hiltCompiler" }
+html-mermaid-dokka-plugin = { module = "com.glureau:html-mermaid-dokka-plugin", version.ref = "htmlMermaidDokkaPlugin" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }


### PR DESCRIPTION
This enables dokka markdown generation and includes the output in our GitHub pages site. I've included the mermaid plugin which means that mermaid can be included in comments in the code. Dokka is generated from code containing Kdoc syntax comments, see

  https://kotlinlang.org/docs/kotlin-doc.html#kdoc-syntax