### PR TITLE
Nightly build Robo test was limited to 5 minutes, bump it up

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -203,4 +203,4 @@ jobs:
         run: gcloud firebase test android run --type instrumentation --use-orchestrator --app app-debug.apk --test app-debug-androidTest.apk --device model=shiba,version=34,locale=en,orientation=portrait
 
       - name: Run Robo test in Firebase Test Lab
-        run: gcloud firebase test android run --type robo --app=app-debug.apk --timeout=300s --device model=shiba,version=34,locale=en,orientation=portrait
+        run: gcloud firebase test android run --type robo --app=app-debug.apk --timeout=1800s --device model=shiba,version=34,locale=en,orientation=portrait


### PR DESCRIPTION
Now that the Robo test is running for the full length of the timeout bump the duration up to 30 seconds.