### PR TITLE
Add configuration of protomaps server to ease local testing

### DIFF
--- a/app/src/main/assets/osm-bright-gl-style/style.json
+++ b/app/src/main/assets/osm-bright-gl-style/style.json
@@ -46,7 +46,7 @@
   "sources": {
     "openmaptiles": {
       "type": "vector",
-      "url":"https://d1wzlzgah5gfol.cloudfront.net/protomaps.json"
+      "url":"PROTOMAPS_SERVER_URL"
     }
   },
   "sprite": "file:///data/user/0/org.scottishtecharmy.soundscape/files/osm-bright-gl-style/sprite",

--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -2,7 +2,6 @@ package org.scottishtecharmy.soundscape
 
 import android.Manifest
 import android.content.Intent
-import android.net.http.HttpResponseCache
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -30,9 +29,10 @@ import org.scottishtecharmy.soundscape.screens.home.HomeScreen
 import org.scottishtecharmy.soundscape.screens.home.Navigator
 import org.scottishtecharmy.soundscape.services.SoundscapeService
 import org.scottishtecharmy.soundscape.ui.theme.SoundscapeTheme
+import org.scottishtecharmy.soundscape.utils.TileGrid.Companion.PROTOMAPS_SERVER_PATH
+import org.scottishtecharmy.soundscape.utils.TileGrid.Companion.PROTOMAPS_SERVER_BASE
 import org.scottishtecharmy.soundscape.utils.extractAssets
 import java.io.File
-import java.io.IOException
 import javax.inject.Inject
 
 
@@ -91,6 +91,24 @@ class MainActivity : AppCompatActivity() {
         Log.d("ExtractAssets", "Start extraction")
         extractAssets(applicationContext, "osm-bright-gl-style","osm-bright-gl-style")
         Log.d("ExtractAssets", "Completed extraction")
+
+        // Update extracted style.json with protomaps server URI
+        val filesDir = applicationContext.filesDir.toString()
+        val outputStyleStream = File("$filesDir/osm-bright-gl-style/processedstyle.json").outputStream()
+        val inputStyleStream = File("$filesDir/osm-bright-gl-style/style.json").inputStream()
+        inputStyleStream.bufferedReader().useLines { lines ->
+            lines.forEach { line ->
+                if(line.contains("PROTOMAPS_SERVER_URL")) {
+                    val newline = line.replace("PROTOMAPS_SERVER_URL", "$PROTOMAPS_SERVER_BASE/$PROTOMAPS_SERVER_PATH.json")
+                    outputStyleStream.write(newline.toByteArray())
+                }
+                else {
+                    outputStyleStream.write(line.toByteArray())
+                }
+            }
+        }
+        inputStyleStream.close()
+        outputStyleStream.close()
 
         // Debug - dump preferences
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/network/ITileDAO.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/network/ITileDAO.kt
@@ -1,5 +1,7 @@
 package org.scottishtecharmy.soundscape.network
 
+import org.scottishtecharmy.soundscape.utils.TileGrid.Companion.PROTOMAPS_SERVER_PATH
+import org.scottishtecharmy.soundscape.utils.TileGrid.Companion.PROTOMAPS_SUFFIX
 import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -20,14 +22,14 @@ interface ITileDAO {
     ): Call<String>
 
     // protomaps server functions
-    @GET("protomaps/{z}/{x}/{y}.mvt")
+    @GET("$PROTOMAPS_SERVER_PATH/{z}/{x}/{y}.$PROTOMAPS_SUFFIX")
     fun getVectorTile(
         @Path("x") x: Int,
         @Path("y") y: Int,
         @Path("z") z: Int
     ): Call<VectorTile.Tile>
 
-    @GET("protomaps/{z}/{x}/{y}.mvt")
+    @GET("$PROTOMAPS_SERVER_PATH/{z}/{x}/{y}.$PROTOMAPS_SUFFIX")
     fun getVectorTileWithCache(
         @Path("x") x: Int,
         @Path("y") y: Int,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/network/ProtomapsTileClient.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/network/ProtomapsTileClient.kt
@@ -1,6 +1,7 @@
 package org.scottishtecharmy.soundscape.network
 
 import android.app.Application
+import org.scottishtecharmy.soundscape.utils.TileGrid.Companion.PROTOMAPS_SERVER_BASE
 import retrofit2.Retrofit
 import retrofit2.converter.protobuf.ProtoConverterFactory
 
@@ -15,6 +16,6 @@ class ProtomapsTileClient(application: Application) : TileClient(application) {
     }
 
     companion object {
-        private const val BASE_URL = "https://d1wzlzgah5gfol.cloudfront.net"
+        private const val BASE_URL = PROTOMAPS_SERVER_BASE
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
@@ -122,7 +122,7 @@ fun MapContainerLibre(
         // init map first time it is displayed
         map.getMapAsync { mapLibre ->
             // val apiKey = BuildConfig.TILE_PROVIDER_API_KEY
-            val styleUrl = Uri.fromFile(File("$filesDir/osm-bright-gl-style/style.json")).toString()
+            val styleUrl = Uri.fromFile(File("$filesDir/osm-bright-gl-style/processedstyle.json")).toString()
             mapLibre.setStyle(styleUrl) { style ->
                 style.addImage(USER_POSITION_MARKER_NAME, drawable!!)
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/utils/TileGridUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/utils/TileGridUtils.kt
@@ -62,6 +62,34 @@ class TileGrid(newTiles : MutableList<Tile>, newCentralBoundingBox : BoundingBox
         var GRID_SIZE = if(SOUNDSCAPE_TILE_BACKEND) 3 else 2
 
         /**
+         * The default tile server is the one out in the cloud where the tile JSON is at:
+         *    https://server/protomaps.json
+         *
+         * and the tiles are at
+         *    https://server/protomaps/{z}/{x}/{y}.mvt
+         */
+        const val PROTOMAPS_SERVER_BASE = "https://d1wzlzgah5gfol.cloudfront.net"
+        const val PROTOMAPS_SERVER_PATH = "protomaps"
+        const val PROTOMAPS_SUFFIX = "mvt"
+
+        /**
+         * It's also useful to be able to use tiles served up locally when testing. When I
+         * test locally I'm serving up the file like this:
+         *
+         *    tileserver-gl-light --file europe.pmtiles -b 192.168.86.39
+         *
+         * With this configuration the tile JSON descriptor appears at:
+         *    http://192.168.86.39:8080/data/v3.json
+         *
+         * and the tiles within it are at:
+         *    http://192.168.86.39:8080/data/v3/{z}/{x}/{y}.pbf
+         *
+         */
+        //const val PROTOMAPS_SERVER_BASE = "http://192.168.86.39:8080"
+        //const val PROTOMAPS_SERVER_PATH = "data/v3"
+        //const val PROTOMAPS_SUFFIX = "pbf"
+
+        /**
          * Given a location it calculates the set of tiles (VectorTiles) that cover a
          * 3 x 3 grid around the specified location.
          * @param currentLatitude


### PR DESCRIPTION
This change consolidates the location of the protomaps server configuration allowing it to be easily switched between cloud and local for developer testing. It also lays the groundwork for having the server URI be a secret as we now parse the `style.json` used by maplibre and dynamically insert the URL.