### PR TITLE
Don't reparse Intent on screen rotation

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -129,7 +129,11 @@ class MainActivity : AppCompatActivity() {
                 if (it) {
                     // The service has started, so parse the Intent
                     if(intent != null) {
-                        soundscapeIntents.parse(intent, this@MainActivity)
+                        if (intent.action != "") {
+                            soundscapeIntents.parse(intent, this@MainActivity)
+                            // Clear the action so that it doesn't happen on every screen rotate etc.
+                            intent.action = ""
+                        }
                     }
 
                     // Pick the current route
@@ -143,8 +147,10 @@ class MainActivity : AppCompatActivity() {
                 val navController = rememberNavController()
                 val destination by navigator.destination.collectAsState()
                 LaunchedEffect(destination) {
-                    if (navController.currentDestination?.route != destination) {
-                        navController.navigate(destination)
+                    if(destination != "") {
+                        if (navController.currentDestination?.route != destination) {
+                            navController.navigate(destination)
+                        }
                     }
                 }
                 HomeScreen(

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
@@ -6,12 +6,14 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import org.scottishtecharmy.soundscape.SoundscapeServiceConnection
+import org.scottishtecharmy.soundscape.screens.home.Navigator
+import org.scottishtecharmy.soundscape.screens.home.locationDetails.generateLocationDetailsRoute
 import javax.inject.Inject
 
 @HiltViewModel
 class LocationDetailsViewModel @Inject constructor(
-    private val soundscapeServiceConnection : SoundscapeServiceConnection
-): ViewModel() {
+    private val soundscapeServiceConnection : SoundscapeServiceConnection,
+    private val navigator : Navigator): ViewModel() {
 
     private var serviceConnection : SoundscapeServiceConnection? = null
 
@@ -25,6 +27,7 @@ class LocationDetailsViewModel @Inject constructor(
     }
 
     init {
+        navigator.navigate("")
         serviceConnection = soundscapeServiceConnection
         viewModelScope.launch {
             soundscapeServiceConnection.serviceBoundState.collect {


### PR DESCRIPTION
The Intent that launches the app should only be parsed and handled on entry to the app, and not whenever the screen is rotated.