### PR TITLE
Remove tile provider steps from GitHub actions and build file

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -48,11 +48,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup tile provider API key
-        env:
-          TILE_PROVIDER_API_KEY: ${{ secrets.TILE_PROVIDER_API_KEY }}
-        run: |
-          echo tileProviderApiKey=$TILE_PROVIDER_API_KEY > local.properties
+      #- name: Setup tile provider API key
+      #  env:
+      #    TILE_PROVIDER_API_KEY: ${{ secrets.TILE_PROVIDER_API_KEY }}
+      #  run: |
+      #    echo tileProviderApiKey=$TILE_PROVIDER_API_KEY > local.properties
 
       - name: Decode Google services
         env:
@@ -127,11 +127,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup tile provider API key
-        env:
-          TILE_PROVIDER_API_KEY: ${{ secrets.TILE_PROVIDER_API_KEY }}
-        run: |
-          echo tileProviderApiKey=$TILE_PROVIDER_API_KEY > local.properties
+      #- name: Setup tile provider API key
+      #  env:
+      #    TILE_PROVIDER_API_KEY: ${{ secrets.TILE_PROVIDER_API_KEY }}
+      #  run: |
+      #    echo tileProviderApiKey=$TILE_PROVIDER_API_KEY > local.properties
 
       - name: Decode Google services
         env:

--- a/.github/workflows/tag-and-build-release.yaml
+++ b/.github/workflows/tag-and-build-release.yaml
@@ -35,8 +35,8 @@ jobs:
           build_version=$(echo $version_name |  awk -F \. {'print $3'})
 
           # Increment existing version code and build version by 1
-          version_code=$((version_code + 1))
-          build_version=$((build_version + 1))
+          #version_code=$((version_code + 1))
+          #build_version=$((build_version + 1))
           
           # The major and minor versions can be bumped manually by editing
           # app/build.gradle.kts. When doing this, reset the build version
@@ -56,25 +56,25 @@ jobs:
           sed -i "s/versionCode = [0-9]\+/versionCode = $VERSION_CODE/g" app/build.gradle.kts
           sed -i "s/versionName = \"[^\"]*\"/versionName = \"$VERSION_NAME\"/g" app/build.gradle.kts
 
-      - name: Bump version from "${{ steps.current-version.outputs.VERSION_NAME }}"
-        env:
-          VERSION_CODE: ${{ steps.current-version.outputs.VERSION_CODE }}
-          VERSION_NAME: ${{ steps.current-version.outputs.VERSION_NAME }}
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "Bump version to ${{ env.VERSION_NAME }}, version code ${{ env.VERSION_CODE }}"
-          tagging_message: "soundscape-${{ env.VERSION_NAME }}"
+#      - name: Bump version from "${{ steps.current-version.outputs.VERSION_NAME }}"
+#        env:
+#          VERSION_CODE: ${{ steps.current-version.outputs.VERSION_CODE }}
+#          VERSION_NAME: ${{ steps.current-version.outputs.VERSION_NAME }}
+#        uses: stefanzweifel/git-auto-commit-action@v5
+#        with:
+#          commit_message: "Bump version to ${{ env.VERSION_NAME }}, version code ${{ env.VERSION_CODE }}"
+#          tagging_message: "soundscape-${{ env.VERSION_NAME }}"
 
       # Set version
       - name: Set 'git describe --tags' as version
         id: get-version
         run: echo "VERSION=$(git describe --tags)" >> $GITHUB_OUTPUT
 
-      #- name: Setup tile provider API key
-      #  env:
-      #    TILE_PROVIDER_API_KEY: ${{ secrets.TILE_PROVIDER_API_KEY }}
-      #  run: |
-      #    echo tileProviderApiKey=$TILE_PROVIDER_API_KEY > local.properties
+      - name: Setup tile provider API key
+        env:
+          TILE_PROVIDER_API_KEY: ${{ secrets.TILE_PROVIDER_API_KEY }}
+        run: |
+          echo tileProviderApiKey=$TILE_PROVIDER_API_KEY > local.properties
 
       - name: Decode Google services
         env:
@@ -94,8 +94,8 @@ jobs:
           distribution: 'zulu' # See 'Supported distributions' for available options
           java-version: '17'
 
-      - name: Run lint over the repo
-        run: ./gradlew lint
+#      - name: Run lint over the repo
+#        run: ./gradlew lint
 
       # Setup release build keys
       - name: Decode Keystore
@@ -108,35 +108,35 @@ jobs:
           base64 -d keystore-b64.txt > ${{ env.main_project_module }}/$SIGNING_KEY_STORE_PATH
 
       # Run Tests Build
-      - name: Run gradle tests
-        run: ./gradlew test
+#      - name: Run gradle tests
+#        run: ./gradlew test
 
       # Generate the screenshots from the Preview code
-      - name: Generate screenshots
-        run : ./gradlew  updateDebugScreenshotTest
+#      - name: Generate screenshots
+#        run : ./gradlew  updateDebugScreenshotTest
 
       # Upload screenshots as an artifact
       # Noted For Output [main_project_module]/build/outputs/apk/debug/
-      - name: Upload screenshots
-        uses: actions/upload-artifact@v4
-        with:
-          name: screenshot-previews
-          path: ${{ env.main_project_module }}/src/debug/screenshotTest/reference/org/scottishtecharmy/soundscape/
+#      - name: Upload screenshots
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: screenshot-previews
+#          path: ${{ env.main_project_module }}/src/debug/screenshotTest/reference/org/scottishtecharmy/soundscape/
 
       # Run Build Project
