### PR TITLE
If no TTS voices are found allow mis-matched locales

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/SettingsViewModel.kt
@@ -54,6 +54,20 @@ class SettingsViewModel @Inject constructor(
                                         voiceTypes.add(type.name)
                                     }
                                 }
+                                if(voiceTypes.isEmpty()) {
+                                    // I found that with some alternate Text to Speech engines
+                                    // installed (e.g. Vocalizer TTS) the locale language doesn't
+                                    // always match. If we found no voices, try again without checking
+                                    // the language.
+                                    for (type in audioEngineVoiceTypes) {
+                                        if (!type.isNetworkConnectionRequired &&
+                                            !type.features.contains("notInstalled")
+                                        ) {
+                                            // The Voice don't contain any description, just a text string
+                                            voiceTypes.add(type.name)
+                                        }
+                                    }
+                                }
 
                                 val audioEngineBeaconTypes = audioEngine.getListOfBeaconTypes()
                                 val beaconTypes = mutableListOf<String>()


### PR DESCRIPTION
I installed the Vocalizer TTS app which gives me access to a much wider range of voices. They sound better than Google, are well named, and seem to do a better job with Street vs. Saint abbreviations. However, the locale for the voice I chose was "eng" rather than than the "en" which was in our locale and so the voice was ignored. If no voices are found when checking the list from the TTS engine this change means that it's re-checked this time without matching on the locale language.