### PR TITLE
Translation strings for heading and travelling in a direction.

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -107,6 +107,22 @@
     <string name="directions_direction_behind_to_the_left">bagved til venstre</string>
     <string name="directions_direction_to_the_left">til venstre</string>
     <string name="directions_direction_ahead_to_the_left">forude til venstre</string>
+    <string name="directions_traveling_n">Kører nord</string>
+    <string name="directions_traveling_ne">Kører nordøst</string>
+    <string name="directions_traveling_e">Kører øst</string>
+    <string name="directions_traveling_se">Kører sydøst</string>
+    <string name="directions_traveling_s">Kører syd</string>
+    <string name="directions_traveling_sw">Kører sydvest</string>
+    <string name="directions_traveling_w">Kører vest</string>
+    <string name="directions_traveling_nw">Kører nordvest</string>
+    <string name="directions_heading_n">På vej nord</string>
+    <string name="directions_heading_ne">På vej nordøst</string>
+    <string name="directions_heading_e">På vej øst</string>
+    <string name="directions_heading_se">På vej sydøst</string>
+    <string name="directions_heading_s">På vej syd</string>
+    <string name="directions_heading_sw">På vej sydvest</string>
+    <string name="directions_heading_w">På vej vest</string>
+    <string name="directions_heading_nw">På vej nordvest</string>
 
     <string name="intersection_approaching_intersection">Nærmer sig kryds</string>
     <string name="directions_intersection_with_name_direction">Kryds med %1$s %2$s</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -106,6 +106,22 @@
     <string name="directions_direction_behind_to_the_left">hinten links</string>
     <string name="directions_direction_to_the_left">nach links</string>
     <string name="directions_direction_ahead_to_the_left">links vor Ihnen</string>
+    <string name="directions_traveling_n">Nach Norden fahrend</string>
+    <string name="directions_traveling_ne">Nach Nordosten fahrend</string>
+    <string name="directions_traveling_e">Nach Osten fahrend</string>
+    <string name="directions_traveling_se">Nach Südosten fahrend</string>
+    <string name="directions_traveling_s">Nach Süden fahrend</string>
+    <string name="directions_traveling_sw">Nach Südwesten fahrend</string>
+    <string name="directions_traveling_w">Nach Westen fahrend</string>
+    <string name="directions_traveling_nw">Nach Nordwesten fahrend</string>
+    <string name="directions_heading_n">Richtung Norden</string>
+    <string name="directions_heading_ne">Richtung Nordosten</string>
+    <string name="directions_heading_e">Richtung Osten</string>
+    <string name="directions_heading_se">Richtung Südosten</string>
+    <string name="directions_heading_s">Richtung Süden</string>
+    <string name="directions_heading_sw">Richtung Südwesten</string>
+    <string name="directions_heading_w">Richtung Westen</string>
+    <string name="directions_heading_nw">Richtung Nordwesten</string>
 
     <string name="intersection_approaching_intersection">Kreuzung vor Ihnen</string>
     <string name="directions_intersection_with_name_direction">Kreuzung mit %1$s %2$s</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -107,6 +107,22 @@
     <string name="directions_direction_behind_to_the_left">πίσω προς τα αριστερά</string>
     <string name="directions_direction_to_the_left">προς τα αριστερά</string>
     <string name="directions_direction_ahead_to_the_left">μπροστά προς τα αριστερά</string>
