### PR TITLE
Prevent drawing behind status bar

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
@@ -1,7 +1,11 @@
 package org.scottishtecharmy.soundscape.screens.home
 
 import android.util.Log
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -80,7 +84,8 @@ fun HomeScreen(
             val uiState = settingsViewModel.state.collectAsStateWithLifecycle()
             Settings(
                 onNavigateUp = { navController.navigateUp() },
-                uiState = uiState.value
+                uiState = uiState.value,
+                modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing),
             )
         }
 
@@ -105,6 +110,7 @@ fun HomeScreen(
                 latitude = location.value?.latitude,
                 longitude = location.value?.longitude,
                 heading = heading.value,
+                modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing),
             )
         }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
@@ -46,6 +46,7 @@ fun LocationDetailsScreen(
                     heading : Float,
                     onNavigateUp: () -> Unit,
                     viewModel: LocationDetailsViewModel = hiltViewModel(),
+                    modifier: Modifier = Modifier
 ) {
     LocationDetails(
         onNavigateUp = onNavigateUp,
@@ -58,7 +59,8 @@ fun LocationDetailsScreen(
         },
         latitude = latitude,
         longitude = longitude,
-        heading = heading
+        heading = heading,
+        modifier = modifier
     )
 }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
@@ -37,11 +37,12 @@ fun SettingsPreview() {
 @Composable
 fun Settings(
     onNavigateUp: () -> Unit,
-    uiState : SettingsViewModel.SettingsUiState)
+    uiState: SettingsViewModel.SettingsUiState,
+    modifier: Modifier = Modifier,
+)
 {
     ProvidePreferenceLocals {
-        LazyColumn {
-
+        LazyColumn (modifier = modifier){
             stickyHeader {
                 Surface {
                     CustomAppBar(stringResource(R.string.general_alert_settings),


### PR DESCRIPTION
When an app is running on Android 15 edge-to-edge mode is enabled by default. As a result the Settings and LocationDetails screens on my Pixel 8 are currently drawing behind the system status bar. This change fixes that - though I'm not sure on what the convention is for setting and passing Modifier?