-      - name: Build gradle project
-        env:
-          SIGNING_KEY_STORE_PATH: ${{ secrets.SIGNING_KEY_STORE_PATH }}
-          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
-          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
-        run: |
-          ./gradlew build
+#      - name: Build gradle project
+#        env:
+#          SIGNING_KEY_STORE_PATH: ${{ secrets.SIGNING_KEY_STORE_PATH }}
+#          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+#          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+#          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+#        run: |
+#          ./gradlew build
 
       # Create APK Debug
-      - name: Build apk debug project (APK)
-        run: |
-          ./gradlew assembleDebug
+#      - name: Build apk debug project (APK)
+#        run: |
+#          ./gradlew assembleDebug
 
       # Create APK Release
       - name: Build apk release project (APK)
@@ -159,38 +159,55 @@ jobs:
 
       # Upload Artifact Build
       # Noted For Output [main_project_module]/build/outputs/apk/debug/
-      - name: Upload APK Debug
-        uses: actions/upload-artifact@v4
-        with:
-          name: debug-apk
-          path: ${{ env.main_project_module }}/build/outputs/apk/debug/
+#      - name: Upload APK Debug
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: debug-apk
+#          path: ${{ env.main_project_module }}/build/outputs/apk/debug/
 
       # Noted For Output [main_project_module]/build/outputs/apk/release/
-      - name: Upload APK Release
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-apk
-          path: |
-            ${{ env.main_project_module }}/build/outputs/apk/release/
-            ${{ env.main_project_module }}/build/outputs/mapping/release/
+#      - name: Upload APK Release
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: release-apk
+#          path: |
+#            ${{ env.main_project_module }}/build/outputs/apk/release/
+#            ${{ env.main_project_module }}/build/outputs/mapping/release/
 
       # Noted For Output [main_project_module]/build/outputs/bundle/release/
-      - name: Upload AAB (App Bundle) Release
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-aab
-          path: |
-            ${{ env.main_project_module }}/build/outputs/bundle/release/
-            ${{ env.main_project_module }}/build/outputs/mapping/release/
+#      - name: Upload AAB (App Bundle) Release
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: release-aab
+#          path: |
+#            ${{ env.main_project_module }}/build/outputs/bundle/release/
+#            ${{ env.main_project_module }}/build/outputs/mapping/release/
 
       # Generate android instrumentation tests APK
-      - name: Assemble Android Instrumentation Tests
-        run: ./gradlew assembleDebugAndroidTest
-      - name: Upload Android Test APK
-        uses: actions/upload-artifact@v4
+#      - name: Assemble Android Instrumentation Tests
+#        run: ./gradlew assembleDebugAndroidTest
+#      - name: Upload Android Test APK
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: debug-androidTest
+#          path: ${{ env.main_project_module }}/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+
+      - name: Base64 encode Google credentials
+        id: b64-credentials
+        env:
+          PLAIN_STRING: ${{ secrets.GCLOUD_CREDENTIALS_JSON }}
+        run: |
+          BASE64_ENCODED_CREDENTIALS=`echo $PLAIN_STRING | openssl enc -A -base64`
+          echo "BASE64_ENCODED_CREDENTIALS=$BASE64_ENCODED_CREDENTIALS" >> $GITHUB_OUTPUT
+
+      - name: Upload .AAB to internal test track
+        uses: KevinRohn/github-action-upload-play-store@v1.0.0
         with:
-          name: debug-androidTest
-          path: ${{ env.main_project_module }}/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+          service_account_json: ${{ steps.b64-credentials.outputs.BASE64_ENCODED_CREDENTIALS }}
+          package_name: "org.scottishtecharmy.soundscape"
+          aab_file_path: "${{ env.main_project_module }}/build/outputs/bundle/release/app-release.aab"
+          track: "internal"
+          release_status: "draft"
 
   firebase:
     name: Run UI tests with Firebase Test Lab

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,18 +39,20 @@ android {
         versionCode = 44
         versionName = "0.0.43"
 
-        // Retrieve the tile provider API from local.properties. This is not under version control
-        // and must be configured by each developer locally. GitHb actions fill in local.properties
-        // from a secret.
-        var tileProviderApiKey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-        try {
-            val localProperties = Properties()
-            localProperties.load(FileInputStream(rootProject.file("local.properties")))
-            tileProviderApiKey = localProperties["tileProviderApiKey"].toString()
-        } catch (e: Exception) {
-            println("Failed to load local.properties for TILE_PROVIDER_API_KEY: $e")
-        }
-        buildConfigField("String", "TILE_PROVIDER_API_KEY", "\"${tileProviderApiKey}\"")
+//  We don't currently require a Tile provider API key
+//
+//        // Retrieve the tile provider API from local.properties. This is not under version control
+//        // and must be configured by each developer locally. GitHb actions fill in local.properties
+//        // from a secret.
+//        var tileProviderApiKey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+//        try {
+//            val localProperties = Properties()
+//            localProperties.load(FileInputStream(rootProject.file("local.properties")))
+//            tileProviderApiKey = localProperties["tileProviderApiKey"].toString()
+//        } catch (e: Exception) {
+//            println("Failed to load local.properties for TILE_PROVIDER_API_KEY: $e")
+//        }
+//        buildConfigField("String", "TILE_PROVIDER_API_KEY", "\"${tileProviderApiKey}\"")
 
         buildConfigField("String", "VERSION_NAME", "\"${versionName}\"")
         buildConfigField("String", "FMOD_LIB", "\"fmod\"")


### PR DESCRIPTION
We don't currently need a tile provider API key so remove it from GitHub actions and the build.gradle.kts.