### PR TITLE
Centralize intersection description code

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/IntersectionUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/IntersectionUtils.kt
@@ -1,0 +1,211 @@
+package org.scottishtecharmy.soundscape.geoengine.callouts
+
+import android.content.Context
+import android.util.Log
+import org.scottishtecharmy.soundscape.R
+import org.scottishtecharmy.soundscape.geoengine.PositionedString
+import org.scottishtecharmy.soundscape.geoengine.filters.CalloutHistory
+import org.scottishtecharmy.soundscape.geoengine.filters.TrackedCallout
+import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
+import org.scottishtecharmy.soundscape.geoengine.utils.RelativeDirections
+import org.scottishtecharmy.soundscape.geoengine.utils.checkWhetherIntersectionIsOfInterest
+import org.scottishtecharmy.soundscape.geoengine.utils.getFovTrianglePoints
+import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionRoadNames
+import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionRoadNamesRelativeDirections
+import org.scottishtecharmy.soundscape.geoengine.utils.getNearestRoad
+import org.scottishtecharmy.soundscape.geoengine.utils.getRelativeDirectionLabel
+import org.scottishtecharmy.soundscape.geoengine.utils.getRelativeDirectionsPolygons
+import org.scottishtecharmy.soundscape.geoengine.utils.getRoadBearingToIntersection
+import org.scottishtecharmy.soundscape.geoengine.utils.removeDuplicates
+import org.scottishtecharmy.soundscape.geoengine.utils.sortedByDistanceTo
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
+
+enum class ComplexIntersectionApproach {
+    INTERSECTION_WITH_MOST_OSM_IDS,
+    NEAREST_NON_TRIVIAL_INTERSECTION
+}
+
+data class IntersectionDescription(val roads: FeatureCollection = FeatureCollection(),
+                                   val location: LngLatAlt = LngLatAlt(),
+                                   val name: String = "",
+                                   val fovBaseLocation: LngLatAlt = LngLatAlt())
+
+/**
+ * getIntersectionDescriptionFromFov returns a description of the 'best' intersection within the
+ * field of view. The description includes the roads that join the intersection, the location of the
+ * intersection and the name of the intersection.
+ *
+ * @param roadTree A FeatureTree of roads to use
+ * @param intersectionTree A FeatureTree of intersections to use
+ * @param currentLocation The location at the base of the FOV as a LngLatAlt
+ * @param deviceHeading The direction for the FOV triangle as a Double
+ * @param fovDistance The distance that the FOV triangle covers in metres as a Double
+ * @param approach The algorithm used to pick the best intersection.
+ *
+ * @return An IntersectionDescription containing all the data required for callouts to describe the
+ * intersection.
+ */
+fun getIntersectionDescriptionFromFov(roadTree: FeatureTree,
+                                      intersectionTree: FeatureTree,
+                                      currentLocation: LngLatAlt,
+                                      deviceHeading: Double,
+                                      fovDistance: Double,
+                                      approach: ComplexIntersectionApproach
+) : IntersectionDescription {
+
+    // Create FOV triangle
+    val points = getFovTrianglePoints(currentLocation, deviceHeading, fovDistance)
+
+    // Find roads within FOV
+    val fovRoads = roadTree.generateFeatureCollectionWithinTriangle(
+        currentLocation, points.left, points.right)
+    if(fovRoads.features.isEmpty()) return IntersectionDescription()
+
+    // Find intersections within FOV
+    val fovIntersections = intersectionTree.generateFeatureCollectionWithinTriangle(
+        currentLocation, points.left, points.right)
+    if(fovIntersections.features.isEmpty()) return IntersectionDescription()
+
+    // Sort the FOV intersections by distance
+    val sortedFovIntersections = sortedByDistanceTo(currentLocation, fovIntersections)
+
+    // Which road are we nearest to? In order to allow any road (including those outwith the FOV
+    // triangle as it could be 1m behind us) we pass in the complete road FeatureTree.
+    val nearestRoad = getNearestRoad(currentLocation, roadTree)
+
+    // Inspect each intersection so as to skip trivial ones
+    val nonTrivialIntersections = FeatureCollection()
+    for (i in 0 until sortedFovIntersections.features.size) {
+        // Get the roads for the intersection
+        val intersectionRoads = getIntersectionRoadNames(sortedFovIntersections.features[i], fovRoads)
+        // Skip 'simple' intersections e.g. ones where the only roads involved have the same name
+        if(checkWhetherIntersectionIsOfInterest(intersectionRoads, nearestRoad)) {
+            nonTrivialIntersections.addFeature(sortedFovIntersections.features[i])
+        }
+    }
+    if(nonTrivialIntersections.features.isEmpty()) {
+        return IntersectionDescription()
+    }
+
+    // We have two different approaches to picking the intersection we're interested in
+    val intersection: Feature? = when(approach) {
+        ComplexIntersectionApproach.INTERSECTION_WITH_MOST_OSM_IDS -> {
+            // Pick the intersection feature with the most osm_ids and describe that.
+            nonTrivialIntersections.features.maxByOrNull { feature ->
+                (feature.foreign?.get("osm_ids") as? List<*>)?.size ?: 0
+            }
+        }
+
+        ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION -> {
+            // Use the nearest "checked" intersection to the device location?
+            nonTrivialIntersections.features[0]
+        }
+    }
+
+    // Use the nearest intersection, but remove duplicated OSM ids from it (those which loop back)
+    val nearestIntersection = removeDuplicates(sortedFovIntersections.features[0])
+
+    // Find the bearing that we're coming in at - measured to the nearest intersection
+    val nearestRoadBearing = getRoadBearingToIntersection(nearestIntersection, nearestRoad, deviceHeading)
+
+    // Create a set of relative direction polygons
+    val intersectionLocation = intersection!!.geometry as Point
+    val relativeDirections = getRelativeDirectionsPolygons(
+        intersectionLocation.coordinates,
+        nearestRoadBearing,
+        5.0,
+        RelativeDirections.COMBINED
+    )
+
+    val intersectionNameProperty = intersection.properties?.get("name")
+    val intersectionName = if(intersectionNameProperty == null)
+        ""
+    else
+        intersectionNameProperty as String
+
+    // And use the polygons to describe the roads at the intersection
+    val intersectionRoadNames = getIntersectionRoadNames(intersection, fovRoads)
+    return IntersectionDescription(
+        getIntersectionRoadNamesRelativeDirections(
+                intersectionRoadNames,
+                intersection,
+                relativeDirections
+        ),
+        intersectionLocation.coordinates,
+        intersectionName,
+        currentLocation
+    )
+}
+
+/**
+ * addIntersectionCalloutFromDescription adds a callout to the results list for the intersection
+ * described in the parameters. This will become more configurable e.g. whether to include the
+ * distance or not.
+ *
+ * @param description The description of the intersection to callout
+ * @param localizedContext A context for obtaining localized strings
+ * @param results The list of callouts that is appended to
+ * @param calloutHistory An optional CalloutHistory to use so as to filter out recently played out
+ * callouts
+ */
+fun addIntersectionCalloutFromDescription(
+    description: IntersectionDescription,
+    localizedContext: Context,
+    results: MutableList<PositionedString>,
+    calloutHistory: CalloutHistory? = null
+) {
+    if(description.roads.features.isEmpty()) return
+
+    if(calloutHistory != null) {
+        val callout =
+            TrackedCallout(
+                description.name,
+                description.location,
+                isPoint = true,
+                isGeneric = false,
+            )
+        if (calloutHistory.find(callout)) {
+            Log.d("Intersections", "Discard ${callout.callout} as in history")
+            return
+        } else {
+            calloutHistory.add(callout)
+        }
+    }
+
+    // Report distance
+    results.add(
+        PositionedString(
+            "${localizedContext.getString(R.string.intersection_approaching_intersection)} ${
+                localizedContext.getString(
+                    R.string.distance_format_meters,
+                    description.fovBaseLocation.distance(description.location).toInt().toString(),
+                )
+            }",
+        ),
+    )
+
+    // Report roads
+    for (feature in description.roads.features) {
+        val direction = feature.properties?.get("Direction").toString().toIntOrNull()
+
+        // Don't call out the road we are on (0) as part of the intersection
+        if (direction != null && direction != 0) {
+            val relativeDirectionString = getRelativeDirectionLabel(
+                localizedContext,
+                direction
+            )
+            if (feature.properties?.get("name") != null) {
+                val intersectionCallout =
+                    localizedContext.getString(
+                        R.string.directions_intersection_with_name_direction,
+                        feature.properties?.get("name"),
+                        relativeDirectionString,
+                    )
+                results.add(PositionedString(intersectionCallout))
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/CompassDirections.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/CompassDirections.kt
@@ -4,35 +4,169 @@ package org.scottishtecharmy.soundscape.geoengine.utils
 import android.content.Context
 import org.scottishtecharmy.soundscape.R
 
-fun getCompassLabelFacingDirection(localizedContext: Context, degrees: Int, locale: java.util.Locale): String{
-    return when (degrees) {
-        in 338..360, in 0..22 -> localizedContext.getString(R.string.directions_facing_n)
-        in 23..67 -> localizedContext.getString(R.string.directions_facing_ne)
-        in 68..112 -> localizedContext.getString(R.string.directions_facing_e)
-        in 113..157 -> localizedContext.getString(R.string.directions_facing_se)
-        in 158..202 -> localizedContext.getString(R.string.directions_facing_s)
-        in 203..247 -> localizedContext.getString(R.string.directions_facing_sw)
-        in 248..292 -> localizedContext.getString(R.string.directions_facing_w)
-        in 293..337 -> localizedContext.getString(R.string.directions_facing_nw)
-        else -> ""
+fun getCompassLabelFacingDirection(localizedContext: Context,
+                                   degrees: Int,
+                                   inMotion: Boolean,
+                                   inVehicle: Boolean
+): String{
+    if(!inMotion) {
+        return when (degrees) {
+            in 338..360, in 0..22 -> localizedContext.getString(R.string.directions_facing_n)
+            in 23..67 -> localizedContext.getString(R.string.directions_facing_ne)
+            in 68..112 -> localizedContext.getString(R.string.directions_facing_e)
+            in 113..157 -> localizedContext.getString(R.string.directions_facing_se)
+            in 158..202 -> localizedContext.getString(R.string.directions_facing_s)
+            in 203..247 -> localizedContext.getString(R.string.directions_facing_sw)
+            in 248..292 -> localizedContext.getString(R.string.directions_facing_w)
+            in 293..337 -> localizedContext.getString(R.string.directions_facing_nw)
+            else -> ""
+        }
+    } else if(inVehicle) {
+        return when (degrees) {
+            in 338..360, in 0..22 -> localizedContext.getString(R.string.directions_traveling_n)
+            in 23..67 -> localizedContext.getString(R.string.directions_traveling_ne)
+            in 68..112 -> localizedContext.getString(R.string.directions_traveling_e)
+            in 113..157 -> localizedContext.getString(R.string.directions_traveling_se)
+            in 158..202 -> localizedContext.getString(R.string.directions_traveling_s)
+            in 203..247 -> localizedContext.getString(R.string.directions_traveling_sw)
+            in 248..292 -> localizedContext.getString(R.string.directions_traveling_w)
+            in 293..337 -> localizedContext.getString(R.string.directions_traveling_nw)
+            else -> ""
+        }
+    } else {
+        return when (degrees) {
+            in 338..360, in 0..22 -> localizedContext.getString(R.string.directions_heading_n)
+            in 23..67 -> localizedContext.getString(R.string.directions_heading_ne)
+            in 68..112 -> localizedContext.getString(R.string.directions_heading_e)
+            in 113..157 -> localizedContext.getString(R.string.directions_heading_se)
+            in 158..202 -> localizedContext.getString(R.string.directions_heading_s)
+            in 203..247 -> localizedContext.getString(R.string.directions_heading_sw)
+            in 248..292 -> localizedContext.getString(R.string.directions_heading_w)
+            in 293..337 -> localizedContext.getString(R.string.directions_heading_nw)
+            else -> ""
+        }
     }
 }
 
-fun getCompassLabelFacingDirectionAlong(localizedContext: Context, degrees: Int, placeholder: String, locale: java.util.Locale):String{
-    return when (degrees) {
-        in 338 .. 360, in 0 .. 22 -> localizedContext.getString(R.string.directions_along_facing_n, placeholder)
-        in 23 .. 67 -> localizedContext.getString(R.string.directions_along_facing_ne, placeholder)
-        in 68 .. 112 -> localizedContext.getString(R.string.directions_along_facing_e, placeholder)
-        in 113 .. 157 -> localizedContext.getString(R.string.directions_along_facing_se, placeholder)
-        in 158 .. 202 -> localizedContext.getString(R.string.directions_along_facing_s, placeholder)
-        in 203 .. 247 -> localizedContext.getString(R.string.directions_along_facing_sw, placeholder)
-        in 248 .. 292 -> localizedContext.getString(R.string.directions_along_facing_w, placeholder)
-        in 293 .. 337 -> localizedContext.getString(R.string.directions_along_facing_nw, placeholder)
-        else -> ""
+fun getCompassLabelFacingDirectionAlong(localizedContext: Context,
+                                        degrees: Int,
+                                        placeholder: String,
+                                        inMotion: Boolean,
+                                        inVehicle: Boolean
+):String{
+    if(!inMotion) {
+        return when (degrees) {
+            in 338..360, in 0..22 -> localizedContext.getString(
+                R.string.directions_along_facing_n,
+                placeholder
+            )
+            in 23..67 -> localizedContext.getString(
+                R.string.directions_along_facing_ne,
+                placeholder
+            )
+            in 68..112 -> localizedContext.getString(
+                R.string.directions_along_facing_e,
+                placeholder
+            )
+            in 113..157 -> localizedContext.getString(
+                R.string.directions_along_facing_se,
+                placeholder
+            )
+            in 158..202 -> localizedContext.getString(
+                R.string.directions_along_facing_s,
+                placeholder
+            )
+            in 203..247 -> localizedContext.getString(
+                R.string.directions_along_facing_sw,
+                placeholder
+            )
+            in 248..292 -> localizedContext.getString(
+                R.string.directions_along_facing_w,
+                placeholder
+            )
+            in 293..337 -> localizedContext.getString(
+                R.string.directions_along_facing_nw,
+                placeholder
+            )
+            else -> ""
+        }
+    } else if(inVehicle) {
+        return when (degrees) {
+            in 338..360, in 0..22 -> localizedContext.getString(
+                R.string.directions_along_traveling_n,
+                placeholder
+            )
+            in 23..67 -> localizedContext.getString(
+                R.string.directions_along_traveling_ne,
+                placeholder
+            )
+            in 68..112 -> localizedContext.getString(
+                R.string.directions_along_traveling_e,
+                placeholder
+            )
+            in 113..157 -> localizedContext.getString(
+                R.string.directions_along_traveling_se,
+                placeholder
+            )
+            in 158..202 -> localizedContext.getString(
+                R.string.directions_along_traveling_s,
+                placeholder
+            )
+            in 203..247 -> localizedContext.getString(
+                R.string.directions_along_traveling_sw,
+                placeholder
+            )
+            in 248..292 -> localizedContext.getString(
+                R.string.directions_along_traveling_w,
+                placeholder
+            )
+            in 293..337 -> localizedContext.getString(
+                R.string.directions_along_traveling_nw,
+                placeholder
+            )
+            else -> ""
+        }
+    } else {
+        return when (degrees) {
+            in 338..360, in 0..22 -> localizedContext.getString(
+                R.string.directions_along_heading_n,
+                placeholder
+            )
+            in 23..67 -> localizedContext.getString(
+                R.string.directions_along_heading_ne,
+                placeholder
+            )
+            in 68..112 -> localizedContext.getString(
+                R.string.directions_along_heading_e,
+                placeholder
+            )
+            in 113..157 -> localizedContext.getString(
+                R.string.directions_along_heading_se,
+                placeholder
+            )
+            in 158..202 -> localizedContext.getString(
+                R.string.directions_along_heading_s,
+                placeholder
+            )
+            in 203..247 -> localizedContext.getString(
+                R.string.directions_along_heading_sw,
+                placeholder
+            )
+            in 248..292 -> localizedContext.getString(
+                R.string.directions_along_heading_w,
+                placeholder
+            )
+            in 293..337 -> localizedContext.getString(
+                R.string.directions_along_heading_nw,
+                placeholder
+            )
+            else -> ""
+        }
     }
 }
 
-fun getRelativeDirectionLabel(localizedContext: Context, relativeDirection: Int, locale: java.util.Locale): String{
+fun getRelativeDirectionLabel(localizedContext: Context,
+                              relativeDirection: Int): String{
     return when (relativeDirection) {
         0 -> localizedContext.getString(R.string.directions_direction_behind)
         1 -> localizedContext.getString(R.string.directions_direction_behind_to_the_left)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/FeatureTree.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/FeatureTree.kt
@@ -426,6 +426,7 @@ class FeatureTree(featureCollection: FeatureCollection?) {
 
         val results =
             nearestWithinTriangle(arrayListOf(location, left, right), 1) ?: return null
+        if(results.count() == 0) return null
 
         return results.first().value()
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/IntersectionUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/IntersectionUtils.kt
@@ -1,2 +1,0 @@
-package org.scottishtecharmy.soundscape.geoengine.utils
-

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileUtils.kt
@@ -567,54 +567,18 @@ fun getIntersectionRoadNames(
  * Roads can contain crossings which are Points not LineStrings.
  * @param currentLocation
  * Location of device.
- * @param roadFeatureCollection
- * The intersection feature collection that contains the intersections we want to test.
+ * @param searchTree
+ * The FeatureTree to search for the nearest road.
  * @return A Feature that is the nearest road.
  */
 fun getNearestRoad(
     currentLocation: LngLatAlt,
-    roadFeatureCollection: FeatureCollection
+    searchTree: FeatureTree
 ): Feature? {
 
-    //TODO I have no idea if roads can also be represented with MultiLineStrings.
-    // In which case this will fail. Need to have a look at some tiles with motorways/dual carriageways
-
-    var maxDistanceToRoad = Int.MAX_VALUE.toDouble()
-    var nearestRoad : Feature? = null
-
-    for (feature in roadFeatureCollection) {
-        if (feature.geometry.type == "LineString") {
-            val distanceToRoad = distanceToLineString(
-                currentLocation,
-                (feature.geometry as LineString)
-            )
-            if (distanceToRoad < maxDistanceToRoad) {
-                nearestRoad = feature
-                maxDistanceToRoad = distanceToRoad
-            }
-        } else if (feature.geometry.type == "Polygon") {
-            val distanceToRoad = distanceToPolygon(
-                currentLocation,
-                (feature.geometry as Polygon)
-            )
-            if (distanceToRoad < maxDistanceToRoad) {
-                nearestRoad = feature
-                maxDistanceToRoad = distanceToRoad
-            }
-        }  else {
-            val distanceToRoad = currentLocation.distance(
-                LngLatAlt((feature.geometry as Point).coordinates.latitude,
-                          (feature.geometry as Point).coordinates.longitude)
-            )
-            if (distanceToRoad < maxDistanceToRoad) {
-                nearestRoad = feature
-                maxDistanceToRoad = distanceToRoad
-            }
-        }
-    }
-
-    // TODO As the distance to the road has already been calculated
-    //  perhaps we could insert the distance to the road as a property/foreign member of the Feature?
+    // This is just the nearest road. In the future, the algorithm will get almost certainly become
+    // more elaborate.
+    val nearestRoad = searchTree.getNearestFeature(currentLocation)
     return nearestRoad
 }
 

--- a/app/src/test/java/org/scottishtecharmy/soundscape/ComplexIntersections.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/ComplexIntersections.kt
@@ -3,24 +3,14 @@ package org.scottishtecharmy.soundscape
 import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
+import org.scottishtecharmy.soundscape.geoengine.callouts.ComplexIntersectionApproach
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
-import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
-import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
-import org.scottishtecharmy.soundscape.geoengine.utils.RelativeDirections
-import org.scottishtecharmy.soundscape.geoengine.utils.checkWhetherIntersectionIsOfInterest
-import org.scottishtecharmy.soundscape.geoengine.utils.generateDebugFovGeoJson
-import org.scottishtecharmy.soundscape.geoengine.utils.getFovFeatureCollection
-import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionRoadNames
-import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionRoadNamesRelativeDirections
 import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionsFeatureCollectionFromTileFeatureCollection
-import org.scottishtecharmy.soundscape.geoengine.utils.getNearestRoad
-import org.scottishtecharmy.soundscape.geoengine.utils.getRelativeDirectionsPolygons
-import org.scottishtecharmy.soundscape.geoengine.utils.getRoadBearingToIntersection
+import org.scottishtecharmy.soundscape.geoengine.callouts.getIntersectionDescriptionFromFov
 import org.scottishtecharmy.soundscape.geoengine.utils.getRoadsFeatureCollectionFromTileFeatureCollection
-import org.scottishtecharmy.soundscape.geoengine.utils.sortedByDistanceTo
 
 class ComplexIntersections {
 
@@ -45,101 +35,21 @@ class ComplexIntersections {
             getRoadsFeatureCollectionFromTileFeatureCollection(
                 featureCollectionTest!!
             )
-        // create FOV to pickup the roads
-        val fovRoadsFeatureCollection = getFovFeatureCollection(
-            currentLocation,
-            deviceHeading,
-            fovDistance,
-            FeatureTree(testRoadsCollectionFromTileFeatureCollection)
-        )
-//        generateDebugFovGeoJson(currentLocation, deviceHeading, fovDistance, testRoadsCollectionFromTileFeatureCollection)
 
         // Get the intersections from the tile
         val testIntersectionsCollectionFromTileFeatureCollection =
             getIntersectionsFeatureCollectionFromTileFeatureCollection(
                 featureCollectionTest
             )
-        // Create a FOV triangle to pick up the intersections
-        val fovIntersectionsFeatureCollection = getFovFeatureCollection(
+
+        val roadRelativeDirections = getIntersectionDescriptionFromFov(
+            FeatureTree(testRoadsCollectionFromTileFeatureCollection),
+            FeatureTree(testIntersectionsCollectionFromTileFeatureCollection),
             currentLocation,
             deviceHeading,
             fovDistance,
-            FeatureTree(testIntersectionsCollectionFromTileFeatureCollection)
-        )
-        generateDebugFovGeoJson(currentLocation, deviceHeading, fovDistance, testIntersectionsCollectionFromTileFeatureCollection)
+            ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION).roads
 
-        val roadsFOVString =
-            moshi.adapter(FeatureCollection::class.java).toJson(fovRoadsFeatureCollection)
-        println("Roads in FOV: $roadsFOVString")
-        val intersectionsFOVString =
-            moshi.adapter(FeatureCollection::class.java).toJson(fovIntersectionsFeatureCollection)
-        println("Intersections in FOV: $intersectionsFOVString")
-
-        // I will need a feature collection of all the intersections in the FOV sorted by distance to the current location
-        val intersectionsSortedByDistance = sortedByDistanceTo(
-            currentLocation,
-            fovIntersectionsFeatureCollection
-        )
-        val intersectionsSortedByDistanceString =
-            moshi.adapter(FeatureCollection::class.java).toJson(intersectionsSortedByDistance)
-        println("Intersections in FOV sorted by distance: $intersectionsSortedByDistanceString")
-        println("Number of intersections in FOV: ${intersectionsSortedByDistance.features.size}")
-
-        val testNearestRoad = getNearestRoad(currentLocation, fovRoadsFeatureCollection)
-        val intersectionsNeedsFurtherCheckingFC = FeatureCollection()
-
-        for (i in 0 until intersectionsSortedByDistance.features.size) {
-            val intersectionRoadNames = getIntersectionRoadNames(intersectionsSortedByDistance.features[i], fovRoadsFeatureCollection)
-            val intersectionsNeedsFurtherChecking = checkWhetherIntersectionIsOfInterest(intersectionRoadNames, testNearestRoad)
-            if(intersectionsNeedsFurtherChecking) {
-                intersectionsNeedsFurtherCheckingFC.addFeature(intersectionsSortedByDistance.features[i])
-            }
-        }
-        println("Intersections that need further checking: ${intersectionsNeedsFurtherCheckingFC.features.size}")
-
-        // Approach 1: find the intersection feature with the most osm_ids and use that?
-        // The code doesn't give us the correct result as it jumps to the wrong/next intersection
-        /*val featureWithMostOsmIds: Feature? = intersectionsNeedsFurtherCheckingFC.features.maxByOrNull {
-                feature ->
-            (feature.foreign?.get("osm_ids") as? List<*>)?.size ?: 0
-        }
-        val newIntersectionFeatureCollection = FeatureCollection()
-        if (featureWithMostOsmIds != null) {
-            newIntersectionFeatureCollection.addFeature(featureWithMostOsmIds)
-        }*/
-
-        // Approach 2: Use the nearest "checked" intersection to the device location?
-        val intersectionsToCheckSortedByDistance = sortedByDistanceTo(
-            currentLocation,
-            intersectionsNeedsFurtherCheckingFC
-        )
-        val nearestCheckedIntersection = intersectionsToCheckSortedByDistance.features[0]
-
-
-        val nearestIntersection = FeatureTree(fovIntersectionsFeatureCollection).getNearestFeature(currentLocation)
-        val nearestRoadBearing = getRoadBearingToIntersection(nearestIntersection, testNearestRoad, deviceHeading)
-        val intersectionLocation = nearestCheckedIntersection.geometry as Point
-        val intersectionRelativeDirections = getRelativeDirectionsPolygons(
-            LngLatAlt(intersectionLocation.coordinates.longitude,
-                intersectionLocation.coordinates.latitude),
-            nearestRoadBearing,
-            //fovDistance,
-            5.0,
-            RelativeDirections.COMBINED
-        )
-        val relativeDirectionsString =
-            moshi.adapter(FeatureCollection::class.java).toJson(intersectionRelativeDirections)
-        println("relative directions polygons: $relativeDirectionsString")
-
-        val intersectionRoadNames = getIntersectionRoadNames(nearestCheckedIntersection, fovRoadsFeatureCollection)
-        val intersectionRoadNamesString =
-            moshi.adapter(FeatureCollection::class.java).toJson(intersectionRoadNames)
-        println("Intersection roads: $intersectionRoadNamesString")
-        val roadRelativeDirections = getIntersectionRoadNamesRelativeDirections(
-            intersectionRoadNames,
-            nearestCheckedIntersection,
-            intersectionRelativeDirections
-        )
 
         Assert.assertEquals(3, roadRelativeDirections.features.size )
 
@@ -172,96 +82,19 @@ class ComplexIntersections {
             getRoadsFeatureCollectionFromTileFeatureCollection(
                 featureCollectionTest!!
             )
-        // create FOV to pickup the roads
-        val fovRoadsFeatureCollection = getFovFeatureCollection(
-            currentLocation,
-            deviceHeading,
-            fovDistance,
-            FeatureTree(testRoadsCollectionFromTileFeatureCollection)
-        )
+
         // Get the intersections from the tile
         val testIntersectionsCollectionFromTileFeatureCollection =
             getIntersectionsFeatureCollectionFromTileFeatureCollection(
                 featureCollectionTest
             )
-        // Create a FOV triangle to pick up the intersections
-        val fovIntersectionsFeatureCollection = getFovFeatureCollection(
+        val roadRelativeDirections = getIntersectionDescriptionFromFov(
+            FeatureTree(testRoadsCollectionFromTileFeatureCollection),
+            FeatureTree(testIntersectionsCollectionFromTileFeatureCollection),
             currentLocation,
             deviceHeading,
             fovDistance,
-            FeatureTree(testIntersectionsCollectionFromTileFeatureCollection)
-        )
-
-        val roadsFOVString =
-            moshi.adapter(FeatureCollection::class.java).toJson(fovRoadsFeatureCollection)
-        println("Roads in FOV: $roadsFOVString")
-        val intersectionsFOVString =
-            moshi.adapter(FeatureCollection::class.java).toJson(fovIntersectionsFeatureCollection)
-        println("Intersections in FOV: $intersectionsFOVString")
-        // TODO A lot more processing to make sense of the data above to enable a callout to the user...
-
-        // I will need a feature collection of all the intersections in the FOV sorted by distance to the current location
-        val intersectionsSortedByDistance = sortedByDistanceTo(
-            currentLocation,
-            fovIntersectionsFeatureCollection
-        )
-        val intersectionsSortedByDistanceString =
-            moshi.adapter(FeatureCollection::class.java).toJson(intersectionsSortedByDistance)
-        println("Intersections in FOV sorted by distance: $intersectionsSortedByDistanceString")
-        println("Number of intersections in FOV: ${intersectionsSortedByDistance.features.size}")
-
-        val testNearestRoad = getNearestRoad(currentLocation, fovRoadsFeatureCollection)
-        val intersectionsNeedsFurtherCheckingFC = FeatureCollection()
-
-        for (i in 0 until intersectionsSortedByDistance.features.size) {
-            val intersectionRoadNames = getIntersectionRoadNames(intersectionsSortedByDistance.features[i], fovRoadsFeatureCollection)
-            val intersectionsNeedsFurtherChecking = checkWhetherIntersectionIsOfInterest(intersectionRoadNames, testNearestRoad)
-            if(intersectionsNeedsFurtherChecking) {
-                intersectionsNeedsFurtherCheckingFC.addFeature(intersectionsSortedByDistance.features[i])
-            }
-        }
-        println("Intersections that need further checking: ${intersectionsNeedsFurtherCheckingFC.features.size}")
-
-        // Approach 1: find the intersection feature with the most osm_ids and use that?
-        // The code does give us the correct result as it jumps to the intersection with the most osm_ids
-        val featureWithMostOsmIds: Feature? = intersectionsNeedsFurtherCheckingFC.features.maxByOrNull {
-                feature ->
-            (feature.foreign?.get("osm_ids") as? List<*>)?.size ?: 0
-        }
-
-        // Approach 2: Use the nearest "checked" intersection to the device location?
-        /*val intersectionsToCheckSortedByDistance = sortedByDistanceTo(
-            currentLocation.latitude,
-            currentLocation.longitude,
-            intersectionsNeedsFurtherCheckingFC
-        )*/
-        val nearestIntersection = FeatureTree(fovIntersectionsFeatureCollection).getNearestFeature(currentLocation)
-        val nearestRoadBearing = getRoadBearingToIntersection(nearestIntersection, testNearestRoad, deviceHeading)
-        val intersectionLocation = featureWithMostOsmIds!!.geometry as Point
-        val intersectionRelativeDirections = getRelativeDirectionsPolygons(
-            LngLatAlt(intersectionLocation.coordinates.longitude,
-                intersectionLocation.coordinates.latitude),
-            nearestRoadBearing,
-            //fovDistance,
-            5.0,
-            RelativeDirections.COMBINED
-        )
-        //val newIntersectionFeatureCollection = FeatureCollection()
-        //newIntersectionFeatureCollection.addFeature(intersectionsToCheckSortedByDistance.features[0])
-
-        val intersectionRoadNames = getIntersectionRoadNames(featureWithMostOsmIds, fovRoadsFeatureCollection)
-        val intersectionRoadNamesString =
-            moshi.adapter(FeatureCollection::class.java).toJson(intersectionRoadNames)
-        println("Intersection roads: $intersectionRoadNamesString")
-        val roadRelativeDirections = getIntersectionRoadNamesRelativeDirections(
-            intersectionRoadNames,
-            featureWithMostOsmIds,
-            intersectionRelativeDirections
-        )
-
-        val intersectionRelativeDirectionsString =
-            moshi.adapter(FeatureCollection::class.java).toJson(intersectionRelativeDirections)
-        println("Intersection relative directions polygons: $intersectionRelativeDirectionsString")
+            ComplexIntersectionApproach.INTERSECTION_WITH_MOST_OSM_IDS).roads
 
         Assert.assertEquals(4, roadRelativeDirections.features.size )
         //
@@ -275,6 +108,4 @@ class ComplexIntersections {
         Assert.assertEquals("Weston Road", roadRelativeDirections.features[3].properties!!["name"])
 
     }
-
-
 }

--- a/app/src/test/java/org/scottishtecharmy/soundscape/CrossingTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/CrossingTest.kt
@@ -45,13 +45,6 @@ class CrossingTest {
             fovDistance,
             FeatureTree(crossingsFeatureCollection)
         )
-        // Create a FOV triangle to pick up the roads
-        val fovRoadsFeatureCollection = getFovFeatureCollection(
-            currentLocation,
-            deviceHeading,
-            fovDistance,
-            FeatureTree(testRoadsCollectionFromTileFeatureCollection)
-        )
         Assert.assertEquals(1, fovCrossingFeatureCollection.features.size)
 
         val nearestCrossing = FeatureTree(fovCrossingFeatureCollection).getNearestFeature(currentLocation)
@@ -66,7 +59,7 @@ class CrossingTest {
         // Confirm which road the crossing is on
         val nearestRoadToCrossing = getNearestRoad(
             LngLatAlt(crossingLocation.coordinates.longitude,crossingLocation.coordinates.latitude),
-            fovRoadsFeatureCollection
+            FeatureTree(testRoadsCollectionFromTileFeatureCollection)
         )
 
         Assert.assertEquals(24.58, distanceToCrossing, 0.1)

--- a/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTest.kt
@@ -2,25 +2,15 @@ package org.scottishtecharmy.soundscape
 
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
-import org.scottishtecharmy.soundscape.geojsonparser.geojson.LineString
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
-import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
-import org.scottishtecharmy.soundscape.geoengine.utils.RelativeDirections
-import org.scottishtecharmy.soundscape.geoengine.utils.getFovFeatureCollection
-import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionRoadNamesRelativeDirections
 import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionsFeatureCollectionFromTileFeatureCollection
-import org.scottishtecharmy.soundscape.geoengine.utils.getNearestRoad
-import org.scottishtecharmy.soundscape.geoengine.utils.getRelativeDirectionsPolygons
-import org.scottishtecharmy.soundscape.geoengine.utils.getRoadBearingToIntersection
 import org.scottishtecharmy.soundscape.geoengine.utils.getRoadsFeatureCollectionFromTileFeatureCollection
-import org.scottishtecharmy.soundscape.geoengine.utils.lineStringIsCircular
-import org.scottishtecharmy.soundscape.geoengine.utils.removeDuplicates
 import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
+import org.scottishtecharmy.soundscape.geoengine.callouts.ComplexIntersectionApproach
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
-import org.scottishtecharmy.soundscape.geoengine.utils.getFovTrianglePoints
-import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionRoadNames
+import org.scottishtecharmy.soundscape.geoengine.callouts.getIntersectionDescriptionFromFov
 
 
 class IntersectionsTest {
@@ -40,58 +30,21 @@ class IntersectionsTest {
                 featureCollectionTest!!
             )
         )
-        // create FOV to pickup the roads
-        val fovRoadsFeatureCollection = getFovFeatureCollection(
-            currentLocation,
-            deviceHeading,
-            fovDistance,
-            testRoadsTree
-        )
+
         // Get the intersections from the tile
         val testIntersectionsTree = FeatureTree(
             getIntersectionsFeatureCollectionFromTileFeatureCollection(
                 featureCollectionTest
             )
         )
-        // Create a FOV triangle to pick up the intersection
-        val points = getFovTrianglePoints(currentLocation, deviceHeading, fovDistance)
-        val testNearestIntersection = testIntersectionsTree.getNearestFeatureWithinTriangle(
+
+        return getIntersectionDescriptionFromFov(testRoadsTree,
+            testIntersectionsTree,
             currentLocation,
-            points.left,
-            points.right
-        )
-
-        // This will remove the duplicate "osm_ids" from the intersection
-        val cleanNearestIntersection = removeDuplicates(testNearestIntersection)
-
-        val testNearestRoad = getNearestRoad(currentLocation, fovRoadsFeatureCollection)
-
-        val testNearestRoadBearing = getRoadBearingToIntersection(cleanNearestIntersection, testNearestRoad, deviceHeading)
-
-        val testIntersectionRoadNames = getIntersectionRoadNames(
-            cleanNearestIntersection, fovRoadsFeatureCollection)
-
-        // are any of the roads that make up the intersection circular?
-        for(road in testIntersectionRoadNames){
-            if (lineStringIsCircular(road.geometry as LineString)){
-                println("Circular path")
-            }
-
-        }
-
-        val intersectionLocation = cleanNearestIntersection!!.geometry as Point
-
-        val intersectionRelativeDirections = getRelativeDirectionsPolygons(
-            intersectionLocation.coordinates,
-            testNearestRoadBearing,
+            deviceHeading,
             fovDistance,
-            RelativeDirections.COMBINED
-        )
-
-        return getIntersectionRoadNamesRelativeDirections(
-            testIntersectionRoadNames,
-            cleanNearestIntersection,
-            intersectionRelativeDirections)
+            ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION
+        ).roads
     }
 
     @Test

--- a/app/src/test/java/org/scottishtecharmy/soundscape/RoundaboutsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/RoundaboutsTest.kt
@@ -114,7 +114,7 @@ class RoundaboutsTest {
         val boundingBoxOfCircle = getBoundingBoxOfLineString(roundaboutCircleRoad.features[0].geometry as LineString)
         val boundingBoxOfCircleCorners = getBoundingBoxCorners(boundingBoxOfCircle)
         val centerOfBoundingBox = getCenterOfBoundingBox(boundingBoxOfCircleCorners)
-        val testNearestRoad = getNearestRoad(currentLocation, fovRoadsFeatureCollection)
+        val testNearestRoad = getNearestRoad(currentLocation, FeatureTree(fovRoadsFeatureCollection))
         val testNearestRoadBearing =
             getRoadBearingToIntersection(nearestIntersection, testNearestRoad, deviceHeading)
         val roundaboutRoadsRelativeDirections = getRelativeDirectionsPolygons(
@@ -220,7 +220,7 @@ class RoundaboutsTest {
         // This will remove the duplicate "osm_ids" from the intersection
         val cleanNearestIntersection = removeDuplicates(nearestIntersection)
 
-        val testNearestRoad = getNearestRoad(currentLocation, fovRoadsFeatureCollection)
+        val testNearestRoad = getNearestRoad(currentLocation, FeatureTree(fovRoadsFeatureCollection))
 
         val testNearestRoadBearing = getRoadBearingToIntersection(cleanNearestIntersection, testNearestRoad, deviceHeading)
 
@@ -298,7 +298,7 @@ class RoundaboutsTest {
         println("Number of roads that make up the nearest intersection ${intersectionRoadNames.features.size}")
         // I need to test that the intersection roads have
         // "oneway" and "yes" tags and that the road names are all the same
-        val testNearestRoad = getNearestRoad(currentLocation, fovRoadsFeatureCollection)
+        val testNearestRoad = getNearestRoad(currentLocation, FeatureTree(fovRoadsFeatureCollection))
         for (road in intersectionRoadNames) {
             if(testNearestRoad!!.properties?.get("name") == road.properties?.get("name")
                 && road.properties?.get("oneway") == "yes"){

--- a/app/src/test/java/org/scottishtecharmy/soundscape/StreetPreviewTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/StreetPreviewTest.kt
@@ -39,7 +39,7 @@ class StreetPreviewTest {
             featureCollectionTest!!)
         val nearestRoad = getNearestRoad(
             LngLatAlt(-2.693002695425122,51.43938442591545),
-            roadFeatureCollectionTest
+            FeatureTree(roadFeatureCollectionTest)
         )
         val nearestRoadTest = FeatureCollection()
         nearestRoadTest.addFeature(nearestRoad!!)
@@ -103,7 +103,7 @@ class StreetPreviewTest {
         val nearestRoadTest = roadFeatureCollectionTest?.let {
             getNearestRoad(
                 LngLatAlt(-2.693002695425122,51.43938442591545),
-                it
+                FeatureTree(it)
             )
         }
         // trace along the road with equidistant points 30m apart.
@@ -164,7 +164,7 @@ class StreetPreviewTest {
                     if (fovRoadsFeatureCollection.features.size > 0) {
                         val nearestRoad = getNearestRoad(
                             currentLocation,
-                            fovRoadsFeatureCollection
+                            FeatureTree(roadFeatureCollectionTest)
                         )
 
                         if (nearestRoad!!.properties?.get("name") != null) {
@@ -188,7 +188,7 @@ class StreetPreviewTest {
 
                                 val testNearestRoad = getNearestRoad(
                                     currentLocation,
-                                    fovRoadsFeatureCollection
+                                    FeatureTree(roadFeatureCollectionTest)
                                 )
                                 val intersectionsNeedsFurtherCheckingFC = FeatureCollection()
 
@@ -261,7 +261,7 @@ class StreetPreviewTest {
                             // Confirm which road the crossing is on
                             val nearestRoadToCrossing = getNearestRoad(
                                 crossingLocation.coordinates,
-                                fovRoadsFeatureCollection
+                                FeatureTree(roadFeatureCollectionTest)
                             )
 
                             val crossingCallout = buildString {
@@ -290,7 +290,7 @@ class StreetPreviewTest {
                             // Confirm which road the crossing is on
                             val nearestRoadToBus = getNearestRoad(
                                 busStopLocation.coordinates,
-                                fovRoadsFeatureCollection
+                                FeatureTree(roadFeatureCollectionTest)
                             )
 
                             val busStopCallout = buildString {

--- a/app/src/test/java/org/scottishtecharmy/soundscape/TileUtilsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/TileUtilsTest.kt
@@ -527,7 +527,7 @@ class TileUtilsTest {
         )
         // This should pick up three roads in the FoV
         Assert.assertEquals(3, fovRoadsFeatureCollection.features.size)
-        val nearestRoad = getNearestRoad(currentLocation, fovRoadsFeatureCollection)
+        val nearestRoad = getNearestRoad(currentLocation, FeatureTree(testRoadsCollectionFromTileFeatureCollection))
         // Should only be the nearest road in this Feature Collection
         assert(nearestRoad != null)
         // The nearest road to the current location should be Weston Road

--- a/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckIntersectionLayers.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckIntersectionLayers.kt
@@ -85,7 +85,7 @@ class VisuallyCheckIntersectionLayers {
             fovIntersectionsFeatureCollection
         )
         // Get the nearest Road in the FoV
-        val testNearestRoad = getNearestRoad(currentLocation, fovRoadsFeatureCollection)
+        val testNearestRoad = getNearestRoad(currentLocation, FeatureTree(testRoadsCollectionFromTileFeatureCollection))
         val intersectionsNeedsFurtherCheckingFC = FeatureCollection()
         for (i in 0 until intersectionsSortedByDistance.features.size) {
             val intersectionRoadNames = getIntersectionRoadNames(intersectionsSortedByDistance.features[i], fovRoadsFeatureCollection)
@@ -137,7 +137,7 @@ class VisuallyCheckIntersectionLayers {
         val crossingLocation = nearestCrossing!!.geometry as Point
         val nearestRoadToCrossing = getNearestRoad(
             LngLatAlt(crossingLocation.coordinates.longitude,crossingLocation.coordinates.latitude),
-            fovRoadsFeatureCollection
+            FeatureTree(testRoadsCollectionFromTileFeatureCollection)
         )
         // *** End of Crossing
 
@@ -152,7 +152,6 @@ class VisuallyCheckIntersectionLayers {
         Assert.assertEquals("Clevedon Road", roadRelativeDirections.features[1].properties!!["name"])
         Assert.assertEquals(7, roadRelativeDirections.features[2].properties!!["Direction"])
         Assert.assertEquals("Clevedon Road", roadRelativeDirections.features[2].properties!!["name"])
-
 
         // *************************************************************
         // *** Display Field of View triangle ***


### PR DESCRIPTION
The main change here is to de-duplicate the intersection description code from the unit tests and GeoEngine and have a single function in a new file IntersectionUtils. This should be the same as as that which was in the ComplexIntersections unit test. A new function in the same file can then take the IntersectionDescription and turn it into a callout. The other change in that area is the start of improving the callout code to use the results of the ActivityRecognition to switch between heading, facing and travelling in the callouts.
The final change is that getNearestRoad now uses FeatureTree to perform it's searching. Not only does this improve its performance, but it allows us to search outside the FOV - the nearest road could be 0.5m behind the current FOV and searching only within the FOV would preclude that. The unit tests all still pass with this change.