### PR TITLE
Improve maplibre usability

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
@@ -86,9 +86,9 @@ fun HomeContent(
                     beaconLocation = beaconLocation,
                     mapCenter = LatLng(latitude, longitude),
                     allowScrolling = false,
-                    mapViewRotation = heading,
+                    mapViewRotation = 0.0F,
                     userLocation = LatLng(latitude, longitude),
-                    userSymbolRotation = 0.0F,
+                    userSymbolRotation = heading,
                     onMapLongClick = onMapLongClick,
                     onMarkerClick = onMarkerClick,
                     tileGridGeoJson = tileGridGeoJson

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/MapViewHelper.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/MapViewHelper.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import org.maplibre.android.MapLibre
+import org.maplibre.android.maps.MapLibreMapOptions.createFromAttributes
 import org.maplibre.android.maps.MapView
 
 @Composable
@@ -16,7 +17,11 @@ fun rememberMapViewWithLifecycle(disposeCode : (map : MapView) -> Unit): MapView
     val context = LocalContext.current
     val mapView = remember {
         MapLibre.getInstance(context)
-        return@remember MapView(context)
+        val options = createFromAttributes(context)
+        options.apply {
+            pixelRatio(4.0F)
+        }
+        return@remember MapView(context, options)
     }
 
     val lifecycle = LocalLifecycleOwner.current.lifecycle


### PR DESCRIPTION
There were a couple of issues with the way in which our GUI map was rendered:

1. The icons, text and roads were very small and zooming in didn't make them larger. The fix is to set the `pixelRatio` which means that the map is now rendered as if the DPI were a quarter of it's previous value and then scaled up. This gives a slightly "soft" look, but at least everything is larger.
2. Rotating the map with the phone wasn't performant on complex map tiles. The fix is to switch to rotate only the icon showing the user location and to keep the map with North at the top. This matches the iOS behaviour.