### PR TITLE
Update settings with some more audio control and refactor

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -92,8 +92,7 @@ class MainActivity : AppCompatActivity() {
             Log.d(TAG, "Preference: " + pref.key + " = " + pref.value)
         }
 
-        val sharedPrefs = PreferenceManager.getDefaultSharedPreferences(this)
-        val isFirstLaunch = sharedPrefs.getBoolean(FIRST_LAUNCH_KEY, true)
+        val isFirstLaunch = sharedPreferences.getBoolean(FIRST_LAUNCH_KEY, true)
 
         Log.d(TAG, "isFirstLaunch: $isFirstLaunch")
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -280,6 +279,10 @@ class MainActivity : AppCompatActivity() {
         const val UNNAMED_ROADS_KEY = "UnnamedRoads"
         const val BEACON_TYPE_DEFAULT = "Classic"
         const val BEACON_TYPE_KEY = "BeaconType"
+        const val VOICE_TYPE_DEFAULT = "Default"
+        const val VOICE_TYPE_KEY = "VoiceType"
+        const val SPEECH_RATE_DEFAULT = 1.0f
+        const val SPEECH_RATE_KEY = "SpeechRate"
 
         const val FIRST_LAUNCH_KEY = "FirstLaunch"
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
@@ -20,6 +20,7 @@ import org.scottishtecharmy.soundscape.screens.markers_routes.navigation.Screens
 import org.scottishtecharmy.soundscape.screens.markers_routes.screens.MarkersAndRoutesScreen
 import org.scottishtecharmy.soundscape.screens.markers_routes.screens.addroute.AddRouteScreen
 import org.scottishtecharmy.soundscape.viewmodels.HomeViewModel
+import org.scottishtecharmy.soundscape.viewmodels.SettingsViewModel
 
 class Navigator {
     var destination = MutableStateFlow(HomeRoutes.Home.route)
@@ -75,9 +76,11 @@ fun HomeScreen(
         // Settings screen
         composable(HomeRoutes.Settings.route) {
             // Always just pop back out of settings, don't add to the queue
+            val settingsViewModel : SettingsViewModel = hiltViewModel()
+            val uiState = settingsViewModel.state.collectAsStateWithLifecycle()
             Settings(
                 onNavigateUp = { navController.navigateUp() },
-                null
+                uiState = uiState.value
             )
         }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
@@ -1,32 +1,20 @@
 package org.scottishtecharmy.soundscape.screens.home.settings
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.rounded.ArrowBack
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.listPreference
+import me.zhanghai.compose.preference.sliderPreference
 import me.zhanghai.compose.preference.switchPreference
 import org.scottishtecharmy.soundscape.MainActivity
 import org.scottishtecharmy.soundscape.R
-import org.scottishtecharmy.soundscape.screens.onboarding.MockHearingPreviewData
+import org.scottishtecharmy.soundscape.screens.markers_routes.components.CustomAppBar
 import org.scottishtecharmy.soundscape.viewmodels.SettingsViewModel
 
 // This code uses the library https://github.com/zhanghai/ComposePreference
@@ -37,108 +25,99 @@ import org.scottishtecharmy.soundscape.viewmodels.SettingsViewModel
 @Preview
 @Composable
 fun SettingsPreview() {
-    Settings({}, MockHearingPreviewData)
+    Settings({}, SettingsViewModel.SettingsUiState())
 }
 
+
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun Settings(
     onNavigateUp: () -> Unit,
-    mockData : MockHearingPreviewData? // TODO set SettingsViewModel in param of SettingsScreen, and create SettingContent
-) {
+    uiState : SettingsViewModel.SettingsUiState)
+{
+    ProvidePreferenceLocals {
+        LazyColumn {
 
-    var viewModel : SettingsViewModel? = null
-    if(mockData == null)
-        viewModel = hiltViewModel<SettingsViewModel>()
+            stickyHeader {
+                Surface {
+                    CustomAppBar(stringResource(R.string.general_alert_settings),
+                        onNavigateUp = onNavigateUp,
+                        navigationButtonTitle = "Back"
+                    )
+                }
+            }
 
-    var beacons : List<String> = emptyList()
-    if(viewModel == null) {
-        // Preview operation
-        if(mockData != null)
-            beacons = mockData.names
-    }
-    else {
-        val uiState: SettingsViewModel.SettingsUiState by viewModel.state.collectAsStateWithLifecycle()
-        beacons = uiState.beaconTypes
-    }
-
-    Column(
-        modifier = Modifier
-            .fillMaxHeight(),
-    ) {
-        IconButton(
-            onClick = {
-                onNavigateUp()
-            },
-        ) {
-            Icon(
-                Icons.AutoMirrored.Rounded.ArrowBack,
-                modifier = Modifier
-                    .size(32.dp)
-                    .padding(start = 4.dp),
-                contentDescription = stringResource(R.string.ui_menu_close),
-                tint = Color.White
+            // TODO : Add strings translations and use them
+            item {
+                Text(
+                    text = stringResource(R.string.menu_manage_callouts),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                )
+            }
+            switchPreference(
+                key = MainActivity.ALLOW_CALLOUTS_KEY,
+                defaultValue = MainActivity.ALLOW_CALLOUTS_DEFAULT,
+                title = { Text(text = stringResource(R.string.callouts_allow_callouts)) },
+                summary = {
+                    Text(
+                        text = if (it) stringResource(R.string.callouts_callouts_on) else stringResource(
+                            R.string.callouts_callouts_off
+                        ),
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
             )
-        }
+            switchPreference(
+                key = MainActivity.PLACES_AND_LANDMARKS_KEY,
+                defaultValue = MainActivity.PLACES_AND_LANDMARKS_DEFAULT,
+                title = { Text(text = stringResource(R.string.callouts_places_and_landmarks)) },
+            )
+            switchPreference(
+                key = MainActivity.MOBILITY_KEY,
+                defaultValue = MainActivity.MOBILITY_DEFAULT,
+                title = { Text(text = stringResource(R.string.callouts_mobility)) },
+            )
+            switchPreference(
+                key = MainActivity.DISTANCE_TO_BEACON_KEY,
+                defaultValue = MainActivity.DISTANCE_TO_BEACON_DEFAULT,
+                title = { Text(text = stringResource(R.string.callouts_audio_beacon)) },
+            )
+            switchPreference(
+                key = MainActivity.UNNAMED_ROADS_KEY,
+                defaultValue = MainActivity.UNNAMED_ROADS_DEFAULT,
+                title = { Text(text = stringResource(R.string.preview_include_unnamed_roads_title)) },
+            )
 
-        Text(
-            text = stringResource(R.string.menu_manage_callouts),
-            textAlign = TextAlign.Left,
-            color = Color.White,
-            modifier = Modifier.fillMaxWidth()
-        )
-        ProvidePreferenceLocals {
-            LazyColumn {
-
-                // TODO : Add strings translations and use them
-
-                switchPreference(
-                    key = MainActivity.ALLOW_CALLOUTS_KEY,
-                    defaultValue = MainActivity.ALLOW_CALLOUTS_DEFAULT,
-                    title = { Text(text = stringResource(R.string.callouts_allow_callouts)) },
-                    summary = { Text(text = if (it) stringResource(R.string.callouts_callouts_on) else stringResource(R.string.callouts_callouts_off)) }
-                )
-                switchPreference(
-                    key = MainActivity.PLACES_AND_LANDMARKS_KEY,
-                    defaultValue = MainActivity.PLACES_AND_LANDMARKS_DEFAULT,
-                    title = { Text(text = stringResource(R.string.callouts_places_and_landmarks)) },
-                    summary = { Text(text = if (it) "On" else "Off") }
-                )
-                switchPreference(
-                    key = MainActivity.MOBILITY_KEY,
-                    defaultValue = MainActivity.MOBILITY_DEFAULT,
-                    title = { Text(text = stringResource(R.string.callouts_mobility)) },
-                    summary = { Text(text = if (it) "On" else "Off") }
-                )
-                switchPreference(
-                    key = MainActivity.DISTANCE_TO_BEACON_KEY,
-                    defaultValue = MainActivity.DISTANCE_TO_BEACON_DEFAULT,
-                    title = { Text(text = stringResource(R.string.callouts_audio_beacon)) },
-                    summary = { Text(text = if (it) "On" else "Off") }
-                )
-                switchPreference(
-                    key = MainActivity.UNNAMED_ROADS_KEY,
-                    defaultValue = MainActivity.UNNAMED_ROADS_DEFAULT,
-                    title = { Text(text = stringResource(R.string.preview_include_unnamed_roads_title)) },
-                    summary = { Text(text = if (it) "On" else "Off") }
+            item {
+                Text(
+                    text = "Manage Audio Engine",
+                    color = MaterialTheme.colorScheme.onPrimary,
                 )
             }
-        }
-        Text(
-            text = "MANAGE BEACONS",
-            textAlign = TextAlign.Left,
-            color = Color.White,
-            modifier = Modifier.fillMaxWidth()
-        )
-        ProvidePreferenceLocals {
-            LazyColumn {
-                listPreference(
-                    key = MainActivity.BEACON_TYPE_KEY,
-                    defaultValue = MainActivity.BEACON_TYPE_DEFAULT,
-                    values = beacons,
-                    title = { Text(text = "Beacon type") },
-                    summary = { Text(text = it) },
-                )
-            }
+            listPreference(
+                key = MainActivity.BEACON_TYPE_KEY,
+                defaultValue = MainActivity.BEACON_TYPE_DEFAULT,
+                values = uiState.beaconTypes,
+                title = { Text(text = "Beacon type") },
+                summary = { Text(text = it, color = MaterialTheme.colorScheme.onPrimary) },
+            )
+
+            listPreference(
+                key = MainActivity.VOICE_TYPE_KEY,
+                defaultValue = MainActivity.VOICE_TYPE_DEFAULT,
+                values = uiState.voiceTypes,
+                title = { Text(text = "Voice type") },
+                summary = { Text(text = it, color = MaterialTheme.colorScheme.onPrimary) },
+            )
+
+            sliderPreference(
+                key = MainActivity.SPEECH_RATE_KEY,
+                defaultValue = MainActivity.SPEECH_RATE_DEFAULT,
+                title = { Text(text = "Speech rate") },
+                valueRange = 0.5f..2.0f,
+                valueSteps = 10,
+                valueText = { Text(text = "%.1fx".format(it), color = MaterialTheme.colorScheme.onPrimary) },
+            )
         }
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -188,14 +188,6 @@ class SoundscapeService : MediaSessionService() {
             // Initialize the audio engine
             audioEngine.initialize(applicationContext)
 
-            val sharedPreferences =
-                PreferenceManager.getDefaultSharedPreferences(applicationContext)
-            val beaconType = sharedPreferences.getString(
-                MainActivity.BEACON_TYPE_KEY,
-                MainActivity.BEACON_TYPE_DEFAULT
-            )
-            audioEngine.setBeaconType(beaconType!!)
-
             locationProvider = AndroidLocationProvider(this)
             directionProvider = AndroidDirectionProvider(this)
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/SettingsViewModel.kt
@@ -1,12 +1,14 @@
 package org.scottishtecharmy.soundscape.viewmodels
 
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
 import javax.inject.Inject
 
@@ -15,14 +17,40 @@ class SettingsViewModel @Inject constructor(private val audioEngine : NativeAudi
 
     data class SettingsUiState(
         // Data for the ViewMode that affects the UI
-        var beaconTypes : List<String> = emptyList()
+        var beaconTypes : List<String> = emptyList(),
+        var voiceTypes : List<String> = emptyList()
     )
-    val state: StateFlow<SettingsUiState> = flow {
-        val audioEngineBeaconTypes = audioEngine.getListOfBeaconTypes()
-        val beaconTypes = mutableListOf<String>()
-        for (type in audioEngineBeaconTypes) {
-            beaconTypes.add(type)
+
+    private val _state: MutableStateFlow<SettingsUiState> = MutableStateFlow(SettingsUiState())
+    val state: StateFlow<SettingsUiState> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            audioEngine.textToSpeechRunning.collectLatest { initialized ->
+                if (initialized) {
+                    // Only once the TextToSpeech engine is initialized can we populate the
+                    // members of these lists.
+                    val audioEngineVoiceTypes = audioEngine.getAvailableSpeechVoices()
+                    val voiceTypes = mutableListOf<String>()
+
+                    val locale = AppCompatDelegate.getApplicationLocales()[0]
+                    for (type in audioEngineVoiceTypes) {
+                        if(!type.isNetworkConnectionRequired &&
+                            !type.features.contains("notInstalled") &&
+                            type.locale.language == locale!!.language) {
+                            // The Voice don't contain any description, just a text string
+                            voiceTypes.add(type.name)
+                        }
+                    }
+
+                    val audioEngineBeaconTypes = audioEngine.getListOfBeaconTypes()
+                    val beaconTypes = mutableListOf<String>()
+                    for (type in audioEngineBeaconTypes) {
+                        beaconTypes.add(type)
+                    }
+                    _state.value = SettingsUiState(beaconTypes = beaconTypes, voiceTypes = voiceTypes)
+                }
+            }
         }
-        emit(SettingsUiState(beaconTypes = beaconTypes))
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SettingsUiState())
+    }
 }


### PR DESCRIPTION
The main aim of this change was to add a list of supported TextToSpeech voices and control of the rate of the speech. To do this, the Settings screen needed some work:

 1. It didn't scroll when there were too many settings to fit on screen
 2. It didn't deal with the delay in the TextToSpeech engine initialization

The change fixes both of these. The second is done with a flow from the audio engine to indicate when the TextToSpeech engine has been configured. When that's received the Settings screen will recompose with the updated values.

The main issue with the voice names is that their poor! There doesn't seem to be any way to get a description of the Voice from the API, so we're left with their names which are ugly to read. There are various online threads which suggest just mapping these to made up names - or Voice 1/2 etc. but that's not been done yet.

The second issue is that as with all of the other settings, the service has to be restarted to use any changes in value.