### PR TITLE
Add space after full stop to add speech engine

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/hearing/HearingScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/hearing/HearingScreen.kt
@@ -47,9 +47,9 @@ fun HearingScreen(
 ){
     val speechText = buildString {
         append(stringResource(R.string.first_launch_callouts_example_1))
-        append(".")
+        append(". ")
         append(stringResource(R.string.first_launch_callouts_example_3))
-        append(".")
+        append(". ")
         append(stringResource(R.string.first_launch_callouts_example_4))
     }
     Hearing(


### PR DESCRIPTION
See issue #201 for discussion on this. Some speech engines read out full stops as 'dot' if there's not a space following them. This avoids it in this one situation.