### PR TITLE
Initial proof of concept for using Photon search API

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -174,6 +174,7 @@ dependencies {
 
     // Retrofit with Scalar Converter
     implementation(libs.converter.scalars)
+    implementation(libs.converter.moshi)
 
     // Location permissions
     implementation(libs.accompanist.permissions)

--- a/app/src/androidTest/java/org/scottishtecharmy/soundscape/PhotonSearchTest.kt
+++ b/app/src/androidTest/java/org/scottishtecharmy/soundscape/PhotonSearchTest.kt
@@ -1,0 +1,46 @@
+package org.scottishtecharmy.soundscape
+
+import android.util.Log
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.scottishtecharmy.soundscape.network.PhotonSearchProvider
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
+
+@RunWith(AndroidJUnit4::class)
+class PhotonSearchTest {
+
+   @Test
+   fun testSearch() {
+       runBlocking {
+           withContext(Dispatchers.IO) {
+
+               val apiInterface = PhotonSearchProvider.getInstance()
+               val call = apiInterface.getSearchResults("Tarland")
+               val response = call.execute()
+               if (call.isExecuted) {
+                   Log.d("PhotonSearchTest", "Successfully got results:")
+                   response.body()?.let { result ->
+                       for (feature in result.features) {
+                           feature.properties?.let { properties ->
+                               if((properties["name"] != null) &&
+                                   (feature.geometry.type == "Point")) {
+
+                                   val location = feature.geometry as Point
+                                   Log.d(
+                                       "PhotonSearchTest",
+                                       "Name: " + properties["name"] +
+                                               " at " + location.coordinates.toString()
+                                   )
+                               }
+                           }
+                       }
+                   }
+               }
+           }
+       }
+   }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geojsonparser/geojson/LngLatAlt.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geojsonparser/geojson/LngLatAlt.kt
@@ -29,4 +29,8 @@ open class LngLatAlt(
         result = 31 * result + (altitude?.hashCode() ?: 0)
         return result
     }
+
+    override fun toString(): String {
+        return "$latitude,$longitude"
+    }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/network/SearchProvider.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/network/SearchProvider.kt
@@ -1,0 +1,47 @@
+package org.scottishtecharmy.soundscape.network
+
+import com.squareup.moshi.Moshi
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
+import retrofit2.Call
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+const val BASE_URL = "https://photon.komoot.io/"
+
+/**
+ * This is a proof of concept for using the photon search engine https://github.com/komoot/photon
+ * In testing it returned by far the best search results and can be run on a relatively modest
+ * server. This is using the demo server at https://photon.komoot.io/
+ *  @param q is the search string to use. Photon supports partial string searches and so this can
+ *  be as little as 3 characters long.
+ *  @param latitude
+ *  @param longitude If these are passed in, then results are prioritized based on that location.
+ *  @param limit is the number of results to return.
+ */
+interface PhotonSearchProvider {
+    @GET("api/")
+    fun getSearchResults(@Query("q") searchString : String,
+                         @Query("lat") latitude : Double? = null,
+                         @Query("lon") longitude : Double? = null,
+                         @Query("limit") limit : UInt = 5U
+                         ): Call<FeatureCollection>
+
+    companion object {
+        private var searchProvider: PhotonSearchProvider? = null
+        private var moshi: Moshi? = null
+        fun getInstance(): PhotonSearchProvider {
+            if (searchProvider == null) {
+                moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
+                searchProvider = Retrofit.Builder()
+                    .baseUrl(BASE_URL)
+                    .addConverterFactory(MoshiConverterFactory.create(moshi!!))
+                    .build().create(PhotonSearchProvider::class.java)
+            }
+            return searchProvider!!
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@
 accompanistPermissions = "0.33.2-alpha"
 androidGpxParser = "2.3.1"
 composePreferenceLibrary = "1.1.1"
+converterMoshi = "2.11.0"
 htmlMermaidDokkaPlugin = "0.6.0"
 mapLibre = "11.5.0"
 mapLibreAnnotation = "3.0.1"
@@ -61,6 +62,7 @@ androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "preferenceKtx" }
 androidx-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
+converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "converterMoshi" }
 converter-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "converterScalars" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }


### PR DESCRIPTION
This commit adds a PhotonSearchProvider which can be used to retrieve search results from a komoot photon server. The test shows a simple use case for it. The retrofit API uses Moshi to parse the JSON inline via the MoshiConverterFactory.