### PR TITLE
GeoEngine tile update cleanup

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -248,7 +248,7 @@ class MainActivity : AppCompatActivity() {
     fun toggleServiceState(newServiceState: Boolean) {
 
         if(!newServiceState) {
-            soundscapeServiceConnection.stopService(applicationContext)
+            soundscapeServiceConnection.stopService()
         }
         else {
             startSoundscapeService()
@@ -290,6 +290,8 @@ class MainActivity : AppCompatActivity() {
         const val VOICE_TYPE_KEY = "VoiceType"
         const val SPEECH_RATE_DEFAULT = 1.0f
         const val SPEECH_RATE_KEY = "SpeechRate"
+        const val MAP_DEBUG_DEFAULT = false
+        const val MAP_DEBUG_KEY = "MapDebug"
 
         const val FIRST_LAUNCH_KEY = "FirstLaunch"
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.services.SoundscapeBinder
 import org.scottishtecharmy.soundscape.services.SoundscapeService
+import org.scottishtecharmy.soundscape.utils.TileGrid
 import javax.inject.Inject
 
 @ActivityRetainedScoped
@@ -35,6 +36,9 @@ class SoundscapeServiceConnection @Inject constructor() {
     }
     fun getStreetPreviewModeFlow(): StateFlow<Boolean>? {
         return soundscapeService?.streetPreviewFlow
+    }
+    fun getTileGridFlow(): StateFlow<TileGrid>? {
+        return soundscapeService?.geoEngine?.tileGridFlow
     }
 
     fun setStreetPreviewMode(on : Boolean, latitude: Double = 0.0, longitude: Double = 0.0) {
@@ -72,7 +76,7 @@ class SoundscapeServiceConnection @Inject constructor() {
         }
     }
 
-    fun stopService(context : Context) {
+    fun stopService() {
         Log.d(TAG, "stopService")
         soundscapeService?.stopForegroundService()
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/dto/BoundingBox.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/dto/BoundingBox.kt
@@ -1,4 +1,8 @@
 package org.scottishtecharmy.soundscape.dto
+
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+import org.scottishtecharmy.soundscape.utils.isBetween
+
 /**
  * Bounding box usually follow the standard format of:
  *

--- a/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/LocationProvider.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/LocationProvider.kt
@@ -38,6 +38,12 @@ abstract class LocationProvider {
     fun getCurrentLongitude() : Double? {
         return mutableLocationFlow.value?.longitude
     }
+    fun get() : LngLatAlt? {
+        mutableLocationFlow.value?.let { location ->
+            return LngLatAlt(location.longitude, location.latitude)
+        }
+        return null
+    }
 
     // Flow to return Location objects
     val mutableLocationFlow = MutableStateFlow<Location?>(null)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
@@ -41,6 +41,7 @@ fun HomeScreen(
     val heading = viewModel.heading.collectAsStateWithLifecycle()
     val beaconLocation = viewModel.beaconLocation.collectAsStateWithLifecycle()
     val streetPreviewMode = viewModel.streetPreviewMode.collectAsStateWithLifecycle()
+    val tileGridGeoJson = viewModel.tileGridGeoJson.collectAsStateWithLifecycle()
 
     NavHost(
         navController = navController,
@@ -69,7 +70,8 @@ fun HomeScreen(
                 getWhatsAroundMe = { viewModel.whatsAroundMe() },
                 shareLocation = { viewModel.shareLocation(context) },
                 rateSoundscape = rateSoundscape,
-                streetPreviewEnabled = streetPreviewMode.value
+                streetPreviewEnabled = streetPreviewMode.value,
+                tileGridGeoJson = tileGridGeoJson.value
             )
         }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
@@ -57,7 +57,8 @@ fun HomePreview() {
         getWhatsAroundMe = {},
         shareLocation = {},
         rateSoundscape = {},
-        streetPreviewEnabled = false
+        streetPreviewEnabled = false,
+        tileGridGeoJson = ""
     )
 }
 
@@ -77,6 +78,7 @@ fun Home(
     rateSoundscape: () -> Unit,
     streetPreviewEnabled : Boolean,
     modifier: Modifier = Modifier,
+    tileGridGeoJson: String
 ) {
     val coroutineScope = rememberCoroutineScope()
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
@@ -131,6 +133,7 @@ fun Home(
                 },
                 onMapLongClick = onMapLongClick,
                 onMarkerClick = onMarkerClick,
+                tileGridGeoJson = tileGridGeoJson
             )
         }
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
@@ -26,7 +26,8 @@ fun HomeContent(
     onMapLongClick: (LatLng) -> Boolean,
     onMarkerClick: (Marker) -> Boolean,
     searchBar: @Composable () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    tileGridGeoJson: String
 ) {
     Column(
         modifier = modifier,
@@ -90,6 +91,7 @@ fun HomeContent(
                     userSymbolRotation = 0.0F,
                     onMapLongClick = onMapLongClick,
                     onMarkerClick = onMarkerClick,
+                    tileGridGeoJson = tileGridGeoJson
                 )
             }
         }
@@ -107,6 +109,7 @@ fun PreviewHomeContent(){
         onNavigate = {},
         onMapLongClick = { false },
         onMarkerClick = { true },
-        searchBar = {}
+        searchBar = {},
+        tileGridGeoJson = ""
     )
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
@@ -115,6 +115,7 @@ fun LocationDetails(
             mapViewRotation = 0.0F,
             userSymbolRotation = heading,
             modifier = modifier.fillMaxWidth().aspectRatio(1.0F),
+            tileGridGeoJson = ""
         )
 
         Button(

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
@@ -12,6 +12,7 @@ import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.listPreference
 import me.zhanghai.compose.preference.sliderPreference
 import me.zhanghai.compose.preference.switchPreference
+import org.scottishtecharmy.soundscape.BuildConfig
 import org.scottishtecharmy.soundscape.MainActivity
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.screens.markers_routes.components.CustomAppBar
@@ -118,6 +119,19 @@ fun Settings(
                 valueSteps = 10,
                 valueText = { Text(text = "%.1fx".format(it), color = MaterialTheme.colorScheme.onPrimary) },
             )
+            if(BuildConfig.DEBUG) {
+                item {
+                    Text(
+                        text = "Debug settings",
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                }
+                switchPreference(
+                    key = MainActivity.MAP_DEBUG_KEY,
+                    defaultValue = MainActivity.MAP_DEBUG_DEFAULT,
+                    title = { Text(text = "Map debug") },
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -66,7 +66,7 @@ class SoundscapeService : MediaSessionService() {
     private var audioBeacon: Long = 0
 
     // Geo engine
-    private var geoEngine = GeoEngine()
+    var geoEngine = GeoEngine()
 
     // Flow to return beacon location
     private val _beaconFlow = MutableStateFlow<LngLatAlt?>(null)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/utils/GeoUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/utils/GeoUtils.kt
@@ -191,7 +191,6 @@ fun pixelXYToLatLon(pixelX: Double, pixelY: Double, zoom: Int): Pair<Double, Dou
     val longitude = 360 * x
 
     return Pair(latitude, longitude)
-
 }
 
 /**
@@ -585,7 +584,7 @@ fun getReferenceCoordinate(path: LineString, targetDistance: Double, reverseLine
  * @return A bounding box object that contains coordinates for West/South/East/North edges
  * or min Lon / min Lat / max Lon / max Lat.
  */
-fun tileToBoundingBox(x: Int, y: Int, zoom: Double): BoundingBox {
+fun tileToBoundingBox(x: Int, y: Int, zoom: Int): BoundingBox {
     val boundingBox = BoundingBox()
     boundingBox.northLatitude = tileToLat(y, zoom)
     boundingBox.southLatitude = tileToLat(y + 1, zoom)
@@ -602,7 +601,7 @@ fun tileToBoundingBox(x: Int, y: Int, zoom: Double): BoundingBox {
  * Zoom level of the Slippy Tile
  * @return a latitude coordinate.
  */
-fun tileToLat(x: Int, zoom: Double): Double {
+fun tileToLat(x: Int, zoom: Int): Double {
     val n: Double = Math.PI - (2.0 * Math.PI * x) / 2.0.pow(zoom)
     return Math.toDegrees(atan(sinh(n)))
 }
@@ -615,7 +614,7 @@ fun tileToLat(x: Int, zoom: Double): Double {
  * Zoom level of the Slippy Tile.
  * @return a longitude coordinate.
  */
-fun tileToLon(y: Int, zoom: Double): Double {
+fun tileToLon(y: Int, zoom: Int): Double {
     return y / 2.0.pow(zoom) * 360.0 - 180
 }
 
@@ -1380,4 +1379,12 @@ fun isBetween(x1: Double, x2: Double, value: Double): Boolean {
     } else {
         value in x1..x2
     }
+}
+
+fun pointIsWithinBoundingBox(point: LngLatAlt?, box: BoundingBox) : Boolean {
+    if(point == null)
+        return true
+
+    return (isBetween(box.westLongitude, box.eastLongitude, point.longitude) &&
+            isBetween(box.southLatitude, box.northLatitude, point.latitude))
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/utils/TileGridUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/utils/TileGridUtils.kt
@@ -1,0 +1,213 @@
+package org.scottishtecharmy.soundscape.utils
+
+import org.scottishtecharmy.soundscape.dto.BoundingBox
+import org.scottishtecharmy.soundscape.dto.VectorTile
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.Polygon
+import org.scottishtecharmy.soundscape.geojsonparser.moshi.GeoJsonObjectMoshiAdapter
+
+class TileGrid(newTiles : MutableList<VectorTile>, newCentralBoundingBox : BoundingBox) {
+
+    val tiles : MutableList<VectorTile> = newTiles
+    var centralBoundingBox : BoundingBox = newCentralBoundingBox
+
+    /**
+     * Return GeoJSON that describes the tile grid and the central bounding box so that it can be
+     * rendered over our map for debug.
+     */
+    fun generateGeoJson() : String {
+        val featureCollection = FeatureCollection()
+
+        if(true) {
+            val feature = Feature()
+            // Add central bounding box
+            val coordinates = arrayListOf<LngLatAlt>()
+            coordinates.add(LngLatAlt(centralBoundingBox.westLongitude, centralBoundingBox.northLatitude))
+            coordinates.add(LngLatAlt(centralBoundingBox.eastLongitude, centralBoundingBox.northLatitude))
+            coordinates.add(LngLatAlt(centralBoundingBox.eastLongitude, centralBoundingBox.southLatitude))
+            coordinates.add(LngLatAlt(centralBoundingBox.westLongitude, centralBoundingBox.southLatitude))
+            coordinates.add(LngLatAlt(centralBoundingBox.westLongitude, centralBoundingBox.northLatitude))
+            feature.geometry = Polygon(coordinates)
+            feature.properties = hashMapOf()
+            featureCollection.addFeature(feature)
+        }
+
+        for(tile in tiles) {
+            val feature = Feature()
+            val box = tileToBoundingBox(tile.tileX, tile.tileY, tile.zoom)
+            val coordinates = arrayListOf<LngLatAlt>()
+            coordinates.add(LngLatAlt(box.westLongitude, box.northLatitude))
+            coordinates.add(LngLatAlt(box.eastLongitude, box.northLatitude))
+            coordinates.add(LngLatAlt(box.eastLongitude, box.southLatitude))
+            coordinates.add(LngLatAlt(box.westLongitude, box.southLatitude))
+            coordinates.add(LngLatAlt(box.westLongitude, box.northLatitude))
+            feature.geometry = Polygon(coordinates)
+            feature.properties = hashMapOf()
+            featureCollection.addFeature(feature)
+        }
+
+        val adapter = GeoJsonObjectMoshiAdapter()
+        return adapter.toJson(featureCollection).toString()
+    }
+
+    companion object {
+        /**
+         * The zoom level and grid size are constant. When using soundscape-backend these will be
+         * 16 and 3, but if we switch to using protobuf tiles they will be 15 and 2.
+         */
+        var ZOOM_LEVEL = 16
+        var GRID_SIZE = 3
+
+        /**
+         * Given a location it calculates the set of tiles (VectorTiles) that cover a
+         * 3 x 3 grid around the specified location.
+         * @param currentLatitude
+         * The current location of the device.
+         * @param currentLongitude
+         * The current location of the device.
+         * @return  A TileGrid describing the new grid
+         */
+        private fun get3x3TileGrid(
+            currentLatitude: Double = 0.0,
+            currentLongitude: Double = 0.0
+        ) : TileGrid {
+
+            // Get tile that contains current location
+            val tileXY = getXYTile(currentLatitude, currentLongitude, ZOOM_LEVEL)
+
+            // Center of grid is at the center of this tile
+            val centerX = (tileXY.first * 256) + 128
+            val centerY = (tileXY.second * 256) + 128
+            val southWest = pixelXYToLatLon((centerX - 192).toDouble(), (centerY + 192).toDouble(), ZOOM_LEVEL)
+            val northEast = pixelXYToLatLon((centerX + 192).toDouble(), (centerY - 192).toDouble(), ZOOM_LEVEL)
+            val centralBoundingBox = BoundingBox(southWest.second,
+                                                 southWest.first,
+                                                 northEast.second,
+                                                 northEast.first)
+
+            // And build 3x3 grid around it ensuring that we wrap at the edges
+            val maxCoordinate = mapSize(ZOOM_LEVEL) / 256
+            val xValues = IntArray(3)
+            xValues[0] = (tileXY.first - 1).mod(maxCoordinate)
+            xValues[1] = tileXY.first
+            xValues[2] = (tileXY.first + 1).mod(maxCoordinate)
+            val yValues = IntArray(3)
+            yValues[0] = (tileXY.second - 1).mod(maxCoordinate)
+            yValues[1] = tileXY.second
+            yValues[2] = (tileXY.second + 1).mod(maxCoordinate)
+
+            val tiles: MutableList<VectorTile> = mutableListOf()
+            for (y in yValues) {
+                for (x in xValues) {
+                    val surroundingTile = VectorTile("", x, y, ZOOM_LEVEL)
+                    surroundingTile.quadkey = getQuadKey(x, y, ZOOM_LEVEL)
+                    tiles.add(surroundingTile)
+                }
+            }
+            return TileGrid(tiles, centralBoundingBox)
+        }
+
+        /**
+         * Given a location it calculates the set of tiles (VectorTiles) that cover a
+         * 2 x 2 grid around the specified location.
+         * @param currentLatitude
+         * The current location of the device.
+         * @param currentLongitude
+         * The current location of the device.
+         * @return  A TileGrid describing the new grid
+         */
+        private fun get2x2TileGrid(
+            currentLatitude: Double = 0.0,
+            currentLongitude: Double = 0.0
+        ): TileGrid {
+
+            // Get tile that contains current location
+            val tileXY = getXYTile(currentLatitude, currentLongitude, ZOOM_LEVEL)
+            // Scale up the tile xy
+            val scaledTile = Pair(tileXY.first * 2, tileXY.second * 2)
+
+            // And the quadrant within that tile
+            val tileQuadrant = getXYTile(currentLatitude, currentLongitude, ZOOM_LEVEL + 1)
+
+            // The center of the grid is the corner of the tile that is shared with the quadrant that the
+            // location is within.
+            val maxCoordinate = mapSize(ZOOM_LEVEL) / 256
+            val xValues = IntArray(2)
+            val yValues = IntArray(2)
+            if (tileQuadrant.first == scaledTile.first) {
+                if (tileQuadrant.second == scaledTile.second) {
+                    // Top left quadrant as the coordinates match
+                    xValues[0] = (tileXY.first - 1).mod(maxCoordinate)
+                    xValues[1] = tileXY.first
+                    yValues[0] = (tileXY.second - 1).mod(maxCoordinate)
+                    yValues[1] = tileXY.second
+                } else {
+                    // Bottom left quadrant as the x coordinate matches
+                    xValues[0] = (tileXY.first - 1).mod(maxCoordinate)
+                    xValues[1] = tileXY.first
+                    yValues[0] = tileXY.second
+                    yValues[1] = (tileXY.second + 1).mod(maxCoordinate)
+                }
+            } else {
+                if (tileQuadrant.second == scaledTile.second) {
+                    // Top right quadrant as only the y coordinates match
+                    xValues[0] = tileXY.first
+                    xValues[1] = (tileXY.first + 1).mod(maxCoordinate)
+                    yValues[0] = (tileXY.second - 1).mod(maxCoordinate)
+                    yValues[1] = tileXY.second
+                } else {
+                    // Bottom right quadrant as neither coordinate matches
+                    xValues[0] = tileXY.first
+                    xValues[1] = (tileXY.first + 1).mod(maxCoordinate)
+                    yValues[0] = tileXY.second
+                    yValues[1] = (tileXY.second + 1).mod(maxCoordinate)
+                }
+            }
+
+            // Center of grid is the top left corner of the bottom right tile
+            val centerX = (xValues[1] * 256)
+            val centerY = (yValues[1] * 256)
+            val southWest = pixelXYToLatLon((centerX - 160).toDouble(), (centerY + 160).toDouble(), ZOOM_LEVEL)
+            val northEast = pixelXYToLatLon((centerX + 160).toDouble(), (centerY - 160).toDouble(), ZOOM_LEVEL)
+            val centralBoundingBox = BoundingBox(southWest.second,
+                southWest.first,
+                northEast.second,
+                northEast.first)
+
+            val tiles: MutableList<VectorTile> = mutableListOf()
+            for (y in yValues) {
+                for (x in xValues) {
+                    val surroundingTile = VectorTile("", x, y, ZOOM_LEVEL)
+                    surroundingTile.quadkey = getQuadKey(x, y, ZOOM_LEVEL)
+                    tiles.add(surroundingTile)
+                }
+            }
+            return TileGrid(tiles, centralBoundingBox)
+        }
+
+        /**
+         * Given a location and a grid size it creates either a 2x2 or a 3x3 grid of tiles
+         * (VectorTiles) to cover that location.
+         * @param currentLatitude
+         * The current location of the device.
+         * @param currentLongitude
+         * The current location of the device.
+         * @return  A TileGrid object which contains a MutableList of VectorTiles representing the
+         * grid along with a BoundingBox around the center of the grid. When the location leaves
+         * that BoundingBox a new grid is required.
+         */
+        fun getTileGrid(
+            currentLatitude: Double = 0.0,
+            currentLongitude: Double = 0.0
+        ): TileGrid {
+            when(GRID_SIZE) {
+                2 -> return get2x2TileGrid(currentLatitude, currentLongitude)
+                3 -> return get3x3TileGrid(currentLatitude, currentLongitude)
+            }
+            assert(false)
+            return TileGrid(mutableListOf(), BoundingBox())
+        }
+    }
+}

--- a/app/src/test/java/org/scottishtecharmy/soundscape/TileUtilsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/TileUtilsTest.kt
@@ -28,8 +28,8 @@ import org.scottishtecharmy.soundscape.utils.polygonContainsCoordinates
 import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
-import org.scottishtecharmy.soundscape.utils.distanceToPolygon
-import org.scottishtecharmy.soundscape.utils.get3x3TileGrid
+import org.scottishtecharmy.soundscape.utils.TileGrid.Companion.GRID_SIZE
+import org.scottishtecharmy.soundscape.utils.TileGrid.Companion.getTileGrid
 import org.scottishtecharmy.soundscape.utils.getDistanceToFeatureCollection
 import org.scottishtecharmy.soundscape.utils.getGpsFromNormalizedMapCoordinates
 import org.scottishtecharmy.soundscape.utils.getNormalizedFromGpsMapCoordinates
@@ -586,12 +586,28 @@ class TileUtilsTest {
 
     @Test
     fun get3x3TileGridTest(){
-        val testGet3x3TileGrid = get3x3TileGrid(65.0, 0.0)
-        Assert.assertEquals(9, testGet3x3TileGrid.size)
-        val testGet3x3TileGrid2 = get3x3TileGrid(-65.0, 0.0)
-        Assert.assertEquals(9, testGet3x3TileGrid2.size)
-        val testGet3x3TileGrid3 = get3x3TileGrid(0.0, 0.0)
-        Assert.assertEquals(9, testGet3x3TileGrid3.size)
+        var tileGrid = getTileGrid(65.0, 0.0)
+        Assert.assertEquals(GRID_SIZE*GRID_SIZE, tileGrid.tiles.size)
+        tileGrid = getTileGrid(-65.0, 0.0)
+        Assert.assertEquals(GRID_SIZE*GRID_SIZE, tileGrid.tiles.size)
+        tileGrid = getTileGrid(0.0, 0.0)
+        Assert.assertEquals(GRID_SIZE*GRID_SIZE, tileGrid.tiles.size)
+        tileGrid = getTileGrid(0.0, 180.0)
+        Assert.assertEquals(GRID_SIZE*GRID_SIZE, tileGrid.tiles.size)
+        tileGrid = getTileGrid(0.0, -180.0)
+        Assert.assertEquals(GRID_SIZE*GRID_SIZE, tileGrid.tiles.size)
+    }
+
+    @Test
+    fun get2x2TileGridTest(){
+
+        // Override Global grid size setting
+        GRID_SIZE = 2
+
+        var tileGrid = getTileGrid(0.001, 0.0)
+        Assert.assertEquals(GRID_SIZE*GRID_SIZE, tileGrid.tiles.size)
+        tileGrid = getTileGrid(0.0, 0.0)
+        Assert.assertEquals(GRID_SIZE*GRID_SIZE, tileGrid.tiles.size)
     }
 
     @Test

--- a/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckOutput.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckOutput.kt
@@ -54,7 +54,7 @@ class VisuallyCheckOutput {
         // convert coordinates to tile - I'm cheating here as the coordinates are already
         // in the center of the tile.
         val tileXY = getXYTile(51.43860066718254, -2.69439697265625, 16 )
-        val tileBoundingBox = tileToBoundingBox(tileXY.first, tileXY.second, 16.0)
+        val tileBoundingBox = tileToBoundingBox(tileXY.first, tileXY.second, 16)
         val tileBoundingBoxCorners = getBoundingBoxCorners(tileBoundingBox)
         val tilePolygon = getPolygonOfBoundingBox(tileBoundingBox)
         val tileBoundingBoxCenter = getCenterOfBoundingBox(tileBoundingBoxCorners)
@@ -90,7 +90,7 @@ class VisuallyCheckOutput {
         val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
         // convert coordinates to tile
         val tileXY = getXYTile(51.43860066718254, -2.69439697265625, 16 )
-        val tileBoundingBox = tileToBoundingBox(tileXY.first, tileXY.second, 16.0)
+        val tileBoundingBox = tileToBoundingBox(tileXY.first, tileXY.second, 16)
         val tileBoundingBoxCorners = getBoundingBoxCorners(tileBoundingBox)
         val tileBoundingBoxCenter = getCenterOfBoundingBox(tileBoundingBoxCorners)
 
@@ -100,7 +100,7 @@ class VisuallyCheckOutput {
         val newFeatureCollection = FeatureCollection()
         // Create a bounding box/Polygon for each tile in the grid
         for(tile in surroundingTiles){
-            val surroundingTileBoundingBox = tileToBoundingBox(tile.tileX, tile.tileY, 16.0)
+            val surroundingTileBoundingBox = tileToBoundingBox(tile.tileX, tile.tileY, 16)
             val polygonBoundingBox = getPolygonOfBoundingBox(surroundingTileBoundingBox)
             val boundingBoxFeature = Feature().also {
                 val ars3: HashMap<String, Any?> = HashMap()
@@ -140,7 +140,7 @@ class VisuallyCheckOutput {
         val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
         // convert coordinates to tile
         val tileXY = getXYTile(51.43860066718254, -2.69439697265625, 16 )
-        val tileBoundingBox = tileToBoundingBox(tileXY.first, tileXY.second, 16.0)
+        val tileBoundingBox = tileToBoundingBox(tileXY.first, tileXY.second, 16)
         val tileBoundingBoxCorners = getBoundingBoxCorners(tileBoundingBox)
         val tileBoundingBoxCenter = getCenterOfBoundingBox(tileBoundingBoxCorners)
 
@@ -150,7 +150,7 @@ class VisuallyCheckOutput {
         val newFeatureCollection = FeatureCollection()
         // Create a bounding box/Polygon for each tile in the grid
         for(tile in surroundingTiles){
-            val surroundingTileBoundingBox = tileToBoundingBox(tile.tileX, tile.tileY, 16.0)
+            val surroundingTileBoundingBox = tileToBoundingBox(tile.tileX, tile.tileY, 16)
             val polygonBoundingBox = getPolygonOfBoundingBox(surroundingTileBoundingBox)
             val boundingBoxFeature = Feature().also {
                 val ars3: HashMap<String, Any?> = HashMap()
@@ -185,7 +185,7 @@ class VisuallyCheckOutput {
         val cleanTileFeatureCollection = cleanTileGeoJSON(
             tileXY.first,
             tileXY.second,
-            16.0,
+            16,
             moshi.adapter(FeatureCollection::class.java).toJson(featureCollectionTest)
         )
         // copy and paste into GeoJSON.io
@@ -204,7 +204,7 @@ class VisuallyCheckOutput {
         val cleanTileFeatureCollection = cleanTileGeoJSON(
             tileXY.first,
             tileXY.second,
-            16.0,
+            16,
             moshi.adapter(FeatureCollection::class.java).toJson(entireFeatureCollectionTest)
         )
         // get the roads Feature Collection.
@@ -230,7 +230,7 @@ class VisuallyCheckOutput {
         val cleanTileFeatureCollection = cleanTileGeoJSON(
             tileXY.first,
             tileXY.second,
-            16.0,
+            16,
             moshi.adapter(FeatureCollection::class.java).toJson(entireFeatureCollectionTest)
         )
         // get the Intersections Feature Collection.
@@ -255,7 +255,7 @@ class VisuallyCheckOutput {
         val cleanTileFeatureCollection = cleanTileGeoJSON(
             tileXY.first,
             tileXY.second,
-            16.0,
+            16,
             moshi.adapter(FeatureCollection::class.java).toJson(entireFeatureCollectionTest)
         )
         // get the POI Feature Collection.
@@ -280,7 +280,7 @@ class VisuallyCheckOutput {
         val cleanTileFeatureCollection = cleanTileGeoJSON(
             32295,
             21787,
-            16.0,
+            16,
             moshi.adapter(FeatureCollection::class.java).toJson(entireFeatureCollectionTest)
         )
         // get the paths Feature Collection.
@@ -303,7 +303,7 @@ class VisuallyCheckOutput {
         val cleanTileFeatureCollection = cleanTileGeoJSON(
             32295,
             21787,
-            16.0,
+            16,
             moshi.adapter(FeatureCollection::class.java).toJson(entireFeatureCollectionTest)
         )
         // get the entrances Feature Collection.
@@ -328,7 +328,7 @@ class VisuallyCheckOutput {
         val cleanTileFeatureCollection = cleanTileGeoJSON(
             32295,
             21787,
-            16.0,
+            16,
             moshi.adapter(FeatureCollection::class.java).toJson(entireFeatureCollectionTest)
         )
         // get the poi Feature Collection.


### PR DESCRIPTION
This commit consists of multiple overlapping changes all with the same
aim which is to add an extra layer of abstraction to the tile grid so
that we can cope with different sized tiles for our audio UI.

Features:
 * Display of tile grid outline and 'central area' region on map UI.
  This can be enabled from the settings and is to allow easier debug.
  We can disable this in release builds in the future. The grid shown
  is the one currently in use by the GeoEngine.
  The new GeoJSON layer in our maplibre UI shows that there's
  potential for other debug uses.
 * Support 2x2 grid in addition to 3x3 grid. The reason for this is
  that the protomaps vector tiles are at zoom level 15 and not zoom
  level 16. A 3x3 grid at zoom level 15 is more data than we need,
  so we can now switch to using a 2x2 grid. The central area of the
  grid is where the current location can be without resulting in a
  new grid being generated. Once the user strays outside it, then a
  new grid is required. Although this was only required for 2x2, the
  same logic is used for 3x3 grids too. The result is that there's
  now some hysteresis so that if a user is walking down a tile
  boundary the grid won't continually be updated as they stray back
  and forth from one side of the tile boundary to the other.
 * The upgrading of the tile grid is no longer done on a timer, but
  when the location moves out of the central grid region. This makes
  it much more up to date.

Minor tidying:
 * All zoom levels are now Int rather than Double.
 * The grid size and zoom levels for the TileGrid are now declared
  inside the TileGrid class. They could be private and const, except
  that the unit test uses them.
 * Moved getTileGrid functions into their own file and it now returns
  a TileGrid object which contains the central region as well as the
  list of tiles.

Existing issues:
 * The map debug setting doesn't work immediately, and doesn't go
  away without a restart of the app.
