### PR TITLE
More MVT to GeoJSON translation work

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/utils/MvtToGeoJson.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/utils/MvtToGeoJson.kt
@@ -10,6 +10,10 @@ import org.scottishtecharmy.soundscape.geojsonparser.geojson.Polygon
 import org.scottishtecharmy.soundscape.utils.TileGrid.Companion.ZOOM_LEVEL
 import vector_tile.VectorTile
 
+fun pointIsOffTile(x: Int, y: Int) : Boolean {
+    return (x < 0 || y < 0 || x >= 4096 || y >= 4096)
+}
+
 private fun parseGeometry(
     cropToTile: Boolean,
     geometry: MutableList<Int>
@@ -77,7 +81,7 @@ private fun parseGeometry(
                 // these to global coordinates
                 var add = true
                 if(cropToTile) {
-                    if(x < 0 || y < 0 || x >= 4096 || y >= 4096)
+                    if(pointIsOffTile(x, y))
                         add = false
                 }
                 if(add) {
@@ -222,6 +226,180 @@ class IntersectionDetection {
             }
         }
     }
+}
+
+fun calculateSlope(aConst: Double, a1: Double, a2: Double) : Double? {
+    if (a1 == a2) {
+        // Parallel lines, so no intersection
+        return null
+    }
+    val t = (aConst - a1) / (a2 - a1)
+    if (t < 0.0 || t > 1.0) {
+        // Intersection point is outside the segment
+        return null
+    }
+    return t
+}
+
+// Function to calculate the intersection with a vertical line (x = constant)
+fun intersectVertical(xConst: Double, y1: Double, y2: Double, x1: Double, x2: Double): Double? {
+    val t = calculateSlope(xConst, x1, x2)
+    if(t != null) {
+        return y1 + t * (y2 - y1)
+    }
+    return null
+}
+
+// Function to calculate the intersection with a horizontal line (y = constant)
+fun intersectHorizontal(yConst: Double, x1: Double, x2: Double, y1: Double, y2: Double): Double? {
+    val t = calculateSlope(yConst, y1, y2)
+    if(t != null) {
+        return x1 + t * (x2 - x1)
+    }
+    return null
+}
+
+/** getTileCrossingPoint returns the point at which the line connecting lastPoint and point crosses
+ * the tile boundary. If both points are outside the tile there can be two intersection points
+ * returned. Otherwise there can only be a single intersection point.
+ * @param point1 Point on line that might cross tile boundary
+ * @param point2 Another point on the line that might cross the tile boundary
+ *
+ * @return The coordinates at which the line crosses the tile boundary as a list of pairs of Doubles
+ * to give  us the best precision.
+ */
+fun getTileCrossingPoint(point1 : Pair<Int, Int>, point2 : Pair<Int, Int>) : List<Pair<Double, Double>> {
+
+    // Extract the coordinates of the points and square boundaries
+    val x1 = point1.first.toDouble()
+    val y1 = point1.second.toDouble()
+    val x2 = point2.first.toDouble()
+    val y2 = point2.second.toDouble()
+
+    val intersections = mutableListOf<Pair<Double, Double>>()
+
+    // Check intersections with the four sides of the square
+
+    // Left side (x = 0)
+    intersectVertical(0.0, y1, y2, x1, x2)?.let { yIntersection ->
+        if (yIntersection in 0.0..4096.0) {
+            intersections.add(Pair(0.0, yIntersection))
+        }
+    }
+
+    // Right side (x = 4096)
+    intersectVertical(4096.0, y1, y2, x1, x2)?.let { yIntersection ->
+        if (yIntersection in 0.0..4096.0) {
+            intersections.add(Pair(4096.0, yIntersection))
+        }
+    }
+
+    // Bottom side (y = 0.0)
+    intersectHorizontal(0.0, x1, x2, y1, y2)?.let { xIntersection ->
+        if (xIntersection in 0.0..4096.0) {
+            intersections.add(Pair(xIntersection, 0.0))
+        }
+    }
+
+    // Top side (y = 4096)
+    intersectHorizontal(4096.0, x1, x2, y1, y2)?.let { xIntersection ->
+        if (xIntersection in 0.0..4096.0) {
+            intersections.add(Pair(xIntersection, 4096.0))
+        }
+    }
+
+    // Return any intersections that we found
+    return intersections
+}
+
+/**
+ * convertGeometryAndClipLineToTile takes a line and converts it into a List of LineStrings. In the
+ * simplest case, the points are all within the tile and so there will just be a single LineString
+ * output. However, if the line goes off and on the tile (bouncing around in the buffer region) then
+ * there can be multiple segments returned.
+ */
+fun convertGeometryAndClipLineToTile(tileX : Int,
+                                     tileY : Int,
+                                     tileZoom : Int,
+                                     line : ArrayList<Pair<Int, Int>>) : List<LineString> {
+    val returnList = mutableListOf<LineString>()
+
+    if(line.isEmpty()) {
+        return returnList
+    }
+
+    // We want to iterate through the line detecting when it goes off/on tile and creating line
+    // segments for each. The ends of the line as it goes off tile need to be in LatLng as we want
+    // to interpolate as precisely as possible so that the line end is at the same point on adjacent
+    // tiles. The only other thing to bear in mind is that it's possible for two points to be off
+    // tile but the line between them to cross through the tile.
+    var offTile = pointIsOffTile(line[0].first, line[0].second)
+    val segment = arrayListOf<LngLatAlt>()
+    var lastPoint = line[0]
+    for(point in line) {
+        if(pointIsOffTile(point.first, point.second) != offTile){
+            if(offTile) {
+                // We started off tile and this point is now on tile
+                // Add interpolated point from lastPoint to this point
+                val interpolatedPoint = getTileCrossingPoint(lastPoint, point)
+                segment.add(getLatLonTileWithOffset(tileX,
+                    tileY,
+                    tileZoom,
+                    interpolatedPoint[0].first/4096.0,
+                    interpolatedPoint[0].second/4096.0))
+
+                // Add the new point
+                segment.add(getLatLonTileWithOffset(tileX,
+                    tileY,
+                    tileZoom,
+                    point.first.toDouble()/4096.0,
+                    point.second.toDouble()/4096.0))
+            } else {
+                // We started on tile and this point is now off tile
+                // Add interpolated point from lastPoint to this point
+                val interpolatedPoint = getTileCrossingPoint(lastPoint, point)
+                segment.add(getLatLonTileWithOffset(tileX,
+                    tileY,
+                    tileZoom,
+                    interpolatedPoint[0].first/4096.0,
+                    interpolatedPoint[0].second/4096.0))
+
+                returnList.add(LineString(ArrayList(segment)))
+                segment.clear()
+            }
+
+            // Update the current point state
+            offTile = offTile.xor(true)
+        }
+        else if(!offTile) {
+            segment.add(getLatLonTileWithOffset(tileX,
+                tileY,
+                tileZoom,
+                point.first.toDouble()/4096.0,
+                point.second.toDouble()/4096.0))
+        } else {
+            // We're continuing off tile, but we need to check if the line between the two off tile
+            // points crossed over the tile.
+            val interpolatedPoints = getTileCrossingPoint(lastPoint, point)
+            for(ip in interpolatedPoints) {
+                segment.add(getLatLonTileWithOffset(tileX,
+                    tileY,
+                    tileZoom,
+                    ip.first/4096.0,
+                    ip.second/4096.0))
+            }
+            if(segment.isNotEmpty()) {
+                returnList.add(LineString(ArrayList(segment)))
+                segment.clear()
+            }
+        }
+
+        lastPoint = point
+    }
+    if(segment.isNotEmpty()) {
+        returnList.add(LineString(segment))
+    }
+    return returnList
 }
 
 /**
@@ -405,16 +583,10 @@ fun vectorTileToGeoJson(tileX: Int,
                                 feature.id
                             )
                             intersectionDetection.addLine(line, details)
-                            listOfGeometries.add(
-                                LineString(
-                                    convertGeometry(
-                                        tileX,
-                                        tileY,
-                                        tileZoom,
-                                        line
-                                    )
-                                )
-                            )
+                            val clippedLines = convertGeometryAndClipLineToTile(tileX, tileY, tileZoom, line)
+                            for(clippedLine in clippedLines) {
+                                listOfGeometries.add(clippedLine)
+                            }
                         }
                    }
                 }


### PR DESCRIPTION
The first change removes some false intersections which we were creating where two line segments for the same path/road met. I had code in to do this previously, but had forgotten why it was there and had removed it.

The second change is fairly complex to look at but is simply truncating path/road strings at the tile boundary using interpolated nodes on the tile edge. The result seems pretty good and is better than the 20m of overlapping roads that we had prior to the change.