+    <string name="directions_traveling_n">Ταξιδεύοντας βόρεια</string>
+    <string name="directions_traveling_ne">Ταξιδεύοντας βορειοανατολικά</string>
+    <string name="directions_traveling_e">Ταξιδεύοντας ανατολικά</string>
+    <string name="directions_traveling_se">Ταξιδεύοντας νοτιοανατολικά</string>
+    <string name="directions_traveling_s">Ταξιδεύοντας νότια</string>
+    <string name="directions_traveling_sw">Ταξιδεύοντας νοτιοδυτικά</string>
+    <string name="directions_traveling_w">Ταξιδεύοντας δυτικά</string>
+    <string name="directions_traveling_nw">Ταξιδεύοντας βορειοδυτικά</string>
+    <string name="directions_heading_n">Κατεύθυνση βόρεια</string>
+    <string name="directions_heading_ne">Κατεύθυνση βορειοανατολικά</string>
+    <string name="directions_heading_e">Κατεύθυνση ανατολικά</string>
+    <string name="directions_heading_se">Κατεύθυνση νοτιοανατολικά</string>
+    <string name="directions_heading_s">Κατεύθυνση νότια</string>
+    <string name="directions_heading_sw">Κατεύθυνση νοτιοδυτικά</string>
+    <string name="directions_heading_w">Κατεύθυνση δυτικά</string>
+    <string name="directions_heading_nw">Κατεύθυνση βορειοδυτικά</string>
 
     <string name="intersection_approaching_intersection">Πλησιάζετε τη διασταύρωση</string>
     <string name="directions_intersection_with_name_direction">Διασταύρωση με %1$s %2$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -106,6 +106,22 @@
     <string name="directions_direction_behind_to_the_left">detrás a la izquierda</string>
     <string name="directions_direction_to_the_left">a la izquierda</string>
     <string name="directions_direction_ahead_to_the_left">adelante a la izquierda</string>
+    <string name="directions_traveling_n">Viajando al norte</string>
+    <string name="directions_traveling_ne">Viajando al nordeste</string>
+    <string name="directions_traveling_e">Viajando al este</string>
+    <string name="directions_traveling_se">Viajando al sudeste</string>
+    <string name="directions_traveling_s">Viajando al sur</string>
+    <string name="directions_traveling_sw">Viajando al suroeste</string>
+    <string name="directions_traveling_w">Viajando al oeste</string>
+    <string name="directions_traveling_nw">Viajando al noroeste</string>
+    <string name="directions_heading_n">Caminando hacia el norte</string>
+    <string name="directions_heading_ne">Caminando hacia el nordeste</string>
+    <string name="directions_heading_e">Caminando hacia el este</string>
+    <string name="directions_heading_se">Caminando hacia el sudeste</string>
+    <string name="directions_heading_s">Caminando hacia el sur</string>
+    <string name="directions_heading_sw">Caminando hacia el suroeste</string>
+    <string name="directions_heading_w">Caminando hacia el oeste</string>
+    <string name="directions_heading_nw">Caminando hacia el noroeste</string>
 
     <string name="intersection_approaching_intersection">Aproximándose al cruce</string>
     <string name="directions_intersection_with_name_direction">Cruce con %1$s %2$s</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -106,6 +106,22 @@
     <string name="directions_direction_behind_to_the_left">takana vasemmalla</string>
     <string name="directions_direction_to_the_left">vasemmalla</string>
     <string name="directions_direction_ahead_to_the_left">edessä vasemmalla</string>
+    <string name="directions_traveling_n">Kuljetaan pohjoiseen</string>
+    <string name="directions_traveling_ne">Kuljetaan koilliseen</string>
+    <string name="directions_traveling_e">Kuljetaan itään</string>
+    <string name="directions_traveling_se">Kuljetaan kaakkoon</string>
+    <string name="directions_traveling_s">Kuljetaan etelään</string>
+    <string name="directions_traveling_sw">Kuljetaan lounaaseen</string>
+    <string name="directions_traveling_w">Kuljetaan länteen</string>
+    <string name="directions_traveling_nw">Kuljetaan luoteeseen</string>
+    <string name="directions_heading_n">Matkalla pohjoiseen</string>
+    <string name="directions_heading_ne">Matkalla koilliseen</string>
+    <string name="directions_heading_e">Matkalla itään</string>
+    <string name="directions_heading_se">Matkalla kaakkoon</string>
+    <string name="directions_heading_s">Matkalla etelään</string>
+    <string name="directions_heading_sw">Matkalla lounaaseen</string>
+    <string name="directions_heading_w">Matkalla länteen</string>
+    <string name="directions_heading_nw">Matkalla luoteeseen</string>
 
     <string name="intersection_approaching_intersection">Lähestytään risteystä</string>
     <string name="directions_intersection_with_name_direction">Risteys tien %1$s kanssa %2$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -106,6 +106,22 @@
     <string name="directions_direction_behind_to_the_left">derrière vous à gauche</string>
     <string name="directions_direction_to_the_left">à gauche</string>
     <string name="directions_direction_ahead_to_the_left">face à vous à gauche</string>
