### PR TITLE
Don't deduplicate in getGridFeatureCollections with protomaps backend

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -871,8 +871,17 @@ class GeoEngine {
                     joiner.addInterpolatedPoints(ip)
                 }
 
-                for((index, fc) in featureCollection.withIndex())
-                    deduplicateFeatureCollection(gridFeatureCollection[index], fc, processedOsmIds[index])
+                if(SOUNDSCAPE_TILE_BACKEND) {
+                    for ((index, fc) in featureCollection.withIndex())
+                        deduplicateFeatureCollection(
+                            gridFeatureCollection[index],
+                            fc,
+                            processedOsmIds[index]
+                        )
+                } else {
+                    for ((index, fc) in featureCollection.withIndex())
+                        gridFeatureCollection[index].plusAssign(fc!!)
+                }
             }
         }
         for(fc in gridFeatureCollection)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geojsonparser/geojson/FeatureCollection.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geojsonparser/geojson/FeatureCollection.kt
@@ -28,4 +28,8 @@ open class FeatureCollection : GeoJsonObject(), Iterable<Feature> {
     operator fun plusAssign(rhs: Feature): Unit {
         features.add(rhs)
     }
+
+    operator fun plusAssign(rhs: FeatureCollection): Unit {
+        features.addAll(rhs)
+    }
 }


### PR DESCRIPTION
All the deduplication has already been taken care of during the MVT to GeoJSON translation and no further deduplication should be done. Because we can have multiple segments of the same OSM id (e.g. separate ones where a road crosses a tile) we actually can't de-duplicate.