### PR TITLE
Add caching to protomaps tile client

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -117,15 +117,6 @@ class MainActivity : AppCompatActivity() {
             return
         }
 
-        // Install HTTP cache this caches all of the UI tiles (at least?)
-        try {
-            val httpCacheDir = File(applicationContext.cacheDir, "http")
-            val httpCacheSize = (100 * 1024 * 1024).toLong() // 100 MiB
-            HttpResponseCache.install(httpCacheDir, httpCacheSize)
-        } catch (e: IOException) {
-            Log.i("Injection", "HTTP response cache installation failed:$e")
-        }
-
         checkAndRequestNotificationPermissions()
         soundscapeServiceConnection.tryToBindToServiceIfRunning(applicationContext)
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/network/ITileDAO.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/network/ITileDAO.kt
@@ -3,8 +3,10 @@ package org.scottishtecharmy.soundscape.network
 import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Path
+import vector_tile.VectorTile
 
 interface ITileDAO {
+    // soundscape-backend functions
     @GET("tiles/16/{x}/{y}.json")
     fun getTile(
         @Path("x") x: Int,
@@ -16,4 +18,19 @@ interface ITileDAO {
         @Path("x") x: Int,
         @Path("y") y: Int
     ): Call<String>
+
+    // protomaps server functions
+    @GET("protomaps/{z}/{x}/{y}.mvt")
+    fun getVectorTile(
+        @Path("x") x: Int,
+        @Path("y") y: Int,
+        @Path("z") z: Int
+    ): Call<VectorTile.Tile>
+
+    @GET("protomaps/{z}/{x}/{y}.mvt")
+    fun getVectorTileWithCache(
+        @Path("x") x: Int,
+        @Path("y") y: Int,
+        @Path("z") z: Int
+    ): Call<VectorTile.Tile>
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/network/ProtomapsTileClient.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/network/ProtomapsTileClient.kt
@@ -1,39 +1,19 @@
 package org.scottishtecharmy.soundscape.network
 
-import retrofit2.Call
+import android.app.Application
 import retrofit2.Retrofit
 import retrofit2.converter.protobuf.ProtoConverterFactory
-import retrofit2.http.GET
-import retrofit2.http.Path
-import vector_tile.VectorTile
 
-interface IProtomapsTileDAO {
-    @GET("protomaps/{z}/{x}/{y}.mvt")
-    fun getMvtTileWithCache(
-        @Path("x") x: Int,
-        @Path("y") y: Int,
-        @Path("z") z: Int
-    ): Call<VectorTile.Tile>
-}
-/**
- * This is a retrofit client for getting tiles from our protomaps server and parsing the protobuf
- * automatically as it goes
- *  @param x tile coordinate
- *  @param y tile coordinate
- *  @param z zoom level
- */
-class ProtomapsTileClient {
+class ProtomapsTileClient(application: Application) : TileClient(application) {
 
-    private var retrofitInstance : Retrofit? = null
-    fun getClient(): IProtomapsTileDAO {
-        if(retrofitInstance == null) {
-            retrofitInstance = Retrofit.Builder()
-                .baseUrl(BASE_URL)
-                .addConverterFactory(ProtoConverterFactory.create())
-                .build()
-        }
-        return retrofitInstance!!.create(IProtomapsTileDAO::class.java)
+    override fun buildRetrofit() : Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .addConverterFactory(ProtoConverterFactory.create())
+            .client(okHttpClient)
+            .build()
     }
+
     companion object {
         private const val BASE_URL = "https://d1wzlzgah5gfol.cloudfront.net"
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/network/SoundscapeBackendTileClient.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/network/SoundscapeBackendTileClient.kt
@@ -1,0 +1,21 @@
+package org.scottishtecharmy.soundscape.network
+
+import android.app.Application
+import retrofit2.Retrofit
+import retrofit2.converter.scalars.ScalarsConverterFactory
+
+class SoundscapeBackendTileClient(application: Application) : TileClient(application) {
+
+    override fun buildRetrofit() : Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            // use it to output the string
+            .addConverterFactory(ScalarsConverterFactory.create())
+            .client(okHttpClient)
+            .build()
+    }
+
+    companion object {
+        private const val BASE_URL = "https://soundscape.scottishtecharmy.org"
+    }
+}


### PR DESCRIPTION
This change moves the soundscape-backend specific parts of TileClient out into a sub-class so that a protomaps TileClient can share the caching code.

It also removes the unused http caching from MainActivity - we no longer use the type of HTTP access that would use this cache.