### PR TITLE
Fix memory leak when stopping Soundscape service

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -243,8 +243,7 @@ class MainActivity : AppCompatActivity() {
     fun toggleServiceState(newServiceState: Boolean) {
 
         if(!newServiceState) {
-            soundscapeServiceConnection.soundscapeService?.stopForegroundService()
-            soundscapeServiceConnection.soundscapeService = null
+            soundscapeServiceConnection.stopService(applicationContext)
         }
         else {
             startSoundscapeService()

--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+import org.scottishtecharmy.soundscape.services.SoundscapeBinder
 import org.scottishtecharmy.soundscape.services.SoundscapeService
 import javax.inject.Inject
 
@@ -48,16 +49,16 @@ class SoundscapeServiceConnection @Inject constructor() {
             // we've bound to ExampleLocationForegroundService, cast the IBinder and get ExampleLocationForegroundService instance.
             Log.d(TAG, "onServiceConnected")
 
-            val binder = service as SoundscapeService.LocalBinder
-            soundscapeService = binder.getService()
+            val binder = service as SoundscapeBinder
+            soundscapeService = binder.getSoundscapeService()
             _serviceBoundState.value = true
         }
 
         override fun onServiceDisconnected(arg0: ComponentName) {
             // This is called when the connection with the service has been disconnected. Clean up.
-            Log.e(TAG, "onServiceDisconnected")
-
+            Log.d(TAG, "onServiceDisconnected")
             _serviceBoundState.value = false
+            soundscapeService = null
         }
     }
 
@@ -69,6 +70,11 @@ class SoundscapeServiceConnection @Inject constructor() {
                 context.bindService(intent, connection, 0)
             }
         }
+    }
+
+    fun stopService(context : Context) {
+        Log.d(TAG, "stopService")
+        soundscapeService?.stopForegroundService()
     }
 
     companion object {


### PR DESCRIPTION
Leak Canary found a memory leak in the LocalBinder class within the Soundscape service. The implementation was straight from the Android docs, but I guess it's not so common to disconnect from a service when the app isn't shutting down too?
The main fix is to move the LocalBinder class out and add to it a reset() function which removes the reference to the SoundscapeService. When the service is destroyed it calls reset() on the binder and then the garbage collection can continue unhindered.