### PR TITLE
Remove trimming of resource locales from build.gradle.kts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,8 +67,6 @@ android {
                 cppFlags += ""
             }
         }
-
-        resourceConfigurations += listOf("da", "de", "el", "en", "es", "fi", "fr", "it", "ja", "nb", "nl", "pt", "sv")
     }
 
     buildTypes {


### PR DESCRIPTION
Originally this PR was written as follows:

> Since Android 13 it's been possible to set the app language from the App Info dialog for any app. Although we support as far back as Android 11, the app will still use the system configured language just not a different language for the app prior to Android 13. This change removes our in-app language configuration and leaves it to the System. It also fixes support for Brazil, UK and Canada regions where the resources were being stripped out due to not being in the list in resourceConfigurations in build.gradle.kts. The behaviour has been tested on API 35 and API 30 and both work correctly.

However, I've changed it so that it's now just the minimal change to get the regional languages working.