### PR TITLE
Add back in nearest road for Ahead of Me

### DIFF
--- a/app/src/androidTest/java/org/scottishtecharmy/soundscape/PhotonSearchTest.kt
+++ b/app/src/androidTest/java/org/scottishtecharmy/soundscape/PhotonSearchTest.kt
@@ -9,6 +9,7 @@ import org.scottishtecharmy.soundscape.network.PhotonSearchProvider
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
+import java.io.InterruptedIOException
 
 @RunWith(AndroidJUnit4::class)
 class PhotonSearchTest {
@@ -18,27 +19,34 @@ class PhotonSearchTest {
        runBlocking {
            withContext(Dispatchers.IO) {
 
-               val apiInterface = PhotonSearchProvider.getInstance()
-               val call = apiInterface.getSearchResults("Tarland")
-               val response = call.execute()
-               if (call.isExecuted) {
-                   Log.d("PhotonSearchTest", "Successfully got results:")
-                   response.body()?.let { result ->
-                       for (feature in result.features) {
-                           feature.properties?.let { properties ->
-                               if((properties["name"] != null) &&
-                                   (feature.geometry.type == "Point")) {
+               try {
+                   val apiInterface = PhotonSearchProvider.getInstance()
+                   val call = apiInterface.getSearchResults("Tarland")
+                   val response = call.execute()
+                   if (call.isExecuted) {
+                       Log.d("PhotonSearchTest", "Successfully got results:")
+                       response.body()?.let { result ->
+                           for (feature in result.features) {
+                               feature.properties?.let { properties ->
+                                   if ((properties["name"] != null) &&
+                                       (feature.geometry.type == "Point")
+                                   ) {
 
-                                   val location = feature.geometry as Point
-                                   Log.d(
-                                       "PhotonSearchTest",
-                                       "Name: " + properties["name"] +
-                                               " at " + location.coordinates.toString()
-                                   )
+                                       val location = feature.geometry as Point
+                                       Log.d(
+                                           "PhotonSearchTest",
+                                           "Name: " + properties["name"] +
+                                                   " at " + location.coordinates.toString()
+                                       )
+                                   }
                                }
                            }
                        }
+                   } else {
+                       Log.e("PhotonSearchTest", "Failed to execute")
                    }
+               } catch(e : InterruptedIOException) {
+                   Log.e("PhotonSearchTest", "Timeout getting results: $e")
                }
            }
        }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -51,7 +51,7 @@ import org.scottishtecharmy.soundscape.geoengine.utils.getFeatureNearestPoint
 import org.scottishtecharmy.soundscape.geoengine.utils.getFovTrianglePoints
 import org.scottishtecharmy.soundscape.geoengine.utils.getNearestRoad
 import org.scottishtecharmy.soundscape.geoengine.utils.getPoiFeatureCollectionBySuperCategory
-import org.scottishtecharmy.soundscape.geoengine.callouts.getIntersectionDescriptionFromFov
+import org.scottishtecharmy.soundscape.geoengine.callouts.getRoadsDescriptionFromFov
 import org.scottishtecharmy.soundscape.geoengine.utils.getSuperCategoryElements
 import org.scottishtecharmy.soundscape.geoengine.utils.mergeAllPolygonsInFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.pointIsWithinBoundingBox
@@ -488,7 +488,7 @@ class GeoEngine {
         val heading = directionProvider.getCurrentDirection().toDouble()
         val fovDistance = 50.0
 
-        val intersectionDescription = getIntersectionDescriptionFromFov(
+        val roadsDescription = getRoadsDescriptionFromFov(
             featureTrees[Fc.ROADS_AND_PATHS.id],
             featureTrees[Fc.INTERSECTIONS.id],
             location,
@@ -496,7 +496,7 @@ class GeoEngine {
             fovDistance,
             ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION)
 
-        addIntersectionCalloutFromDescription(intersectionDescription,
+        addIntersectionCalloutFromDescription(roadsDescription,
                 localizedContext,
                 results,
                 intersectionCalloutHistory)
@@ -995,8 +995,8 @@ class GeoEngine {
                     val orientation = directionProvider.getCurrentDirection().toDouble()
                     val fovDistance = 50.0
 
-                    // Detect if there is an intersection in the FOV
-                    val intersectionDescription = getIntersectionDescriptionFromFov(
+                    // Detect if there is a road or an intersection in the FOV
+                    val roadsDescription = getRoadsDescriptionFromFov(
                         featureTrees[Fc.ROADS_AND_PATHS.id],
                         featureTrees[Fc.INTERSECTIONS.id],
                         location,
@@ -1004,7 +1004,7 @@ class GeoEngine {
                         fovDistance,
                         ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION
                     )
-                    addIntersectionCalloutFromDescription(intersectionDescription,
+                    addIntersectionCalloutFromDescription(roadsDescription,
                         localizedContext,
                         list)
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/network/SearchProvider.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/network/SearchProvider.kt
@@ -13,6 +13,8 @@ import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.Query
 import java.util.Locale
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
 
 const val BASE_URL = "https://photon.komoot.io/"
 
@@ -53,6 +55,7 @@ interface PhotonSearchProvider {
         }
         private val logging = OkHttpClient.Builder()
             .addInterceptor(loggingInterceptor)
+            .callTimeout(20, TimeUnit.SECONDS)
             .build()
 
         fun getInstance(): PhotonSearchProvider {

--- a/app/src/test/java/org/scottishtecharmy/soundscape/ComplexIntersections.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/ComplexIntersections.kt
@@ -9,7 +9,7 @@ import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionsFeatureCollectionFromTileFeatureCollection
-import org.scottishtecharmy.soundscape.geoengine.callouts.getIntersectionDescriptionFromFov
+import org.scottishtecharmy.soundscape.geoengine.callouts.getRoadsDescriptionFromFov
 import org.scottishtecharmy.soundscape.geoengine.utils.getRoadsFeatureCollectionFromTileFeatureCollection
 
 class ComplexIntersections {
@@ -42,13 +42,13 @@ class ComplexIntersections {
                 featureCollectionTest
             )
 
-        val roadRelativeDirections = getIntersectionDescriptionFromFov(
+        val roadRelativeDirections = getRoadsDescriptionFromFov(
             FeatureTree(testRoadsCollectionFromTileFeatureCollection),
             FeatureTree(testIntersectionsCollectionFromTileFeatureCollection),
             currentLocation,
             deviceHeading,
             fovDistance,
-            ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION).roads
+            ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION).intersectionRoads
 
 
         Assert.assertEquals(3, roadRelativeDirections.features.size )
@@ -88,13 +88,13 @@ class ComplexIntersections {
             getIntersectionsFeatureCollectionFromTileFeatureCollection(
                 featureCollectionTest
             )
-        val roadRelativeDirections = getIntersectionDescriptionFromFov(
+        val roadRelativeDirections = getRoadsDescriptionFromFov(
             FeatureTree(testRoadsCollectionFromTileFeatureCollection),
             FeatureTree(testIntersectionsCollectionFromTileFeatureCollection),
             currentLocation,
             deviceHeading,
             fovDistance,
-            ComplexIntersectionApproach.INTERSECTION_WITH_MOST_OSM_IDS).roads
+            ComplexIntersectionApproach.INTERSECTION_WITH_MOST_OSM_IDS).intersectionRoads
 
         Assert.assertEquals(4, roadRelativeDirections.features.size )
         //

--- a/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTest.kt
@@ -10,7 +10,7 @@ import org.junit.Assert
 import org.junit.Test
 import org.scottishtecharmy.soundscape.geoengine.callouts.ComplexIntersectionApproach
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
-import org.scottishtecharmy.soundscape.geoengine.callouts.getIntersectionDescriptionFromFov
+import org.scottishtecharmy.soundscape.geoengine.callouts.getRoadsDescriptionFromFov
 
 
 class IntersectionsTest {
@@ -38,13 +38,13 @@ class IntersectionsTest {
             )
         )
 
-        return getIntersectionDescriptionFromFov(testRoadsTree,
+        return getRoadsDescriptionFromFov(testRoadsTree,
             testIntersectionsTree,
             currentLocation,
             deviceHeading,
             fovDistance,
             ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION
-        ).roads
+        ).intersectionRoads
     }
 
     @Test

--- a/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTestMvt.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTestMvt.kt
@@ -6,7 +6,7 @@ import org.scottishtecharmy.soundscape.geoengine.callouts.ComplexIntersectionApp
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionsFeatureCollectionFromTileFeatureCollection
-import org.scottishtecharmy.soundscape.geoengine.callouts.getIntersectionDescriptionFromFov
+import org.scottishtecharmy.soundscape.geoengine.callouts.getRoadsDescriptionFromFov
 import org.scottishtecharmy.soundscape.geoengine.utils.getRoadsFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 
@@ -29,13 +29,13 @@ class IntersectionsTestMvt {
                 featureCollectionTest
             )
         )
-        return getIntersectionDescriptionFromFov(testRoadsTree,
+        return getRoadsDescriptionFromFov(testRoadsTree,
             testIntersectionsTree,
             currentLocation,
             deviceHeading,
             fovDistance,
             ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION
-        ).roads
+        ).intersectionRoads
     }
     @Test
     fun intersectionsStraightAheadType(){


### PR DESCRIPTION
I'd missed this by mistake when refactoring - this change restores the 'X road ahead' prior to describing an intersection. However, it does bring up a question:
  In the previous commit I switched nearestRoad to be the actual nearest
road, and not the nearest within the FOV. For reporting 'X road ahead' I think that we do want the road in the FOV so I calculate both. It seems 'no worse', but requires some more thought. However, the code is all in one place now so should be easier to consider.