+    <string name="directions_traveling_n">Se déplaçant vers le nord</string>
+    <string name="directions_traveling_ne">Se déplaçant vers le nord-est</string>
+    <string name="directions_traveling_e">Se déplaçant vers l’est</string>
+    <string name="directions_traveling_se">Se déplaçant vers le sud-est</string>
+    <string name="directions_traveling_s">Se déplaçant vers le sud</string>
+    <string name="directions_traveling_sw">Se déplaçant vers le sud-ouest</string>
+    <string name="directions_traveling_w">Se déplaçant vers l’ouest</string>
+    <string name="directions_traveling_nw">Se déplaçant vers le nord-ouest</string>
+    <string name="directions_heading_n">En direction du nord</string>
+    <string name="directions_heading_ne">En direction du nord-est</string>
+    <string name="directions_heading_e">En direction de l’est</string>
+    <string name="directions_heading_se">En direction du sud-est</string>
+    <string name="directions_heading_s">En direction du sud</string>
+    <string name="directions_heading_sw">En direction du sud-ouest</string>
+    <string name="directions_heading_w">En direction de l’ouest</string>
+    <string name="directions_heading_nw">En direction du nord-ouest</string>
 
     <string name="intersection_approaching_intersection">Vous approchez d’une intersection</string>
     <string name="directions_intersection_with_name_direction">Intersection de %1$s %2$s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -106,6 +106,22 @@
     <string name="directions_direction_behind_to_the_left">indietro a sinistra</string>
     <string name="directions_direction_to_the_left">a sinistra</string>
     <string name="directions_direction_ahead_to_the_left">avanti a sinistra</string>
+    <string name="directions_traveling_n">Stai viaggiando verso nord</string>
+    <string name="directions_traveling_ne">Stai viaggiando verso nord est</string>
+    <string name="directions_traveling_e">Stai viaggiando verso est</string>
+    <string name="directions_traveling_se">Stai viaggiando verso sud est</string>
+    <string name="directions_traveling_s">Stai viaggiando verso sud</string>
+    <string name="directions_traveling_sw">Stai viaggiando verso sud ovest</string>
+    <string name="directions_traveling_w">Stai viaggiando verso ovest</string>
+    <string name="directions_traveling_nw">Stai viaggiando verso nord ovest</string>
+    <string name="directions_heading_n">Sei diretto verso nord</string>
+    <string name="directions_heading_ne">Sei diretto verso nord est</string>
+    <string name="directions_heading_e">Sei diretto verso est</string>
+    <string name="directions_heading_se">Sei diretto verso sud est</string>
+    <string name="directions_heading_s">Sei diretto verso sud</string>
+    <string name="directions_heading_sw">Sei diretto verso sud ovest</string>
+    <string name="directions_heading_w">Sei diretto verso ovest</string>
+    <string name="directions_heading_nw">Sei diretto verso nord ovest</string>
 
     <string name="intersection_approaching_intersection">Ti stai avvicinando all\'incrocio</string>
     <string name="directions_intersection_with_name_direction">Incrocio con %1$s %2$s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -107,6 +107,22 @@
     <string name="directions_direction_behind_to_the_left">左後方</string>
     <string name="directions_direction_to_the_left">左方向</string>
     <string name="directions_direction_ahead_to_the_left">左前方</string>
+    <string name="directions_traveling_n">北へ走行中</string>
+    <string name="directions_traveling_ne">北東へ走行中</string>
+    <string name="directions_traveling_e">東へ走行中</string>
+    <string name="directions_traveling_se">南東へ走行中</string>
+    <string name="directions_traveling_s">南へ走行中</string>
+    <string name="directions_traveling_sw">南西へ走行中</string>
+    <string name="directions_traveling_w">西へ走行中</string>
+    <string name="directions_traveling_nw">北西へ走行中</string>
+    <string name="directions_heading_n">北方向へ</string>
+    <string name="directions_heading_ne">北東方向へ</string>
+    <string name="directions_heading_e">東方向へ</string>
+    <string name="directions_heading_se">南東方向へ</string>
+    <string name="directions_heading_s">南方向へ</string>
+    <string name="directions_heading_sw">南西方向へ</string>
+    <string name="directions_heading_w">西方向へ</string>
+    <string name="directions_heading_nw">北西方向へ</string>
 
     <string name="intersection_approaching_intersection">まもなく交差点</string>
     <string name="directions_intersection_with_name_direction">%1$s との交差点が %2$s</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -106,6 +106,22 @@
     <string name="directions_direction_behind_to_the_left">bak deg og til venstre</string>
     <string name="directions_direction_to_the_left">til venstre</string>
     <string name="directions_direction_ahead_to_the_left">foran deg og til venstre</string>
