### PR TITLE
Update application locale when language is selected

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/language/LanguageScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/language/LanguageScreen.kt
@@ -41,7 +41,7 @@ fun LanguageScreen(
         onNavigate = onNavigate,
         supportedLanguages = uiState.supportedLanguages,
         onLanguageSelected = { selectedLanguage ->
-            viewModel.updateSpeechLanguage(selectedLanguage)
+            viewModel.updateLanguage(selectedLanguage)
         },
         selectedLanguageIndex = uiState.selectedLanguageIndex,
         modifier = modifier

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/language/LanguageViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/language/LanguageViewModel.kt
@@ -1,5 +1,7 @@
 package org.scottishtecharmy.soundscape.screens.onboarding.language
 
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -55,9 +57,11 @@ class LanguageViewModel @Inject constructor(private val audioEngine : NativeAudi
         return allLanguages
     }
 
-    fun updateSpeechLanguage(selectedLanguage: Language): Boolean {
+    fun updateLanguage(selectedLanguage: Language): Boolean {
         val indexOfSelectedLanguage = _state.value.supportedLanguages.indexOf(selectedLanguage)
         _state.value = _state.value.copy(selectedLanguageIndex = indexOfSelectedLanguage)
+
+        AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(selectedLanguage.code))
         return audioEngine.setSpeechLanguage(selectedLanguage.code)
     }
 }


### PR DESCRIPTION
Without this change the UI stays in English during onboarding, though the language for the speech engine is updated. This does result in the black UI flash returning when a new language is selected, but perhaps that's unavoidable?