### PR TITLE
Update audio engine immediately if any settings change

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/audio/AudioEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/audio/AudioEngine.kt
@@ -1,5 +1,6 @@
 package org.scottishtecharmy.soundscape.audio
 
+import android.content.SharedPreferences
 import android.speech.tts.Voice
 import java.util.Locale
 
@@ -14,4 +15,6 @@ interface AudioEngine {
     fun getAvailableSpeechLanguages() : Set<Locale>
     fun getAvailableSpeechVoices() : Set<Voice>
     fun setSpeechLanguage(language : String) : Boolean
+    fun updateSpeech(sharedPreferences: SharedPreferences): Boolean
+    fun updateBeaconType(sharedPreferences: SharedPreferences): Boolean
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/audio/NativeAudioEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/audio/NativeAudioEngine.kt
@@ -1,6 +1,8 @@
 package org.scottishtecharmy.soundscape.audio
 
 import android.content.Context
+import android.content.SharedPreferences
+import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
 import android.os.ParcelFileDescriptor
@@ -13,6 +15,7 @@ import androidx.preference.PreferenceManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.scottishtecharmy.soundscape.MainActivity
+import org.scottishtecharmy.soundscape.R
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -30,6 +33,7 @@ class NativeAudioEngine @Inject constructor(): AudioEngine, TextToSpeech.OnInitL
     private lateinit var ttsSocket : ParcelFileDescriptor
     private var textToSpeechVoiceType = MainActivity.VOICE_TYPE_DEFAULT
     private var textToSpeechRate = MainActivity.SPEECH_RATE_DEFAULT
+    private var beaconType = MainActivity.BEACON_TYPE_DEFAULT
 
     private external fun create() : Long
     private external fun destroy(engineHandle: Long)
@@ -47,6 +51,7 @@ class NativeAudioEngine @Inject constructor(): AudioEngine, TextToSpeech.OnInitL
 
     fun destroy()
     {
+        sharedPreferences?.unregisterOnSharedPreferenceChangeListener(sharedPreferencesListener)
         synchronized(engineMutex)
         {
             if (engineHandle == 0L) {
@@ -66,23 +71,42 @@ class NativeAudioEngine @Inject constructor(): AudioEngine, TextToSpeech.OnInitL
             org.fmod.FMOD.close()
         }
     }
-    fun initialize(context : Context)
-    {
 
-        val sharedPreferences =
-            PreferenceManager.getDefaultSharedPreferences(context)
-        val beaconType = sharedPreferences.getString(
-            MainActivity.BEACON_TYPE_KEY,
-            MainActivity.BEACON_TYPE_DEFAULT
-        )
-        textToSpeechVoiceType = sharedPreferences.getString(
-            MainActivity.VOICE_TYPE_KEY,
-            MainActivity.VOICE_TYPE_DEFAULT
-        )!!
-        textToSpeechRate = sharedPreferences.getFloat(
-            MainActivity.SPEECH_RATE_KEY,
-            MainActivity.SPEECH_RATE_DEFAULT
-        )
+    private var sharedPreferences : SharedPreferences? = null
+    private lateinit var sharedPreferencesListener : SharedPreferences.OnSharedPreferenceChangeListener
+
+    fun initialize(context : Context, followPreferences : Boolean = true)
+    {
+        if(followPreferences) {
+            val configLocale = AppCompatDelegate.getApplicationLocales()[0]
+            val configuration = Configuration(context.resources.configuration)
+            configuration.setLocale(configLocale)
+            val localizedContext = context.createConfigurationContext(configuration)
+
+            // Listen for changes to shared preference settings so that we can update the audio engine
+            // configuration.
+            sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+            sharedPreferencesListener =
+                SharedPreferences.OnSharedPreferenceChangeListener { preferences, key ->
+                    if (sharedPreferences == preferences) {
+                        if ((key == MainActivity.VOICE_TYPE_KEY) ||
+                            (key == MainActivity.SPEECH_RATE_KEY)
+                        ) {
+                            if (updateSpeech(preferences)) {
+                                // If the voice type preference changes play some test speech
+                                clearTextToSpeechQueue()
+                                val testString =
+                                    localizedContext.getString(R.string.first_launch_callouts_example_3)
+                                createTextToSpeech(testString)
+                            }
+                        }
+                        if (key == MainActivity.BEACON_TYPE_KEY) {
+                            updateBeaconType(preferences)
+                        }
+                    }
+                }
+            sharedPreferences?.registerOnSharedPreferenceChangeListener(sharedPreferencesListener)
+        }
 
         synchronized(engineMutex) {
             if (engineHandle != 0L) {
@@ -91,7 +115,9 @@ class NativeAudioEngine @Inject constructor(): AudioEngine, TextToSpeech.OnInitL
             org.fmod.FMOD.init(context)
             engineHandle = this.create()
             textToSpeech = TextToSpeech(context, this)
-            setBeaconType(beaconType!!)
+            sharedPreferences?.let {
+                updateBeaconType(it)
+            }
         }
     }
 
@@ -114,11 +140,9 @@ class NativeAudioEngine @Inject constructor(): AudioEngine, TextToSpeech.OnInitL
             val languageCode = AppCompatDelegate.getApplicationLocales().toLanguageTags()
             setSpeechLanguage(languageCode)
 
-            for(voice in textToSpeech.voices) {
-                if(voice.name == textToSpeechVoiceType)
-                    textToSpeech.voice = voice
+            sharedPreferences?.let {
+                updateSpeech(it)
             }
-            textToSpeech.setSpeechRate(textToSpeechRate)
             textToSpeech.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
 
                 override fun onDone(utteranceId: String) {
@@ -258,6 +282,50 @@ class NativeAudioEngine @Inject constructor(): AudioEngine, TextToSpeech.OnInitL
         if (!textToSpeechInitialized)
             return emptySet()
         return textToSpeech.voices
+    }
+
+    override fun updateBeaconType(sharedPreferences: SharedPreferences): Boolean {
+        val newBeaconType = sharedPreferences.getString(
+            MainActivity.BEACON_TYPE_KEY,
+            MainActivity.BEACON_TYPE_DEFAULT
+        )!!
+        if(newBeaconType != beaconType) {
+            setBeaconType(newBeaconType)
+            Log.d(TAG, "Beacon changed from $beaconType to $newBeaconType on $this")
+            beaconType = newBeaconType
+            return true
+        }
+        return false
+    }
+
+    override fun updateSpeech(sharedPreferences: SharedPreferences): Boolean {
+
+        var change = false
+
+        // Check for change in voice type preference
+        val voiceType = sharedPreferences.getString(MainActivity.VOICE_TYPE_KEY, MainActivity.VOICE_TYPE_DEFAULT)!!
+        for (voice in textToSpeech.voices) {
+            if (voice.name == voiceType) {
+                if(textToSpeechVoiceType != voice.name) {
+                    textToSpeech.voice = voice
+                    Log.d(TAG, "Voice changed from $textToSpeechVoiceType to ${voice.name} on $this")
+                    textToSpeechVoiceType = voice.name
+                    change = true
+                }
+                break
+            }
+        }
+
+        // Check for change in rate preference
+        val rate = sharedPreferences.getFloat(MainActivity.SPEECH_RATE_KEY, MainActivity.SPEECH_RATE_DEFAULT)
+        if (rate != textToSpeechRate) {
+            textToSpeech.setSpeechRate(rate)
+            Log.d(TAG, "Speech rate changed from $textToSpeechRate to $rate on $this")
+            textToSpeechRate = rate
+            change = change.or(true)
+        }
+
+        return change
     }
 
     override fun setSpeechLanguage(language : String) : Boolean {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/di/HiltModule.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/di/HiltModule.kt
@@ -17,7 +17,7 @@ class AppNativeAudioEngine {
     @Singleton
     fun provideNativeAudioEngine(@ApplicationContext context: Context): NativeAudioEngine {
         val audioEngine = NativeAudioEngine()
-        audioEngine.initialize(context)
+        audioEngine.initialize(context, false)
         return audioEngine
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/SettingsViewModel.kt
@@ -1,20 +1,23 @@
 package org.scottishtecharmy.soundscape.viewmodels
 
+import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
+import org.scottishtecharmy.soundscape.SoundscapeServiceConnection
 import javax.inject.Inject
 
 @HiltViewModel
-class SettingsViewModel @Inject constructor(private val audioEngine : NativeAudioEngine): ViewModel() {
-
+class SettingsViewModel @Inject constructor(
+    private val soundscapeServiceConnection: SoundscapeServiceConnection
+) : ViewModel() {
     data class SettingsUiState(
         // Data for the ViewMode that affects the UI
         var beaconTypes : List<String> = emptyList(),
@@ -26,31 +29,53 @@ class SettingsViewModel @Inject constructor(private val audioEngine : NativeAudi
 
     init {
         viewModelScope.launch {
-            audioEngine.textToSpeechRunning.collectLatest { initialized ->
-                if (initialized) {
-                    // Only once the TextToSpeech engine is initialized can we populate the
-                    // members of these lists.
-                    val audioEngineVoiceTypes = audioEngine.getAvailableSpeechVoices()
-                    val voiceTypes = mutableListOf<String>()
+            // Connect to the service and use its audio engine to get configuration and to
+            // demonstrate settings changes.
+            soundscapeServiceConnection.serviceBoundState.collect {
+                Log.d(TAG, "serviceBoundState $it")
+                val job = Job()
+                if (it) {
+                    val audioEngine = soundscapeServiceConnection.soundscapeService?.audioEngine!!
+                    viewModelScope.launch(job) {
+                        audioEngine.textToSpeechRunning.collectLatest { initialized ->
+                            if (initialized) {
+                                // Only once the TextToSpeech engine is initialized can we populate the
+                                // members of these lists.
+                                val audioEngineVoiceTypes = audioEngine.getAvailableSpeechVoices()
+                                val voiceTypes = mutableListOf<String>()
 
-                    val locale = AppCompatDelegate.getApplicationLocales()[0]
-                    for (type in audioEngineVoiceTypes) {
-                        if(!type.isNetworkConnectionRequired &&
-                            !type.features.contains("notInstalled") &&
-                            type.locale.language == locale!!.language) {
-                            // The Voice don't contain any description, just a text string
-                            voiceTypes.add(type.name)
+                                val locale = AppCompatDelegate.getApplicationLocales()[0]
+                                for (type in audioEngineVoiceTypes) {
+                                    if (!type.isNetworkConnectionRequired &&
+                                        !type.features.contains("notInstalled") &&
+                                        type.locale.language == locale!!.language
+                                    ) {
+                                        // The Voice don't contain any description, just a text string
+                                        voiceTypes.add(type.name)
+                                    }
+                                }
+
+                                val audioEngineBeaconTypes = audioEngine.getListOfBeaconTypes()
+                                val beaconTypes = mutableListOf<String>()
+                                for (type in audioEngineBeaconTypes) {
+                                    beaconTypes.add(type)
+                                }
+                                _state.value = SettingsUiState(
+                                    beaconTypes = beaconTypes,
+                                    voiceTypes = voiceTypes
+                                )
+                            }
                         }
                     }
-
-                    val audioEngineBeaconTypes = audioEngine.getListOfBeaconTypes()
-                    val beaconTypes = mutableListOf<String>()
-                    for (type in audioEngineBeaconTypes) {
-                        beaconTypes.add(type)
-                    }
-                    _state.value = SettingsUiState(beaconTypes = beaconTypes, voiceTypes = voiceTypes)
+                }
+                else
+                {
+                    job.cancel()
                 }
             }
         }
+    }
+    companion object {
+        private const val TAG = "SettingsViewModel"
     }
 }


### PR DESCRIPTION
The main aim of this change is to update the audio engine whenever any of the audio settings are changed. This is done by listening to changes on the SharedPreferences from within the NativeAudioEngine. As well as updating the audio engine, changes to the speech settings also trigger some speech so that it's easy to fiddle with settings and hear their results. This behaviour is disabled for AudioEngine created by Hilt injection as those are running during onboarding when not all of the preferences have been configured.

Another complication is that prior to this change the SettingsViewModel was creating its own audio engine just to get the possible configuration options. This has been changed so that now it connects to the Soundscape service and uses its audio engine.