### PR TITLE
Adjust coordinate calculations for MVT translation by 0.5 pixel

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/mvttranslation/InterpolatedPointsJoiner.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/mvttranslation/InterpolatedPointsJoiner.kt
@@ -173,8 +173,8 @@ fun convertGeometryAndClipLineToTile(
                         tileX,
                         tileY,
                         tileZoom,
-                        point.first.toDouble() / 4096.0,
-                        point.second.toDouble() / 4096.0
+                        sampleToFractionOfTile(point.first),
+                        sampleToFractionOfTile(point.second)
                     )
                 )
             } else {
@@ -204,8 +204,8 @@ fun convertGeometryAndClipLineToTile(
                     tileX,
                     tileY,
                     tileZoom,
-                    point.first.toDouble() / 4096.0,
-                    point.second.toDouble() / 4096.0
+                    sampleToFractionOfTile(point.first),
+                    sampleToFractionOfTile(point.second)
                 )
             )
         } else {
@@ -249,10 +249,10 @@ fun convertGeometryAndClipLineToTile(
 fun getTileCrossingPoint(point1 : Pair<Int, Int>, point2 : Pair<Int, Int>) : List<Pair<Double, Double>> {
 
     // Extract the coordinates of the points and square boundaries
-    val x1 = point1.first.toDouble()
-    val y1 = point1.second.toDouble()
-    val x2 = point2.first.toDouble()
-    val y2 = point2.second.toDouble()
+    val x1 = point1.first.toDouble() + 0.5
+    val y1 = point1.second.toDouble() + 0.5
+    val x2 = point2.first.toDouble() + 0.5
+    val y2 = point2.second.toDouble() + 0.5
 
     val intersections = mutableListOf<Pair<Double, Double>>()
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/mvttranslation/MvtToGeoJson.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/mvttranslation/MvtToGeoJson.kt
@@ -15,6 +15,10 @@ fun pointIsOffTile(x: Int, y: Int) : Boolean {
     return (x < 0 || y < 0 || x >= 4096 || y >= 4096)
 }
 
+fun sampleToFractionOfTile(sample: Int) : Double {
+    return (sample.toDouble() + 0.5) / 4096.0
+}
+
 private fun parseGeometry(
     cropToTile: Boolean,
     geometry: MutableList<Int>
@@ -103,8 +107,8 @@ fun convertGeometry(tileX : Int, tileY : Int, tileZoom : Int, geometry: ArrayLis
             getLatLonTileWithOffset(tileX,
             tileY,
             tileZoom,
-            point.first.toDouble()/4096.0,
-            point.second.toDouble()/4096.0)
+            sampleToFractionOfTile(point.first),
+            sampleToFractionOfTile(point.second))
         )
     }
     return results


### PR DESCRIPTION
The calculations that translate the integer relative tile coordinates into fractional tile coordinates now place the sample point in the middle of the sample range i.e. on the half pixel. This fixes the calculations made for the interpolated points where lines cross tile boundaries as the tile boundaries are no longer coincident with the sample points.