### PR TITLE
Work on MVT to GeoJSON to add joining of paths/roads at tile boundaries

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/database/local/RealmConfiguration.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/database/local/RealmConfiguration.kt
@@ -28,7 +28,17 @@ object RealmConfiguration {
             if(!SOUNDSCAPE_TILE_BACKEND)
                 deleteRealm(config)
 
-            tileDataRealm = Realm.open(config)
+            try {
+                tileDataRealm = Realm.open(config)
+            } catch(e: Exception) {
+                Log.e("Realm", "Exception opening database: $e")
+
+                // TODO: Is this really the best approach, deleting the database and trying again?
+                // We're going to delete it and try again. This is likely due to a change in schema
+                Log.e("Realm", "Deleting and re-trying")
+                deleteRealm(config)
+                tileDataRealm = Realm.open(config)
+            }
         }
         return tileDataRealm!!
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/database/local/dao/TilesDao.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/database/local/dao/TilesDao.kt
@@ -44,6 +44,7 @@ class TilesDao(val realm: Realm) {
             pois = tile?.pois ?: "-"
             busStops = tile?.busStops ?: "-"
             crossings = tile?.crossings ?: "-"
+            interpolations = tile?.interpolations ?: "-"
         }
     }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/database/local/model/TileData.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/database/local/model/TileData.kt
@@ -5,6 +5,7 @@ import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.annotations.PrimaryKey
 
 class TileData() : RealmObject {
+
     @PrimaryKey
     var quadKey : String = ""
     var lastUpdated : RealmInstant? = RealmInstant.now() // this timestamps it
@@ -16,6 +17,7 @@ class TileData() : RealmObject {
     var pois : String = "" // same as above
     var busStops: String = ""
     var crossings: String = ""
+    var interpolations: String = ""
     //var pois : RealmList<GDASpatialDataResultEntity> = realmListOf()
     //var roads : RealmList<GDASpatialDataResultEntity> = realmListOf()
     //var paths : RealmList<GDASpatialDataResultEntity> = realmListOf()

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geojsonparser/geojson/MultiPoint.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geojsonparser/geojson/MultiPoint.kt
@@ -20,4 +20,8 @@ open class MultiPoint() : Geometry<LngLatAlt>() {
     constructor(vararg points: LngLatAlt) : this() {
         this.coordinates = arrayListOf(*points)
     }
+
+    constructor(points: ArrayList<LngLatAlt>) : this() {
+        this.coordinates = points
+    }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geojsonparser/moshi/GeoJsonObjectMoshiAdapter.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geojsonparser/moshi/GeoJsonObjectMoshiAdapter.kt
@@ -166,7 +166,6 @@ open class GeoJsonObjectMoshiAdapter() : JsonAdapter<GeoJsonObject>() {
             is String -> writer.value(value)
             is Double -> writer.value(value)
             is Int -> writer.value(value)
-            is Long -> writer.value(value)
             is Boolean -> writer.value(value)
             is Map<*, *> -> writeMap(value, writer)
             is Collection<*> -> {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/utils/TileUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/utils/TileUtils.kt
@@ -237,6 +237,25 @@ fun getCrossingsFromTileFeatureCollection(tileFeatureCollection: FeatureCollecti
 }
 
 /**
+ * Given a valid Tile feature collection this will parse the collection and return an interpolation
+ * points feature collection. Uses the "edgePoint" feature_value to extract crossings from GeoJSON.
+ * @param tileFeatureCollection
+ * A FeatureCollection object.
+ * @return A FeatureCollection object that contains only edgePoints
+ */
+fun getInterpolationPointsFromTileFeatureCollection(tileFeatureCollection: FeatureCollection): FeatureCollection{
+    val interpolationPointsFeatureCollection = FeatureCollection()
+    for (feature in tileFeatureCollection) {
+        feature.properties?.let { properties ->
+            if (properties["class"] == "edgePoint") {
+                interpolationPointsFeatureCollection.addFeature(feature)
+            }
+        }
+    }
+    return interpolationPointsFeatureCollection
+}
+
+/**
  * Given a valid Tile feature collection this will parse the collection and return a paths
  * feature collection. Uses the "footway", "path", "cycleway", "bridleway" feature_value to extract
  * Paths from Feature Collection.
@@ -486,6 +505,14 @@ fun processTileFeatureCollection(tileFeatureCollection: FeatureCollection?,
         crossingsFeatureCollection
     )
     tileData.crossings = crossingsString
+
+    val interpolationFeatureCollection = getInterpolationPointsFromTileFeatureCollection(
+        tileFeatureCollection
+    )
+    val interpolationString = moshi.adapter(FeatureCollection::class.java).toJson(
+        interpolationFeatureCollection
+    )
+    tileData.interpolations = interpolationString
 
     return  tileData
 


### PR DESCRIPTION
All of the work in these commits is aimed at having `getGridFeatureCollections()` return connecting `LineStrings` at tile boundaries to join up roads and paths which meander across them. Whilst doing this work I noticed that the `Long` id from the MVT couldn't be roundtripped via JSON as JSON only supports `Int` and `Double`. As a result, the id now used internally is a `Double` which is large enough (by a factor of 10000) despite it being non-ideal.