+    <string name="directions_traveling_n">Kjører mot nord</string>
+    <string name="directions_traveling_ne">Kjører mot nordøst</string>
+    <string name="directions_traveling_e">Kjører mot øst</string>
+    <string name="directions_traveling_se">Kjører mot sørøst</string>
+    <string name="directions_traveling_s">Kjører mot sør</string>
+    <string name="directions_traveling_sw">Kjører mot sørvest</string>
+    <string name="directions_traveling_w">Kjører mot vest</string>
+    <string name="directions_traveling_nw">Kjører mot nordvest</string>
+    <string name="directions_heading_n">Du går mot nord</string>
+    <string name="directions_heading_ne">Du går mot nordøst</string>
+    <string name="directions_heading_e">Du går mot øst</string>
+    <string name="directions_heading_se">Du går mot sørøst</string>
+    <string name="directions_heading_s">Du går mot sør</string>
+    <string name="directions_heading_sw">Du går mot sørvest</string>
+    <string name="directions_heading_w">Du går mot vest</string>
+    <string name="directions_heading_nw">Du går mot nordvest</string>
 
     <string name="intersection_approaching_intersection">Du nærmer deg et veikryss</string>
     <string name="directions_intersection_with_name_direction">Veikryss med %1$s %2$s</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -107,6 +107,22 @@
     <string name="directions_direction_behind_to_the_left">achter u naar links</string>
     <string name="directions_direction_to_the_left">naar links</string>
     <string name="directions_direction_ahead_to_the_left">vóór u naar links</string>
+    <string name="directions_traveling_n">U rijdt naar het noorden</string>
+    <string name="directions_traveling_ne">U rijdt naar het noordoosten</string>
+    <string name="directions_traveling_e">U rijdt naar het oosten</string>
+    <string name="directions_traveling_se">U rijdt naar het zuidoosten</string>
+    <string name="directions_traveling_s">U rijdt naar het zuiden</string>
+    <string name="directions_traveling_sw">U rijdt naar het zuidwesten</string>
+    <string name="directions_traveling_w">U rijdt naar het westen</string>
+    <string name="directions_traveling_nw">U rijdt naar het noordwesten</string>
+    <string name="directions_heading_n">U loopt naar het noorden</string>
+    <string name="directions_heading_ne">U loopt naar het noordoosten</string>
+    <string name="directions_heading_e">U loopt naar het oosten</string>
+    <string name="directions_heading_se">U loopt naar het zuidoosten</string>
+    <string name="directions_heading_s">U loopt naar het zuiden</string>
+    <string name="directions_heading_sw">U loopt naar het zuidwesten</string>
+    <string name="directions_heading_w">U loopt naar het westen</string>
+    <string name="directions_heading_nw">U loopt naar het noordwesten</string>
 
     <string name="intersection_approaching_intersection">U nadert een kruispunt</string>
     <string name="directions_intersection_with_name_direction">Kruispunt met %1$s %2$s</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -107,6 +107,22 @@
     <string name="directions_direction_behind_to_the_left">atrás, à esquerda</string>
     <string name="directions_direction_to_the_left">à esquerda</string>
     <string name="directions_direction_ahead_to_the_left">à frente, à esquerda</string>
