### PR TITLE
Initial Route import and playback

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,14 @@
             </intent-filter>
 
             <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="content"/>
+                <data android:mimeType="application/octet-stream" />
+            </intent-filter>
+
+            <intent-filter>
                 <!-- geo intents to set a beacon -->
                 <data android:scheme="geo" />
                 <action android:name="android.intent.action.VIEW"/>

--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -131,6 +131,9 @@ class MainActivity : AppCompatActivity() {
                     if(intent != null) {
                         soundscapeIntents.parse(intent, this@MainActivity)
                     }
+
+                    // Pick the current route
+                    setupCurrentRoute()
                 }
             }
         }
@@ -240,6 +243,10 @@ class MainActivity : AppCompatActivity() {
             startSoundscapeService()
             soundscapeServiceConnection.tryToBindToServiceIfRunning()
         }
+    }
+
+    fun setupCurrentRoute() {
+        soundscapeServiceConnection.soundscapeService?.setupCurrentRoute()
     }
 
     /**

--- a/app/src/main/java/org/scottishtecharmy/soundscape/database/local/RealmConfiguration.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/database/local/RealmConfiguration.kt
@@ -1,19 +1,64 @@
 package org.scottishtecharmy.soundscape.database.local
 
+import android.util.Log
 import org.scottishtecharmy.soundscape.database.local.model.TileData
 import io.realm.kotlin.Realm
+import io.realm.kotlin.Realm.Companion.deleteRealm
 import io.realm.kotlin.RealmConfiguration
+import org.scottishtecharmy.soundscape.database.local.model.Location
+import org.scottishtecharmy.soundscape.database.local.model.RouteData
+import org.scottishtecharmy.soundscape.database.local.model.RoutePoint
 
 object RealmConfiguration {
-    private var realm: Realm? = null
+    private var tileDataRealm: Realm? = null
+    private var markersRealm: Realm? = null
 
-    fun getInstance(): Realm {
+    fun getTileDataInstance(): Realm {
         // has this object been created or opened yet?
-        if (realm == null || realm!!.isClosed()) {
+        if (tileDataRealm == null || tileDataRealm!!.isClosed()) {
             // create the realm db based on the TileData model/schema
-            val config = RealmConfiguration.create(setOf(TileData::class))
-            realm = Realm.open(config)
+            val config = RealmConfiguration.Builder(
+                schema = setOf(TileData::class)
+            ).name("TileData").build()
+            tileDataRealm = Realm.open(config)
         }
-        return realm!!
+        return tileDataRealm!!
+    }
+
+    /**
+     * getMarkersInstance opens the Realm database which stores the markers and routes.
+     * @param startAfresh if true results in the database being deleted and re-created.
+     *
+     * The database is current created inMemory so that it only exists when Soundscape is opened
+     * with a GPX file. If it's opened in any other way then the database will be empty.
+     */
+    fun getMarkersInstance(startAfresh: Boolean = false): Realm {
+
+        Log.d("RealmConfiguration", "getMarkersInstance: $markersRealm, $startAfresh")
+        if(startAfresh && (markersRealm != null) && !markersRealm!!.isClosed()) {
+            // The database is open, but we want to start afresh, so close it
+            Log.d("RealmConfiguration", "Close the database so that we can re-open it")
+            markersRealm?.close()
+        }
+
+        if (markersRealm == null || markersRealm!!.isClosed()) {
+            val config = RealmConfiguration.Builder(
+                schema = setOf(
+                    RouteData::class,
+                    RoutePoint::class,
+                    Location::class
+                )
+            ).name("MarkersAndRoutes").inMemory().build()
+
+            // TODO: Once we are happy with the format of the database, this option should be removed
+            if(startAfresh) {
+                // Delete the realm so that we start a brand new database
+                Log.d("RealmConfiguration", "Delete Markers database")
+                deleteRealm(config)
+            }
+            markersRealm = Realm.open(config)
+        }
+
+        return markersRealm!!
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/database/local/dao/RoutesDao.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/database/local/dao/RoutesDao.kt
@@ -35,6 +35,10 @@ class RoutesDao(private val realm: Realm) {
         return realm.query<RouteData>("name == $0", name).find()
     }
 
+    fun getRoutes(): List<RouteData> {
+        return realm.query<RouteData>().find()
+    }
+
     fun getWaypoints(): List<RoutePoint> {
         return realm.query<RoutePoint>().find()
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/database/repository/RoutesRepository.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/database/repository/RoutesRepository.kt
@@ -16,6 +16,10 @@ class RoutesRepository(private val routesDao: RoutesDao) {
         routesDao.getRoute(name)
     }
 
+    suspend fun getRoutes() = withContext(Dispatchers.IO){
+        routesDao.getRoutes()
+    }
+
     suspend fun deleteRoute(name: String) = withContext(Dispatchers.IO) {
         routesDao.deleteRoute(name)
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/RoutePlayer.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/RoutePlayer.kt
@@ -1,0 +1,113 @@
+package org.scottishtecharmy.soundscape.services
+
+import android.util.Log
+import io.realm.kotlin.ext.copyFromRealm
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.scottishtecharmy.soundscape.database.local.RealmConfiguration
+import org.scottishtecharmy.soundscape.database.local.dao.RoutesDao
+import org.scottishtecharmy.soundscape.database.local.model.RouteData
+import org.scottishtecharmy.soundscape.database.repository.RoutesRepository
+import org.scottishtecharmy.soundscape.utils.distance
+
+class RoutePlayer(val service: SoundscapeService) {
+    private var currentRouteData: RouteData? = null
+    private var currentMarker = -1
+    private val coroutineScope = CoroutineScope(Job())
+
+    fun setupCurrentRoute() {
+        val realm = RealmConfiguration.getMarkersInstance()
+        val routesDao = RoutesDao(realm)
+        val routesRepository = RoutesRepository(routesDao)
+
+        Log.e(TAG, "setupCurrentRoute")
+        coroutineScope.launch {
+            val dbRoutes = routesRepository.getRoutes()
+            if(dbRoutes.isNotEmpty()) {
+                currentRouteData = dbRoutes[0].copyFromRealm()
+            }
+            currentMarker = 0
+            play()
+            Log.d(TAG, toString())
+        }
+
+        coroutineScope.launch {
+            // Observe location updates from the service
+            service.locationProvider.locationFlow.collectLatest { value ->
+                if (value != null) {
+                    currentRouteData?.let { route ->
+                        if(currentMarker < route.waypoints.size) {
+                            val location = route.waypoints[currentMarker].location!!
+                            if(distance(location.latitude, location.longitude, value.latitude, value.longitude) < 10) {
+                                // We're within 10m of the marker, move on to the next one
+                                moveToNext()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun createBeaconAtWaypoint(index: Int) {
+        currentRouteData?.let {route ->
+            assert(index < route.waypoints.size)
+            val location = route.waypoints[index].location!!
+
+            service.audioEngine.clearTextToSpeechQueue()
+            service.audioEngine.createTextToSpeech(location.latitude, location.longitude, "Move to marker ${index+1}, ${route.waypoints[index].name}")
+
+            service.createBeacon(location.latitude, location.longitude)
+}
+    }
+
+    fun play() {
+        createBeaconAtWaypoint(currentMarker)
+        Log.d(TAG, toString())
+    }
+
+    private fun moveToNext() {
+        currentRouteData?.let {route ->
+            if((currentMarker + 1) < route.waypoints.size) {
+                currentMarker++
+
+                createBeaconAtWaypoint(currentMarker)
+            }
+        }
+        Log.d(TAG, toString())
+    }
+
+    fun moveToPrevious() {
+        if(currentMarker > 0) {
+            currentMarker--
+            createBeaconAtWaypoint(currentMarker)
+        }
+        Log.d(TAG, toString())
+    }
+
+    override fun toString(): String {
+        currentRouteData?.let { route ->
+            var state = ""
+            state += "Route : ${route.name}\n"
+            for((index, waypoint) in route.waypoints.withIndex()) {
+                state += "  ${waypoint.name} at ${waypoint.location?.latitude},${waypoint.location?.longitude}"
+                state += if(index == currentMarker) {
+                    " <current>\n"
+                } else {
+                    "\n"
+                }
+            }
+
+            return state
+        }
+        return "No current route set."
+    }
+
+
+    companion object {
+        private const val TAG = "RoutePlayer"
+    }
+}


### PR DESCRIPTION
This is for some very initial testing and development work. If the user selects "Open with Soundscape" on a GPX file from the Android File app then the GPX will be parsed and an inMemory (temporary) database will be created. There's then a new RoutePlayer class which is created to playback the first route that can be found in that database. There's some speech describing when the marker changes and the map reflects the location of the current beacon (marker in the Route).

If the app is launched in any other way, it will work as before with no route available or played back.