### PR TITLE
Keep service alive when app is closed #305

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -178,6 +178,9 @@ class SoundscapeService : MediaSessionService() {
         }
     }
 
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        Log.d(TAG, "onTaskRemoved for service - ignoring, as we want to keep running")
+    }
     override fun onDestroy() {
         // If _mediaSession is not null, run the following block
         mediaSession?.run {


### PR DESCRIPTION
This trivial change stops the service from shutting down when the app is closed. That behaviour came in when we added MediaSessionService and by ignoring the onTaskRemoved call we can revert to the previous behaviour.