+    <string name="directions_traveling_n">Movendo-se para norte</string>
+    <string name="directions_traveling_ne">Movendo-se para nordeste</string>
+    <string name="directions_traveling_e">Movendo-se para leste</string>
+    <string name="directions_traveling_se">Movendo-se para sudeste</string>
+    <string name="directions_traveling_s">Movendo-se para sul</string>
+    <string name="directions_traveling_sw">Movendo-se para sudoeste</string>
+    <string name="directions_traveling_w">Movendo-se para oeste</string>
+    <string name="directions_traveling_nw">Movendo-se para noroeste</string>
+    <string name="directions_heading_n">Indo para norte</string>
+    <string name="directions_heading_ne">Indo para nordeste</string>
+    <string name="directions_heading_e">Indo para leste</string>
+    <string name="directions_heading_se">Indo para sudeste</string>
+    <string name="directions_heading_s">Indo para sul</string>
+    <string name="directions_heading_sw">Indo para sudoeste</string>
+    <string name="directions_heading_w">Indo para oeste</string>
+    <string name="directions_heading_nw">Indo para noroeste</string>
 
     <string name="intersection_approaching_intersection">Aproximando-se do cruzamento</string>
     <string name="directions_intersection_with_name_direction">Cruzamento com %1$s %2$s</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -106,6 +106,22 @@
     <string name="directions_direction_behind_to_the_left">bakom till vänster</string>
     <string name="directions_direction_to_the_left">till vänster</string>
     <string name="directions_direction_ahead_to_the_left">framme till vänster</string>
+    <string name="directions_traveling_n">Reser norrut</string>
+    <string name="directions_traveling_ne">Reser mot nordost</string>
+    <string name="directions_traveling_e">Reser österut</string>
+    <string name="directions_traveling_se">Reser mot sydost</string>
+    <string name="directions_traveling_s">Reser söderut</string>
+    <string name="directions_traveling_sw">Reser mot sydväst</string>
+    <string name="directions_traveling_w">Reser västerut</string>
+    <string name="directions_traveling_nw">Reser mot nordväst</string>
+    <string name="directions_heading_n">På väg norrut</string>
+    <string name="directions_heading_ne">På väg mot nordost</string>
+    <string name="directions_heading_e">På väg österut</string>
+    <string name="directions_heading_se">På väg mot sydost</string>
+    <string name="directions_heading_s">På väg söderut</string>
+    <string name="directions_heading_sw">På väg mot sydväst</string>
+    <string name="directions_heading_w">På väg västerut</string>
+    <string name="directions_heading_nw">På väg mot nordväst</string>
 
     <string name="intersection_approaching_intersection">Du närmar dig en vägkorsning</string>
     <string name="directions_intersection_with_name_direction">Vägkorsning med %1$s %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,22 @@
     <string name="directions_direction_behind_to_the_left">behind to the left</string>
     <string name="directions_direction_to_the_left">to the left</string>
     <string name="directions_direction_ahead_to_the_left">ahead to the left</string>
+    <string name="directions_traveling_n">Travelling north</string>
+    <string name="directions_traveling_ne">Travelling northeast</string>
+    <string name="directions_traveling_e">Travelling east</string>
+    <string name="directions_traveling_se">Travelling southeast</string>
+    <string name="directions_traveling_s">Travelling south</string>
+    <string name="directions_traveling_sw">Travelling southwest</string>
+    <string name="directions_traveling_w">Travelling west</string>
+    <string name="directions_traveling_nw">Travelling northwest</string>
+    <string name="directions_heading_n">Heading north</string>
+    <string name="directions_heading_ne">Heading northeast</string>
+    <string name="directions_heading_e">Heading east</string>
+    <string name="directions_heading_se">Heading southeast</string>
+    <string name="directions_heading_s">Heading south</string>
+    <string name="directions_heading_sw">Heading southwest</string>
+    <string name="directions_heading_w">Heading west</string>
+    <string name="directions_heading_nw">Heading northwest</string>
 
     <string name="intersection_approaching_intersection">Approaching intersection</string>
     <string name="directions_intersection_with_name_direction">Intersection with %1$s %2$s</string>


### PR DESCRIPTION
We currently only have translation strings for "Facing $direction" for "My Location" as we are pretending the user is stationary as we don't currently detect if the user is stationary, walking or in a vehicle. This PR adds the basic strings for "Heading $direction" and "Travelling $direction" in anticipation of getting the Activity Recognition API working correctly. 
"Facing" = stationary 
"Heading" = walking 
"Travelling" = in a vehicle
I'll add the "Travelling north along $road" and "Heading north along $road" strings in another PR