### PR TITLE
Use system Locale when an application Locale isn't set

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/audio/NativeAudioEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/audio/NativeAudioEngine.kt
@@ -10,12 +10,12 @@ import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
 import android.speech.tts.Voice
 import android.util.Log
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.PreferenceManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.scottishtecharmy.soundscape.MainActivity
 import org.scottishtecharmy.soundscape.R
+import org.scottishtecharmy.soundscape.utils.getCurrentLocale
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -79,7 +79,7 @@ class NativeAudioEngine @Inject constructor(): AudioEngine, TextToSpeech.OnInitL
     fun initialize(context : Context, followPreferences : Boolean = true)
     {
         if(followPreferences) {
-            val configLocale = AppCompatDelegate.getApplicationLocales()[0]
+            val configLocale = getCurrentLocale()
             val configuration = Configuration(context.resources.configuration)
             configuration.setLocale(configLocale)
             val localizedContext = context.createConfigurationContext(configuration)
@@ -138,7 +138,7 @@ class NativeAudioEngine @Inject constructor(): AudioEngine, TextToSpeech.OnInitL
             Log.d(TAG, "Android version " + Build.VERSION.SDK_INT)
 
             // Get the current locale and initialize the text to speech engine with it
-            val languageCode = AppCompatDelegate.getApplicationLocales().toLanguageTags()
+            val languageCode = getCurrentLocale().toLanguageTag()
             setSpeechLanguage(languageCode)
 
             sharedPreferences?.let {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.content.res.Configuration
 import android.util.Log
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.PreferenceManager
 import com.squareup.moshi.Moshi
 import io.realm.kotlin.Realm
@@ -43,6 +42,7 @@ import org.scottishtecharmy.soundscape.utils.distanceToPolygon
 import org.scottishtecharmy.soundscape.utils.get3x3TileGrid
 import org.scottishtecharmy.soundscape.utils.getCompassLabelFacingDirection
 import org.scottishtecharmy.soundscape.utils.getCompassLabelFacingDirectionAlong
+import org.scottishtecharmy.soundscape.utils.getCurrentLocale
 import org.scottishtecharmy.soundscape.utils.getFovIntersectionFeatureCollection
 import org.scottishtecharmy.soundscape.utils.getFovRoadsFeatureCollection
 import org.scottishtecharmy.soundscape.utils.getIntersectionRoadNames
@@ -95,7 +95,7 @@ class GeoEngine {
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(application.applicationContext)
 
         tileClient = TileClient(application)
-        configLocale = AppCompatDelegate.getApplicationLocales()[0]!!
+        configLocale = getCurrentLocale()
         configuration = Configuration(application.applicationContext.resources.configuration)
         configuration.setLocale(configLocale)
         localizedContext = application.applicationContext.createConfigurationContext(configuration)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/language/LanguageScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/language/LanguageScreen.kt
@@ -108,6 +108,7 @@ fun LanguageComposable(
                     selectedLanguageIndex != -1
                 }
             }
+
             Column(modifier = Modifier.padding(horizontal = 50.dp)) {
                 OnboardButton(
                     text = stringResource(R.string.ui_continue),

--- a/app/src/main/java/org/scottishtecharmy/soundscape/utils/Locale.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/utils/Locale.kt
@@ -1,0 +1,12 @@
+package org.scottishtecharmy.soundscape.utils
+
+import androidx.appcompat.app.AppCompatDelegate
+import java.util.Locale
+
+/**
+ * Return the application locale if there is one, otherwise return the default system one
+ */
+fun getCurrentLocale() : Locale {
+    val appLocale = AppCompatDelegate.getApplicationLocales()[0]
+    return appLocale ?: Locale.getDefault()
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/SettingsViewModel.kt
@@ -1,7 +1,6 @@
 package org.scottishtecharmy.soundscape.viewmodels
 
 import android.util.Log
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -12,6 +11,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.scottishtecharmy.soundscape.SoundscapeServiceConnection
+import org.scottishtecharmy.soundscape.utils.getCurrentLocale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -44,11 +44,11 @@ class SettingsViewModel @Inject constructor(
                                 val audioEngineVoiceTypes = audioEngine.getAvailableSpeechVoices()
                                 val voiceTypes = mutableListOf<String>()
 
-                                val locale = AppCompatDelegate.getApplicationLocales()[0]
+                                val locale = getCurrentLocale()
                                 for (type in audioEngineVoiceTypes) {
                                     if (!type.isNetworkConnectionRequired &&
                                         !type.features.contains("notInstalled") &&
-                                        type.locale.language == locale!!.language
+                                        type.locale.language == locale.language
                                     ) {
                                         // The Voice don't contain any description, just a text string
                                         voiceTypes.add(type.name)


### PR DESCRIPTION
There were several places where it was assumed that there was a valid application Locale. This commit replaces those with a call to a utility function which returns the application Locale if it's valid or the default system one if it's not.