### PR TITLE
Teleporting changes to aid Geo development

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
@@ -36,19 +36,13 @@ class SoundscapeServiceConnection @Inject constructor(@ApplicationContext contex
     fun getBeaconFlow(): StateFlow<LngLatAlt?>? {
         return soundscapeService?.beaconFlow
     }
+    fun getStreetPreviewModeFlow(): StateFlow<Boolean>? {
+        return soundscapeService?.streetPreviewFlow
+    }
 
-    fun setStreetPreviewMode(on : Boolean, latitude: Double, longitude: Double) {
-
-        soundscapeService?.let { service ->
-
-            _serviceBoundState.value = false
-            service.setStreetPreviewMode(
-                true,
-                latitude.toDouble(),
-                longitude.toDouble()
-            )
-            _serviceBoundState.value = true
-        }
+    fun setStreetPreviewMode(on : Boolean, latitude: Double = 0.0, longitude: Double = 0.0) {
+        Log.d(TAG, "setStreetPreviewMode $on")
+        soundscapeService?.setStreetPreviewMode(on, latitude, longitude)
     }
 
     // needed to communicate with the service.

--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
@@ -37,6 +37,20 @@ class SoundscapeServiceConnection @Inject constructor(@ApplicationContext contex
         return soundscapeService?.beaconFlow
     }
 
+    fun setStreetPreviewMode(on : Boolean, latitude: Double, longitude: Double) {
+
+        soundscapeService?.let { service ->
+
+            _serviceBoundState.value = false
+            service.setStreetPreviewMode(
+                true,
+                latitude.toDouble(),
+                longitude.toDouble()
+            )
+            _serviceBoundState.value = true
+        }
+    }
+
     // needed to communicate with the service.
     private val connection = object : ServiceConnection {
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
@@ -39,6 +39,7 @@ fun HomeScreen(
     val location = viewModel.location.collectAsStateWithLifecycle()
     val heading = viewModel.heading.collectAsStateWithLifecycle()
     val beaconLocation = viewModel.beaconLocation.collectAsStateWithLifecycle()
+    val streetPreviewMode = viewModel.streetPreviewMode.collectAsStateWithLifecycle()
 
     NavHost(
         navController = navController,
@@ -66,6 +67,7 @@ fun HomeScreen(
                 getWhatsAroundMe = { viewModel.whatsAroundMe() },
                 shareLocation = { viewModel.shareLocation(context) },
                 rateSoundscape = rateSoundscape,
+                streetPreviewEnabled = streetPreviewMode.value
             )
         }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.LocationOff
 import androidx.compose.material.icons.rounded.LocationOn
 import androidx.compose.material.icons.rounded.Menu
+import androidx.compose.material.icons.rounded.Preview
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -56,6 +57,7 @@ fun HomePreview() {
         getWhatsAroundMe = {},
         shareLocation = {},
         rateSoundscape = {},
+        streetPreviewEnabled = false
     )
 }
 
@@ -73,6 +75,7 @@ fun Home(
     getWhatsAheadOfMe: () -> Unit,
     shareLocation: () -> Unit,
     rateSoundscape: () -> Unit,
+    streetPreviewEnabled : Boolean,
     modifier: Modifier = Modifier,
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -96,6 +99,7 @@ fun Home(
                 HomeTopAppBar(
                     drawerState,
                     coroutineScope,
+                    streetPreviewEnabled
                 )
             },
             bottomBar = {
@@ -137,6 +141,7 @@ fun Home(
 fun HomeTopAppBar(
     drawerState: DrawerState,
     coroutineScope: CoroutineScope,
+    streetPreviewEnabled : Boolean
 ) {
     val context = LocalContext.current
     TopAppBar(
@@ -161,6 +166,21 @@ fun HomeTopAppBar(
         },
         actions = {
             var serviceRunning by remember { mutableStateOf(true) }
+            IconToggleButton(
+                checked = streetPreviewEnabled,
+                enabled = true,
+                onCheckedChange = { state ->
+                    if(!state) {
+                        (context as MainActivity).soundscapeServiceConnection.setStreetPreviewMode(
+                            false
+                        )
+                    }
+                },
+            ) {
+                if (streetPreviewEnabled) {
+                    Icon(Icons.Rounded.Preview, contentDescription = "Street Preview enabled")
+                }
+            }
             IconToggleButton(
                 checked = serviceRunning,
                 enabled = true,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
@@ -47,6 +47,9 @@ fun LocationDetailsScreen(
         locationDescription = locationDescription,
         createBeacon = { latitude, longitude ->
             viewModel.createBeacon(latitude, longitude)
+        },
+        enableStreetPreview = { latitude, longitude ->
+            viewModel.enableStreetPreview(latitude, longitude)
         }
     )
 }
@@ -56,6 +59,7 @@ fun LocationDetails(
                     locationDescription : LocationDescription,
                     onNavigateUp: () -> Unit,
                     createBeacon: (latitude: Double, longitude: Double) -> Unit,
+                    enableStreetPreview: (latitude: Double, longitude: Double) -> Unit,
                     modifier: Modifier = Modifier) {
     Column(
         modifier = modifier
@@ -89,6 +93,18 @@ fun LocationDetails(
                 modifier = Modifier.fillMaxWidth(),
             )
         }
+        Button(
+            onClick = {
+                enableStreetPreview(locationDescription.latitude, locationDescription.longitude)
+                onNavigateUp()
+            }
+        ) {
+            Text(
+                text = "Enter Street Preview",
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
    }
 }
 
@@ -99,6 +115,8 @@ fun LocationDetailsPreview() {
         LocationDetails(
             LocationDescription("", 0.0, 0.0),
             createBeacon = { latitude, longitude ->
+            },
+            enableStreetPreview = { latitude, longitude ->
             },
             onNavigateUp = {}
         )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -106,6 +106,10 @@ class SoundscapeService : Service() {
     private val _beaconFlow = MutableStateFlow<LngLatAlt?>(null)
     var beaconFlow: StateFlow<LngLatAlt?> = _beaconFlow
 
+    // Flow to return street preview mode
+    private val _streetPreviewFlow = MutableStateFlow(false)
+    var streetPreviewFlow: StateFlow<Boolean> = _streetPreviewFlow
+
     // OkhttpClientInstance
     private lateinit var okhttpClientInstance: OkhttpClientInstance
 
@@ -139,7 +143,9 @@ class SoundscapeService : Service() {
             // Switch back to phone's location and direction
             locationProvider = AndroidLocationProvider(this)
             directionProvider = AndroidDirectionProvider(this)
+            directionProvider.start(audioEngine, locationProvider)
         }
+        _streetPreviewFlow.value = on
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
@@ -19,6 +19,11 @@ class LocationDetailsViewModel @Inject constructor(
         soundscapeServiceConnection.soundscapeService?.createBeacon(latitude, longitude)
     }
 
+    fun enableStreetPreview(latitude: Double, longitude: Double) {
+        soundscapeServiceConnection.setStreetPreviewMode(true, latitude, longitude)
+
+    }
+
     init {
         serviceConnection = soundscapeServiceConnection
         viewModelScope.launch {


### PR DESCRIPTION
The long term aim is to implement Street Preview mode #147, but in the meantime it's very useful to be able to teleport to a location to test the speech callouts. There are two way to do this:

1. Via `soundscape:` URIs e.g.[`soundscape:55.9517303,-3.2005471`](soundscape:55.9517303,-3.2005471). These open the app in StreetPreview mode at the location provided. This can be provided via Android Studio with Launch Flags e.g. `-d geo:55.8546671,-4.2372673`
![image](https://github.com/user-attachments/assets/10061d6c-4da6-461e-8fb5-c7c7db0b9c73)

2. Clicking the Street Preview button on the LocationDetails screen. That screen can be entered via `geo:` URIs, or sharing a location with Soundscape from Google Maps.

To exit StreetPreview and return to using the device actual location there's a small icon in the top right to click on. When not in StreetPreview mode it is blank.

This UI is 'temporary' until we have StreetPreview implemented.
