### PR TITLE
Create GridState class to hold tile grid data and functionality

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
@@ -37,9 +37,6 @@ class SoundscapeServiceConnection @Inject constructor() {
     fun getStreetPreviewModeFlow(): StateFlow<Boolean>? {
         return soundscapeService?.streetPreviewFlow
     }
-    fun getTileGridFlow(): StateFlow<TileGrid>? {
-        return soundscapeService?.geoEngine?.tileGridFlow
-    }
 
     fun setStreetPreviewMode(on : Boolean, latitude: Double = 0.0, longitude: Double = 0.0) {
         Log.d(TAG, "setStreetPreviewMode $on")

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
@@ -175,9 +175,9 @@ open class GridState {
                              val road: Feature,
                              val distance: Double = Double.POSITIVE_INFINITY)
     fun getNearestFeatureOnRoadInFov(id: TreeId,
-                                             location: LngLatAlt,
-                                             left: LngLatAlt,
-                                             right: LngLatAlt
+                                     location: LngLatAlt,
+                                     left: LngLatAlt,
+                                     right: LngLatAlt
     ): FeatureByRoad? {
 
         checkContext()

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
@@ -1,0 +1,233 @@
+package org.scottishtecharmy.soundscape.geoengine
+
+import android.app.Application
+import android.util.Log
+import com.squareup.moshi.Moshi
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.scottishtecharmy.soundscape.dto.BoundingBox
+import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
+import org.scottishtecharmy.soundscape.geoengine.utils.TileGrid
+import org.scottishtecharmy.soundscape.geoengine.utils.TileGrid.Companion.getTileGrid
+import org.scottishtecharmy.soundscape.geoengine.utils.getNearestRoad
+import org.scottishtecharmy.soundscape.geoengine.utils.pointIsWithinBoundingBox
+import org.scottishtecharmy.soundscape.geoengine.utils.processTileFeatureCollection
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
+import org.scottishtecharmy.soundscape.network.TileClient
+import org.scottishtecharmy.soundscape.services.SoundscapeService
+import kotlin.time.TimeSource
+
+enum class TreeId(
+    val id: Int,
+) {
+    ROADS(0),
+    ROADS_AND_PATHS(1),
+    INTERSECTIONS(2),
+    ENTRANCES(3),
+    CROSSINGS(4),
+    POIS(5),
+    BUS_STOPS(6),
+    INTERPOLATIONS(7),
+    MAX_COLLECTION_ID(8),
+}
+
+open class GridState {
+
+    // HTTP connection to tile server
+    internal lateinit var tileClient: TileClient
+
+    private var centralBoundingBox = BoundingBox()
+    private var featureTrees = Array(TreeId.MAX_COLLECTION_ID.id) { FeatureTree(null) }
+    @OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
+    val treeContext = newSingleThreadContext("TreeContext")
+    var validateContext = true
+
+    open fun start(application: Application, soundscapeService: SoundscapeService) {}
+    fun stop() {}
+    open fun fixupCollectionAndCreateTrees(trees: Array<FeatureTree>,
+                                           featureCollections: Array<FeatureCollection>) {}
+
+    /**
+     * The tile grid service is called each time the location changes. It checks if the location
+     * has moved away from the center of the current tile grid and if it has calculates a new grid.
+     */
+    suspend fun locationUpdate(location: LngLatAlt) {
+        val timeSource = TimeSource.Monotonic
+        val gridStartTime = timeSource.markNow()
+
+        // Check if we're still within the central area of our grid
+        if (!pointIsWithinBoundingBox(location, centralBoundingBox)) {
+            Log.d(TAG, "Update central grid area")
+            // The current location has moved from within the central area, so get the
+            // new grid and the new central area.
+            val tileGrid = getTileGrid(location)
+
+            // We have a new centralBoundingBox, so update the tiles
+            val featureCollections = Array(TreeId.MAX_COLLECTION_ID.id) { FeatureCollection() }
+            if (updateTileGrid(tileGrid, featureCollections)) {
+                // We have got a new grid, so create our new central region
+                centralBoundingBox = tileGrid.centralBoundingBox
+
+                val localTrees = Array(TreeId.MAX_COLLECTION_ID.id) { FeatureTree(null) }
+                fixupCollectionAndCreateTrees(localTrees, featureCollections)
+
+                // Assign rtrees to our shared trees from within the treeContext. All
+                // other accesses of featureTrees needs to be from within the same
+                // context.
+                runBlocking {
+                    withContext(treeContext) {
+                        for (fc in featureCollections.withIndex()) {
+                            featureTrees[fc.index] = localTrees[fc.index]
+                        }
+                    }
+                }
+
+                val gridFinishTime = timeSource.markNow()
+                Log.e(TAG, "Time to populate grid: ${gridFinishTime - gridStartTime}")
+
+            } else {
+                // Updating the tile grid failed, due to a lack of cached tile and then
+                // a lack of network/server issue. There's nothing that we can do, so
+                // simply retry on the next location update.
+            }
+        }
+    }
+
+    private suspend fun updateTileGrid(
+        tileGrid: TileGrid,
+        featureCollections: Array<FeatureCollection>,
+    ): Boolean {
+        for (tile in tileGrid.tiles) {
+            Log.d(TAG, "Tile quad key: ${tile.quadkey}")
+            var ret = false
+            for (retry in 1..5) {
+                ret = updateTile(tile.tileX, tile.tileY, featureCollections)
+                if (ret) {
+                    break
+                }
+            }
+            if (!ret) {
+                return false
+            }
+        }
+        return true
+    }
+
+    internal open suspend fun updateTile(x: Int, y: Int, featureCollections: Array<FeatureCollection>): Boolean {
+        assert(false)
+        return false
+    }
+
+    // All functions which access the featureTrees need to be running within the treeContext,
+    // so assert that this is the case.
+    private fun checkContext() {
+        // TODO: It feels like there should be a way to check the context, but coroutineContext
+        //  is a suspend function and we are not. We can at least check that the current thread
+        //  name matches. This should spot any calls using featureTrees which aren't running in
+        //  the treeContext.
+        if(validateContext) {
+            assert(Thread.currentThread().name.startsWith("TreeContext"))
+        }
+    }
+
+    fun getFeatureTree(id: TreeId): FeatureTree {
+        checkContext()
+        return featureTrees[id.id]
+    }
+
+    internal fun getFeatureCollection(id: TreeId,
+                                      location: LngLatAlt = LngLatAlt(),
+                                      distance : Double = Double.POSITIVE_INFINITY,
+                                      maxCount : Int = 0): FeatureCollection {
+        checkContext()
+        val result = if(distance == Double.POSITIVE_INFINITY) {
+            featureTrees[id.id].generateFeatureCollection()
+        } else {
+            if(maxCount == 0) {
+                featureTrees[id.id].generateNearbyFeatureCollection(location, distance)
+            } else {
+                if (maxCount == 0) {
+                    featureTrees[id.id].generateNearbyFeatureCollection(location, distance)
+                } else {
+                    featureTrees[id.id].generateNearestFeatureCollection(location, distance, maxCount)
+                }
+            }
+        }
+        return result
+    }
+
+    internal fun getNearestFeature(id: TreeId,
+                                   location: LngLatAlt = LngLatAlt(),
+                                   distance : Double = Double.POSITIVE_INFINITY
+    ): Feature? {
+        checkContext()
+        return featureTrees[id.id].getNearestFeature(location, distance)
+    }
+
+    data class FeatureByRoad(val feature: Feature,
+                             val road: Feature,
+                             val distance: Double = Double.POSITIVE_INFINITY)
+    fun getNearestFeatureOnRoadInFov(id: TreeId,
+                                             location: LngLatAlt,
+                                             left: LngLatAlt,
+                                             right: LngLatAlt
+    ): FeatureByRoad? {
+
+        checkContext()
+        val nearestFeature = featureTrees[id.id].getNearestFeatureWithinTriangle(
+            location,
+            left,
+            right)
+        if (nearestFeature != null) {
+            val featureLocation = nearestFeature.geometry as Point
+
+            // Confirm which road the feature is on
+            val nearestRoad = getNearestRoad(
+                featureLocation.coordinates,
+                featureTrees[TreeId.ROADS_AND_PATHS.id]
+            )
+            if(nearestRoad != null) {
+                // We found a feature and the road that it is on
+                val distance = location.distance(featureLocation.coordinates)
+                return FeatureByRoad(nearestFeature, nearestRoad, distance)
+            }
+        }
+
+        return null
+    }
+
+    companion object {
+        fun createFromFeatureCollection(featureCollection: FeatureCollection) : GridState {
+
+            val gridState = GridState()
+
+            val collections = processTileFeatureCollection(featureCollection)
+            for ((index, collection) in collections.withIndex()) {
+                gridState.featureTrees[index] = FeatureTree(collection)
+            }
+            // Because the gridState is static and is not being updated by another thread, we don't
+            // need to run it in a separate context, so disable checking.
+            gridState.validateContext = false
+
+            return gridState
+        }
+
+        fun createFromGeoJson(geoJson: String) : GridState {
+
+            val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
+            val featureCollection = moshi.adapter(FeatureCollection::class.java)
+                .fromJson(geoJson)
+
+            return createFromFeatureCollection(featureCollection!!)
+        }
+
+        internal const val TAG = "GridState"
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
@@ -14,7 +14,6 @@ import org.scottishtecharmy.soundscape.geoengine.utils.TileGrid
 import org.scottishtecharmy.soundscape.geoengine.utils.TileGrid.Companion.getTileGrid
 import org.scottishtecharmy.soundscape.geoengine.utils.getNearestRoad
 import org.scottishtecharmy.soundscape.geoengine.utils.pointIsWithinBoundingBox
-import org.scottishtecharmy.soundscape.geoengine.utils.processTileFeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
@@ -203,12 +202,241 @@ open class GridState {
         return null
     }
 
+    /**
+     * Parses out roads, paths, intersections, entrances, pois, bus stops and crossings from a tile string.
+     * @return a TileData object with the string parsed into separate strings.
+     */
+
+    internal fun processTileString(tileString: String): Array<FeatureCollection> {
+        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
+        val tileFeatureCollection = moshi.adapter(FeatureCollection::class.java)
+            .fromJson(tileString)
+        if(tileFeatureCollection == null)
+            return emptyArray()
+
+        return processTileFeatureCollection(tileFeatureCollection)
+    }
+
+    internal fun processTileFeatureCollection(tileFeatureCollection: FeatureCollection): Array<FeatureCollection> {
+
+        val tileData = Array(TreeId.MAX_COLLECTION_ID.id) { FeatureCollection() }
+
+        // We have separate collections for the different types of Feature. ROADS_AND_PATHS adds PATHS
+        // to the ROADS features already contained in ROADS. This slight extra cost in terms of memory
+        // is made up for by the ease of searching a single collection.
+        tileData[TreeId.ROADS.id] = getRoadsFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
+        tileData[TreeId.ROADS_AND_PATHS.id] = getPathsFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
+        tileData[TreeId.ROADS_AND_PATHS.id].plusAssign(tileData[TreeId.ROADS.id])
+        tileData[TreeId.INTERSECTIONS.id] = getIntersectionsFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
+        tileData[TreeId.ENTRANCES.id] = getEntrancesFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
+        tileData[TreeId.POIS.id] = getPointsOfInterestFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
+        tileData[TreeId.BUS_STOPS.id] = getBusStopsFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
+        tileData[TreeId.CROSSINGS.id] = getCrossingsFromTileFeatureCollection(tileFeatureCollection)
+        tileData[TreeId.INTERPOLATIONS.id] = getInterpolationPointsFromTileFeatureCollection(tileFeatureCollection)
+
+        return  tileData
+    }
+
+    /**
+     * Given a valid Tile feature collection this will parse the collection and return a roads
+     * feature collection. Uses the "highway" feature_type to extract roads from GeoJSON.
+     * @param tileFeatureCollection
+     * A FeatureCollection object.
+     * @return A FeatureCollection object that contains only roads.
+     */
+    private fun getRoadsFeatureCollectionFromTileFeatureCollection(
+        tileFeatureCollection: FeatureCollection
+    ): FeatureCollection {
+
+        val roadsFeatureCollection = FeatureCollection()
+
+        // Original Soundscape excludes the below feature_value (s) even though they have the
+        // feature_type == highway
+        // and creates a separate Paths Feature Collection for them
+        // "footway", "path", "cycleway", "bridleway"
+        // gd_intersection are a special case and get their own Intersections Feature Collection
+
+
+        for (feature in tileFeatureCollection) {
+            feature.foreign?.let { foreign ->
+                if (foreign["feature_type"] == "highway"
+                    && foreign["feature_value"] != "gd_intersection"
+                    && foreign["feature_value"] != "footway"
+                    && foreign["feature_value"] != "path"
+                    && foreign["feature_value"] != "cycleway"
+                    && foreign["feature_value"] != "bridleway"
+                    && foreign["feature_value"] != "bus_stop"
+                    && foreign["feature_value"] != "crossing") {
+                    // We're only going to add linestrings to the roads feature collection
+                    when(feature.geometry.type) {
+                        "LineString", "MultiLineString" ->
+                            roadsFeatureCollection.addFeature(feature)
+                    }
+                }
+            }
+        }
+        return roadsFeatureCollection
+    }
+
+    /**
+     * Given a valid Tile feature collection this will parse the collection and return a bus stops
+     * feature collection. Uses the "bus_stop" feature_value to extract bus stops from GeoJSON.
+     * @param tileFeatureCollection
+     * A FeatureCollection object.
+     * @return A FeatureCollection object that contains only bus stops.
+     */
+    private fun getBusStopsFeatureCollectionFromTileFeatureCollection(
+        tileFeatureCollection: FeatureCollection
+    ): FeatureCollection{
+        val busStopFeatureCollection = FeatureCollection()
+        for (feature in tileFeatureCollection) {
+            feature.foreign?.let { foreign ->
+                if (foreign["feature_type"] == "highway" && foreign["feature_value"] == "bus_stop") {
+                    busStopFeatureCollection.addFeature(feature)
+                }
+            }
+        }
+
+        return busStopFeatureCollection
+    }
+
+    /**
+     * Given a valid Tile feature collection this will parse the collection and return a crossing
+     * feature collection. Uses the "crossing" feature_value to extract crossings from GeoJSON.
+     * @param tileFeatureCollection
+     * A FeatureCollection object.
+     * @return A FeatureCollection object that contains only crossings.
+     */
+    private fun getCrossingsFromTileFeatureCollection(tileFeatureCollection: FeatureCollection): FeatureCollection{
+        val crossingsFeatureCollection = FeatureCollection()
+        for (feature in tileFeatureCollection) {
+            feature.foreign?.let { foreign ->
+                if (foreign["feature_type"] == "highway" && foreign["feature_value"] == "crossing") {
+                    crossingsFeatureCollection.addFeature(feature)
+                }
+            }
+        }
+        return crossingsFeatureCollection
+    }
+
+    /**
+     * Given a valid Tile feature collection this will parse the collection and return an interpolation
+     * points feature collection. Uses the "edgePoint" feature_value to extract crossings from GeoJSON.
+     * @param tileFeatureCollection
+     * A FeatureCollection object.
+     * @return A FeatureCollection object that contains only edgePoints
+     */
+    private fun getInterpolationPointsFromTileFeatureCollection(tileFeatureCollection: FeatureCollection): FeatureCollection{
+        val interpolationPointsFeatureCollection = FeatureCollection()
+        for (feature in tileFeatureCollection) {
+            feature.properties?.let { properties ->
+                if (properties["class"] == "edgePoint") {
+                    interpolationPointsFeatureCollection.addFeature(feature)
+                }
+            }
+        }
+        return interpolationPointsFeatureCollection
+    }
+
+    /**
+     * Given a valid Tile feature collection this will parse the collection and return a paths
+     * feature collection. Uses the "footway", "path", "cycleway", "bridleway" feature_value to extract
+     * Paths from Feature Collection.
+     * @param tileFeatureCollection
+     * A FeatureCollection object.
+     * @return A FeatureCollection object that contains only paths.
+     */
+    private fun getPathsFeatureCollectionFromTileFeatureCollection(
+        tileFeatureCollection: FeatureCollection
+    ): FeatureCollection{
+        val pathsFeatureCollection = FeatureCollection()
+
+        for(feature in tileFeatureCollection) {
+            feature.foreign?.let { foreign ->
+                // We're only going to add linestrings to the roads feature collection
+                when(feature.geometry.type) {
+                    "LineString", "MultiLineString" -> {
+                        if (foreign["feature_type"] == "highway")
+                            when (foreign["feature_value"]) {
+                                "footway" -> pathsFeatureCollection.addFeature(feature)
+                                "path" -> pathsFeatureCollection.addFeature(feature)
+                                "cycleway" -> pathsFeatureCollection.addFeature(feature)
+                                "bridleway" -> pathsFeatureCollection.addFeature(feature)
+                            }
+                    }
+                }
+            }
+        }
+        return pathsFeatureCollection
+    }
+
+    /**
+     * Parses out all the Intersections in a tile FeatureCollection using the "gd_intersection" feature_value.
+     * @param tileFeatureCollection
+     * A FeatureCollection object.
+     * @return a Feature collection object that only contains intersections.
+     */
+    private fun getIntersectionsFeatureCollectionFromTileFeatureCollection(
+        tileFeatureCollection: FeatureCollection
+    ): FeatureCollection {
+        val intersectionsFeatureCollection = FeatureCollection()
+        // split out the intersections into their own intersections FeatureCollection
+        for (feature in tileFeatureCollection) {
+            feature.foreign?.let { foreign ->
+                if (foreign["feature_type"] == "highway" && foreign["feature_value"] == "gd_intersection") {
+                    intersectionsFeatureCollection.addFeature(feature)
+                }
+            }
+        }
+        return intersectionsFeatureCollection
+    }
+
+    /**
+     * Parses out all the Entrances in a tile FeatureCollection using the "gd_entrance_list" feature_type.
+     * @param tileFeatureCollection
+     * A FeatureCollection object.
+     * @return a feature collection object that contains only entrances.
+     */
+    private fun getEntrancesFeatureCollectionFromTileFeatureCollection(
+        tileFeatureCollection: FeatureCollection
+    ): FeatureCollection {
+        val entrancesFeatureCollection = FeatureCollection()
+        for (feature in tileFeatureCollection) {
+            feature.foreign?.let { foreign ->
+                if (foreign["feature_type"] == "gd_entrance_list") {
+                    entrancesFeatureCollection.addFeature(feature)
+                }
+            }
+        }
+        return entrancesFeatureCollection
+    }
+
+    /**
+     * Parses out all the Points of Interest (POI) in a tile FeatureCollection.
+     * @param tileFeatureCollection
+     * A FeatureCollection object.
+     * @return a Feature collection object that contains only POI.
+     */
+    fun getPointsOfInterestFeatureCollectionFromTileFeatureCollection(
+        tileFeatureCollection: FeatureCollection
+    ): FeatureCollection {
+        val poiFeaturesCollection = FeatureCollection()
+        for (feature in tileFeatureCollection) {
+            feature.foreign?.let { foreign ->
+                if (foreign["feature_type"] != "highway" && foreign["feature_type"] != "gd_entrance_list") {
+                    poiFeaturesCollection.addFeature(feature)
+                }
+            }
+        }
+        return poiFeaturesCollection
+    }
+
     companion object {
         fun createFromFeatureCollection(featureCollection: FeatureCollection) : GridState {
 
             val gridState = GridState()
 
-            val collections = processTileFeatureCollection(featureCollection)
+            val collections = gridState.processTileFeatureCollection(featureCollection)
             for ((index, collection) in collections.withIndex()) {
                 gridState.featureTrees[index] = FeatureTree(collection)
             }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/ProtomapsGridState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/ProtomapsGridState.kt
@@ -1,0 +1,84 @@
+package org.scottishtecharmy.soundscape.geoengine
+
+import android.app.Application
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
+import org.scottishtecharmy.soundscape.geoengine.mvttranslation.InterpolatedPointsJoiner
+import org.scottishtecharmy.soundscape.geoengine.mvttranslation.vectorTileToGeoJson
+import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
+import org.scottishtecharmy.soundscape.geoengine.utils.mergeAllPolygonsInFeatureCollection
+import org.scottishtecharmy.soundscape.geoengine.utils.processTileFeatureCollection
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
+import org.scottishtecharmy.soundscape.network.ITileDAO
+import org.scottishtecharmy.soundscape.network.ProtomapsTileClient
+import org.scottishtecharmy.soundscape.services.SoundscapeService
+import retrofit2.awaitResponse
+import kotlin.coroutines.cancellation.CancellationException
+
+class ProtomapsGridState : GridState() {
+
+    override fun start(application: Application, soundscapeService: SoundscapeService) {
+        tileClient = ProtomapsTileClient(application)
+    }
+
+    /**
+     * updateTile is responsible for getting data from the protomaps server and translating it from
+     * MVT format into a set of FeatureCollections.
+     */
+    override suspend fun updateTile(
+        x: Int,
+        y: Int,
+        featureCollections: Array<FeatureCollection>,
+    ): Boolean {
+        var ret = false
+        withContext(Dispatchers.IO) {
+            try {
+                val service =
+                    tileClient.retrofitInstance?.create(ITileDAO::class.java)
+                val tileReq =
+                    async {
+                        service?.getVectorTileWithCache(x, y, ZOOM_LEVEL)
+                    }
+                val result = tileReq.await()?.awaitResponse()?.body()
+                if (result != null) {
+                    Log.e(TAG, "Tile size ${result.serializedSize}")
+                    val tileFeatureCollection = vectorTileToGeoJson(x, y, result)
+                    val collections = processTileFeatureCollection(tileFeatureCollection)
+                    for ((index, collection) in collections.withIndex()) {
+                        featureCollections[index].plusAssign(collection)
+                    }
+
+                    ret = true
+                } else {
+                    Log.e(TAG, "No response for protomaps tile")
+                }
+            } catch (ce: CancellationException) {
+                // We have to rethrow cancellation exceptions
+                throw ce
+            } catch (e: Exception) {
+                Log.e(TAG, "Exception getting protomaps tile $e")
+            }
+        }
+        return ret
+    }
+
+    override fun fixupCollectionAndCreateTrees(trees: Array<FeatureTree>, featureCollections: Array<FeatureCollection>) {
+        // Join up roads/paths at the tile boundary
+        val joiner = InterpolatedPointsJoiner()
+        for (ip in featureCollections[TreeId.INTERPOLATIONS.id]) {
+            joiner.addInterpolatedPoints(ip)
+        }
+        // merging any overlapping Polygons that are on the tile boundaries
+        val mergedPoi = mergeAllPolygonsInFeatureCollection(featureCollections[TreeId.POIS.id])
+        featureCollections[TreeId.POIS.id] = mergedPoi
+
+        joiner.addJoiningLines(featureCollections[TreeId.ROADS_AND_PATHS.id])
+
+        // Create rtrees for each feature collection
+        for ((index, fc) in featureCollections.withIndex()) {
+            trees[index] = FeatureTree(fc)
+        }
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/ProtomapsGridState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/ProtomapsGridState.kt
@@ -9,7 +9,6 @@ import org.scottishtecharmy.soundscape.geoengine.mvttranslation.InterpolatedPoin
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.vectorTileToGeoJson
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geoengine.utils.mergeAllPolygonsInFeatureCollection
-import org.scottishtecharmy.soundscape.geoengine.utils.processTileFeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.network.ITileDAO
 import org.scottishtecharmy.soundscape.network.ProtomapsTileClient

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/SoundscapeBackendGridState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/SoundscapeBackendGridState.kt
@@ -5,12 +5,9 @@ import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
-import org.scottishtecharmy.soundscape.geoengine.mvttranslation.InterpolatedPointsJoiner
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geoengine.utils.cleanTileGeoJSON
 import org.scottishtecharmy.soundscape.geoengine.utils.deduplicateFeatureCollection
-import org.scottishtecharmy.soundscape.geoengine.utils.mergeAllPolygonsInFeatureCollection
-import org.scottishtecharmy.soundscape.geoengine.utils.processTileString
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.network.ITileDAO
 import org.scottishtecharmy.soundscape.network.SoundscapeBackendTileClient

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/SoundscapeBackendGridState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/SoundscapeBackendGridState.kt
@@ -1,0 +1,85 @@
+package org.scottishtecharmy.soundscape.geoengine
+
+import android.app.Application
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
+import org.scottishtecharmy.soundscape.geoengine.mvttranslation.InterpolatedPointsJoiner
+import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
+import org.scottishtecharmy.soundscape.geoengine.utils.cleanTileGeoJSON
+import org.scottishtecharmy.soundscape.geoengine.utils.deduplicateFeatureCollection
+import org.scottishtecharmy.soundscape.geoengine.utils.mergeAllPolygonsInFeatureCollection
+import org.scottishtecharmy.soundscape.geoengine.utils.processTileString
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
+import org.scottishtecharmy.soundscape.network.ITileDAO
+import org.scottishtecharmy.soundscape.network.SoundscapeBackendTileClient
+import org.scottishtecharmy.soundscape.services.SoundscapeService
+import retrofit2.awaitResponse
+import kotlin.coroutines.cancellation.CancellationException
+
+class SoundscapeBackendGridState : GridState() {
+
+    override fun start(application: Application, soundscapeService: SoundscapeService) {
+        tileClient = SoundscapeBackendTileClient(application)
+    }
+
+    override suspend fun updateTile(
+        x: Int,
+        y: Int,
+        featureCollections: Array<FeatureCollection>,
+    ): Boolean {
+        var ret = false
+
+        withContext(Dispatchers.IO) {
+            try {
+                val service =
+                    tileClient.retrofitInstance?.create(ITileDAO::class.java)
+                val tileReq =
+                    async {
+                        service?.getTileWithCache(x, y)
+                    }
+                val result = tileReq.await()?.awaitResponse()?.body()
+                // clean the tile, process the string, perform an insert into db using the clean tile data
+                Log.e(TAG, "Tile size ${result?.length}")
+                val cleanedTile =
+                    result?.let { cleanTileGeoJSON(x, y, ZOOM_LEVEL, it) }
+
+                if (cleanedTile != null) {
+                    val tileData = processTileString(cleanedTile)
+                    for ((index, collection) in tileData.withIndex()) {
+                        featureCollections[index].plusAssign(collection)
+                    }
+
+                    ret = true
+                } else {
+                    Log.e(TAG, "Failed to get clean soundscape-backend tile")
+                }
+            } catch (ce: CancellationException) {
+                // We have to rethrow cancellation exceptions
+                throw ce
+            } catch (e: Exception) {
+                Log.e(TAG, "Exception getting soundscape-backend tile $e")
+            }
+        }
+        return ret
+    }
+
+    override fun fixupCollectionAndCreateTrees(trees: Array<FeatureTree>, featureCollections: Array<FeatureCollection>){
+        // De-duplicate
+        val deDuplicatedCollection =
+            Array(TreeId.MAX_COLLECTION_ID.id) { FeatureCollection() }
+        for ((index, fc) in featureCollections.withIndex()) {
+            val existingSet: MutableSet<Any> = mutableSetOf()
+            deduplicateFeatureCollection(
+                deDuplicatedCollection[index],
+                fc,
+                existingSet,
+            )
+        }
+        // Create rtrees for each feature collection
+        for ((index, fc) in deDuplicatedCollection.withIndex()) {
+            trees[index] = FeatureTree(fc)
+        }
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/StreetPreview.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/StreetPreview.kt
@@ -1,7 +1,6 @@
 package org.scottishtecharmy.soundscape.geoengine
 
 import android.util.Log
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine.Fc
 import org.scottishtecharmy.soundscape.geoengine.utils.RoadDirectionAtIntersection
 import org.scottishtecharmy.soundscape.geoengine.utils.bearingFromTwoPoints
 import org.scottishtecharmy.soundscape.geoengine.utils.distanceToLineString
@@ -42,7 +41,7 @@ class StreetPreview {
 
             PreviewState.INITIAL -> {
                 // Jump to a node on the nearest road or path
-                val road = engine.getNearestFeature(Fc.ROADS_AND_PATHS.id, location, Double.POSITIVE_INFINITY)
+                val road = engine.gridState.getNearestFeature(TreeId.ROADS_AND_PATHS, location, Double.POSITIVE_INFINITY)
                     ?: return
 
                 var nearestDistance = Double.POSITIVE_INFINITY
@@ -131,7 +130,7 @@ class StreetPreview {
 
             if (index != 0) {
                 // Check for an intersection at this point by searching in the intersection tree
-                val intersection = engine.getNearestFeature(Fc.INTERSECTIONS.id, point, 0.5)
+                val intersection = engine.gridState.getNearestFeature(TreeId.INTERSECTIONS, point, 0.5)
                 if (intersection != null) {
                     Log.e(
                         TAG,
@@ -172,7 +171,7 @@ class StreetPreview {
             }
             val currentPoint = line.last()
             val previousPoint = line.dropLast(1).last()
-            val roads = engine.getGridFeatureCollection(Fc.ROADS_AND_PATHS.id, currentPoint, 0.5, 3)
+            val roads = engine.gridState.getFeatureCollection(TreeId.ROADS_AND_PATHS, currentPoint, 0.5, 3)
             for (road in roads) {
                 // Find which roads the currentPoint is in
                 val roadPoints = road.geometry as LineString
@@ -207,8 +206,8 @@ class StreetPreview {
 
         val start = System.currentTimeMillis()
 
-        val nearestIntersection = engine.getNearestFeature(Fc.INTERSECTIONS.id, location, 1.0)
-        val nearestRoads = engine.getGridFeatureCollection(Fc.ROADS_AND_PATHS.id, location, 1.0)
+        val nearestIntersection = engine.gridState.getNearestFeature(TreeId.INTERSECTIONS, location, 1.0)
+        val nearestRoads = engine.gridState.getFeatureCollection(TreeId.ROADS_AND_PATHS, location, 1.0)
 
         if (nearestIntersection != null) {
             // We're at an intersection

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/IntersectionUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/IntersectionUtils.kt
@@ -24,6 +24,7 @@ import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
+import org.scottishtecharmy.soundscape.screens.home.home.USER_POSITION_MARKER_NAME
 
 enum class ComplexIntersectionApproach {
     INTERSECTION_WITH_MOST_OSM_IDS,
@@ -53,7 +54,7 @@ fun getRoadsDescriptionFromFov(gridState: GridState,
 ) : RoadsDescription {
 
     // Create FOV triangle
-    val points = getFovTrianglePoints(userGeometry.location, userGeometry.heading, userGeometry.fovDistance)
+    val points = getFovTrianglePoints(userGeometry)
 
     val roadTree = gridState.getFeatureTree(TreeId.ROADS)
     val intersectionTree = gridState.getFeatureTree(TreeId.INTERSECTIONS)
@@ -116,10 +117,13 @@ fun getRoadsDescriptionFromFov(gridState: GridState,
 
     // Create a set of relative direction polygons
     val intersectionLocation = intersection!!.geometry as Point
-    val relativeDirections = getRelativeDirectionsPolygons(
+    val geometry = GeoEngine.UserGeometry(
         intersectionLocation.coordinates,
         nearestRoadBearing,
-        5.0,
+        5.0
+    )
+    val relativeDirections = getRelativeDirectionsPolygons(
+        geometry,
         RelativeDirections.COMBINED
     )
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/IntersectionUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/IntersectionUtils.kt
@@ -1,8 +1,9 @@
 package org.scottishtecharmy.soundscape.geoengine.callouts
 
 import android.content.Context
-import android.util.Log
 import org.scottishtecharmy.soundscape.R
+import org.scottishtecharmy.soundscape.geoengine.TreeId
+import org.scottishtecharmy.soundscape.geoengine.GridState
 import org.scottishtecharmy.soundscape.geoengine.PositionedString
 import org.scottishtecharmy.soundscape.geoengine.filters.CalloutHistory
 import org.scottishtecharmy.soundscape.geoengine.filters.TrackedCallout
@@ -49,8 +50,7 @@ data class RoadsDescription(val nearestRoad: Feature? = null,
  * @return An IntersectionDescription containing all the data required for callouts to describe the
  * intersection.
  */
-fun getRoadsDescriptionFromFov(roadTree: FeatureTree,
-                               intersectionTree: FeatureTree,
+fun getRoadsDescriptionFromFov(gridState: GridState,
                                currentLocation: LngLatAlt,
                                deviceHeading: Double,
                                fovDistance: Double,
@@ -59,6 +59,9 @@ fun getRoadsDescriptionFromFov(roadTree: FeatureTree,
 
     // Create FOV triangle
     val points = getFovTrianglePoints(currentLocation, deviceHeading, fovDistance)
+
+    val roadTree = gridState.getFeatureTree(TreeId.ROADS)
+    val intersectionTree = gridState.getFeatureTree(TreeId.INTERSECTIONS)
 
     // Find roads within FOV
     val fovRoads = roadTree.generateFeatureCollectionWithinTriangle(

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/GeoUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/GeoUtils.kt
@@ -748,11 +748,7 @@ fun lineStringIsCircular(path: LineString): Boolean {
 fun getQuadrants(heading: Double): List<Quadrant> {
     // Find the quadrant the heading is currently in
     val quadrantIndex = ((heading + 45.0).rem(360.0)).toInt() / 90
-
-    val northHeading = when (quadrantIndex) {
-        0 -> heading
-        else -> (heading + 90 * (4 - quadrantIndex).toDouble()).rem(360.0)
-    }
+    val northHeading = (heading + 90 * (4 - quadrantIndex).toDouble()).rem(360.0)
 
     // Define the quadrants based off the offset heading to the north
     return listOf(
@@ -816,27 +812,6 @@ fun distanceToPolygon(
         last = current
     }
     return minDistance
-}
-
-/**
- * Distance to an intersection from current location.
- * @param location
- * LngLatAlt of current location
- * @param intersection
- * Coordinates for intersection that we want to know the distance to as Point
- * @return The distance of the current location to the intersection in meters.
- */
-fun distanceToIntersection(
-    location: LngLatAlt,
-    intersection: Point
-): Double {
-    return distance(
-        location.latitude,
-        location.longitude,
-        intersection.coordinates.latitude,
-        intersection.coordinates.longitude
-    )
-
 }
 
 /**

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/Quadrant.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/Quadrant.kt
@@ -1,13 +1,9 @@
 package org.scottishtecharmy.soundscape.geoengine.utils
 
-class Quadrant(private val heading: Double) {
-    val left: Double
-    val right: Double
+open class Segment(heading: Double, width: Double) {
 
-    init {
-        left = (heading + 315) % 360.0
-        right = (heading + 45) % 360.0
-    }
+    val left: Double = (heading + 360-(width/2)) % 360.0
+    val right: Double = (heading + width/2) % 360.0
 
     fun contains(headingToCheck: Double): Boolean {
         val wrappedHeading = headingToCheck % 360.0
@@ -17,3 +13,5 @@ class Quadrant(private val heading: Double) {
         } else right < left && (wrappedHeading >= left || wrappedHeading < right)
     }
 }
+
+class Quadrant(private val heading: Double) : Segment(heading, 90.0)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileUtils.kt
@@ -16,7 +16,7 @@ import com.squareup.moshi.Moshi
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.GeometryFactory
 import org.scottishtecharmy.soundscape.dto.BoundingBox
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
+import org.scottishtecharmy.soundscape.geoengine.TreeId
 import org.scottishtecharmy.soundscape.geojsonparser.moshi.GeoJsonObjectMoshiAdapter
 import java.io.FileOutputStream
 import java.lang.Math.toDegrees
@@ -444,20 +444,20 @@ fun processTileString(tileString: String): Array<FeatureCollection> {
 
 fun processTileFeatureCollection(tileFeatureCollection: FeatureCollection): Array<FeatureCollection> {
 
-    val tileData = Array(GeoEngine.Fc.MAX_COLLECTION_ID.id) { FeatureCollection() }
+    val tileData = Array(TreeId.MAX_COLLECTION_ID.id) { FeatureCollection() }
 
     // We have separate collections for the different types of Feature. ROADS_AND_PATHS adds PATHS
     // to the ROADS features already contained in ROADS. This slight extra cost in terms of memory
     // is made up for by the ease of searching a single collection.
-    tileData[GeoEngine.Fc.ROADS.id] = getRoadsFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
-    tileData[GeoEngine.Fc.ROADS_AND_PATHS.id] = getPathsFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
-    tileData[GeoEngine.Fc.ROADS_AND_PATHS.id].plusAssign(tileData[GeoEngine.Fc.ROADS.id])
-    tileData[GeoEngine.Fc.INTERSECTIONS.id] = getIntersectionsFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
-    tileData[GeoEngine.Fc.ENTRANCES.id] = getEntrancesFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
-    tileData[GeoEngine.Fc.POIS.id] = getPointsOfInterestFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
-    tileData[GeoEngine.Fc.BUS_STOPS.id] = getBusStopsFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
-    tileData[GeoEngine.Fc.CROSSINGS.id] = getCrossingsFromTileFeatureCollection(tileFeatureCollection)
-    tileData[GeoEngine.Fc.INTERPOLATIONS.id] = getInterpolationPointsFromTileFeatureCollection(tileFeatureCollection)
+    tileData[TreeId.ROADS.id] = getRoadsFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
+    tileData[TreeId.ROADS_AND_PATHS.id] = getPathsFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
+    tileData[TreeId.ROADS_AND_PATHS.id].plusAssign(tileData[TreeId.ROADS.id])
+    tileData[TreeId.INTERSECTIONS.id] = getIntersectionsFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
+    tileData[TreeId.ENTRANCES.id] = getEntrancesFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
+    tileData[TreeId.POIS.id] = getPointsOfInterestFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
+    tileData[TreeId.BUS_STOPS.id] = getBusStopsFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
+    tileData[TreeId.CROSSINGS.id] = getCrossingsFromTileFeatureCollection(tileFeatureCollection)
+    tileData[TreeId.INTERPOLATIONS.id] = getInterpolationPointsFromTileFeatureCollection(tileFeatureCollection)
 
     return  tileData
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileUtils.kt
@@ -4,7 +4,6 @@ import org.scottishtecharmy.soundscape.dto.IntersectionRelativeDirections
 import org.scottishtecharmy.soundscape.dto.Tile
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
-import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LineString
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.MultiLineString
@@ -12,12 +11,10 @@ import org.scottishtecharmy.soundscape.geojsonparser.geojson.MultiPoint
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.MultiPolygon
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Polygon
-import com.squareup.moshi.Moshi
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.GeometryFactory
 import org.scottishtecharmy.soundscape.dto.BoundingBox
 import org.scottishtecharmy.soundscape.geoengine.GeoEngine
-import org.scottishtecharmy.soundscape.geoengine.TreeId
 import org.scottishtecharmy.soundscape.geojsonparser.moshi.GeoJsonObjectMoshiAdapter
 import java.io.FileOutputStream
 import java.lang.Math.toDegrees
@@ -161,200 +158,6 @@ fun getTilesForRegion(
 }
 
 /**
- * Given a valid Tile feature collection this will parse the collection and return a roads
- * feature collection. Uses the "highway" feature_type to extract roads from GeoJSON.
- * @param tileFeatureCollection
- * A FeatureCollection object.
- * @return A FeatureCollection object that contains only roads.
- */
-fun getRoadsFeatureCollectionFromTileFeatureCollection(
-    tileFeatureCollection: FeatureCollection
-): FeatureCollection {
-
-    val roadsFeatureCollection = FeatureCollection()
-
-    // Original Soundscape excludes the below feature_value (s) even though they have the
-    // feature_type == highway
-    // and creates a separate Paths Feature Collection for them
-    // "footway", "path", "cycleway", "bridleway"
-    // gd_intersection are a special case and get their own Intersections Feature Collection
-
-
-    for (feature in tileFeatureCollection) {
-        feature.foreign?.let { foreign ->
-            if (foreign["feature_type"] == "highway"
-                && foreign["feature_value"] != "gd_intersection"
-                && foreign["feature_value"] != "footway"
-                && foreign["feature_value"] != "path"
-                && foreign["feature_value"] != "cycleway"
-                && foreign["feature_value"] != "bridleway"
-                && foreign["feature_value"] != "bus_stop"
-                && foreign["feature_value"] != "crossing") {
-                    // We're only going to add linestrings to the roads feature collection
-                    when(feature.geometry.type) {
-                        "LineString", "MultiLineString" ->
-                            roadsFeatureCollection.addFeature(feature)
-                    }
-            }
-        }
-    }
-    return roadsFeatureCollection
-}
-
-/**
- * Given a valid Tile feature collection this will parse the collection and return a bus stops
- * feature collection. Uses the "bus_stop" feature_value to extract bus stops from GeoJSON.
- * @param tileFeatureCollection
- * A FeatureCollection object.
- * @return A FeatureCollection object that contains only bus stops.
- */
-fun getBusStopsFeatureCollectionFromTileFeatureCollection(
-    tileFeatureCollection: FeatureCollection
-): FeatureCollection{
-    val busStopFeatureCollection = FeatureCollection()
-    for (feature in tileFeatureCollection) {
-        feature.foreign?.let { foreign ->
-            if (foreign["feature_type"] == "highway" && foreign["feature_value"] == "bus_stop") {
-                busStopFeatureCollection.addFeature(feature)
-            }
-        }
-    }
-
-    return busStopFeatureCollection
-}
-
-/**
- * Given a valid Tile feature collection this will parse the collection and return a crossing
- * feature collection. Uses the "crossing" feature_value to extract crossings from GeoJSON.
- * @param tileFeatureCollection
- * A FeatureCollection object.
- * @return A FeatureCollection object that contains only crossings.
- */
-fun getCrossingsFromTileFeatureCollection(tileFeatureCollection: FeatureCollection): FeatureCollection{
-    val crossingsFeatureCollection = FeatureCollection()
-    for (feature in tileFeatureCollection) {
-        feature.foreign?.let { foreign ->
-            if (foreign["feature_type"] == "highway" && foreign["feature_value"] == "crossing") {
-                crossingsFeatureCollection.addFeature(feature)
-            }
-        }
-    }
-    return crossingsFeatureCollection
-}
-
-/**
- * Given a valid Tile feature collection this will parse the collection and return an interpolation
- * points feature collection. Uses the "edgePoint" feature_value to extract crossings from GeoJSON.
- * @param tileFeatureCollection
- * A FeatureCollection object.
- * @return A FeatureCollection object that contains only edgePoints
- */
-fun getInterpolationPointsFromTileFeatureCollection(tileFeatureCollection: FeatureCollection): FeatureCollection{
-    val interpolationPointsFeatureCollection = FeatureCollection()
-    for (feature in tileFeatureCollection) {
-        feature.properties?.let { properties ->
-            if (properties["class"] == "edgePoint") {
-                interpolationPointsFeatureCollection.addFeature(feature)
-            }
-        }
-    }
-    return interpolationPointsFeatureCollection
-}
-
-/**
- * Given a valid Tile feature collection this will parse the collection and return a paths
- * feature collection. Uses the "footway", "path", "cycleway", "bridleway" feature_value to extract
- * Paths from Feature Collection.
- * @param tileFeatureCollection
- * A FeatureCollection object.
- * @return A FeatureCollection object that contains only paths.
- */
-fun getPathsFeatureCollectionFromTileFeatureCollection(
-    tileFeatureCollection: FeatureCollection
-): FeatureCollection{
-    val pathsFeatureCollection = FeatureCollection()
-
-    for(feature in tileFeatureCollection) {
-        feature.foreign?.let { foreign ->
-            // We're only going to add linestrings to the roads feature collection
-            when(feature.geometry.type) {
-                "LineString", "MultiLineString" -> {
-                    if (foreign["feature_type"] == "highway")
-                        when (foreign["feature_value"]) {
-                            "footway" -> pathsFeatureCollection.addFeature(feature)
-                            "path" -> pathsFeatureCollection.addFeature(feature)
-                            "cycleway" -> pathsFeatureCollection.addFeature(feature)
-                            "bridleway" -> pathsFeatureCollection.addFeature(feature)
-                        }
-                }
-            }
-        }
-    }
-    return pathsFeatureCollection
-}
-
-/**
- * Parses out all the Intersections in a tile FeatureCollection using the "gd_intersection" feature_value.
- * @param tileFeatureCollection
- * A FeatureCollection object.
- * @return a Feature collection object that only contains intersections.
- */
-fun getIntersectionsFeatureCollectionFromTileFeatureCollection(
-    tileFeatureCollection: FeatureCollection
-): FeatureCollection {
-    val intersectionsFeatureCollection = FeatureCollection()
-    // split out the intersections into their own intersections FeatureCollection
-    for (feature in tileFeatureCollection) {
-        feature.foreign?.let { foreign ->
-            if (foreign["feature_type"] == "highway" && foreign["feature_value"] == "gd_intersection") {
-                intersectionsFeatureCollection.addFeature(feature)
-            }
-        }
-    }
-    return intersectionsFeatureCollection
-}
-
-/**
- * Parses out all the Entrances in a tile FeatureCollection using the "gd_entrance_list" feature_type.
- * @param tileFeatureCollection
- * A FeatureCollection object.
- * @return a feature collection object that contains only entrances.
- */
-fun getEntrancesFeatureCollectionFromTileFeatureCollection(
-    tileFeatureCollection: FeatureCollection
-): FeatureCollection {
-    val entrancesFeatureCollection = FeatureCollection()
-    for (feature in tileFeatureCollection) {
-        feature.foreign?.let { foreign ->
-            if (foreign["feature_type"] == "gd_entrance_list") {
-                entrancesFeatureCollection.addFeature(feature)
-            }
-        }
-    }
-    return entrancesFeatureCollection
-}
-
-/**
- * Parses out all the Points of Interest (POI) in a tile FeatureCollection.
- * @param tileFeatureCollection
- * A FeatureCollection object.
- * @return a Feature collection object that contains only POI.
- */
-fun getPointsOfInterestFeatureCollectionFromTileFeatureCollection(
-    tileFeatureCollection: FeatureCollection
-): FeatureCollection {
-    val poiFeaturesCollection = FeatureCollection()
-    for (feature in tileFeatureCollection) {
-        feature.foreign?.let { foreign ->
-            if (foreign["feature_type"] != "highway" && foreign["feature_type"] != "gd_entrance_list") {
-                poiFeaturesCollection.addFeature(feature)
-            }
-        }
-    }
-    return poiFeaturesCollection
-}
-
-/**
  * Parses out the super category Features contained in the Points of Interest (POI) Feature Collection.
  * @param superCategory
  * String for super category. Options are "information", "object", "place", "landmark", "mobility", "safety"
@@ -426,41 +229,6 @@ fun removeDuplicateOsmIds(
     deduplicateFeatureCollection(tempFeatureCollection, featureCollection, processedOsmIds)
 
     return tempFeatureCollection
-}
-
-/**
- * Parses out roads, paths, intersections, entrances, pois, bus stops and crossings from a tile string.
- * @return a TileData object with the string parsed into separate strings.
- */
-
-fun processTileString(tileString: String): Array<FeatureCollection> {
-    val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-    val tileFeatureCollection = moshi.adapter(FeatureCollection::class.java)
-        .fromJson(tileString)
-    if(tileFeatureCollection == null)
-        return emptyArray()
-
-    return processTileFeatureCollection(tileFeatureCollection)
-}
-
-fun processTileFeatureCollection(tileFeatureCollection: FeatureCollection): Array<FeatureCollection> {
-
-    val tileData = Array(TreeId.MAX_COLLECTION_ID.id) { FeatureCollection() }
-
-    // We have separate collections for the different types of Feature. ROADS_AND_PATHS adds PATHS
-    // to the ROADS features already contained in ROADS. This slight extra cost in terms of memory
-    // is made up for by the ease of searching a single collection.
-    tileData[TreeId.ROADS.id] = getRoadsFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
-    tileData[TreeId.ROADS_AND_PATHS.id] = getPathsFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
-    tileData[TreeId.ROADS_AND_PATHS.id].plusAssign(tileData[TreeId.ROADS.id])
-    tileData[TreeId.INTERSECTIONS.id] = getIntersectionsFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
-    tileData[TreeId.ENTRANCES.id] = getEntrancesFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
-    tileData[TreeId.POIS.id] = getPointsOfInterestFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
-    tileData[TreeId.BUS_STOPS.id] = getBusStopsFeatureCollectionFromTileFeatureCollection(tileFeatureCollection)
-    tileData[TreeId.CROSSINGS.id] = getCrossingsFromTileFeatureCollection(tileFeatureCollection)
-    tileData[TreeId.INTERPOLATIONS.id] = getInterpolationPointsFromTileFeatureCollection(tileFeatureCollection)
-
-    return  tileData
 }
 
 data class FovLeftRight(val left: LngLatAlt, val right: LngLatAlt)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeViewModel.kt
@@ -119,19 +119,6 @@ class HomeViewModel
                     }
                 }
             }
-
-            viewModelScope.launch(job) {
-                // Observe tile grid update from the service so we can show it on the map
-                soundscapeServiceConnection.getTileGridFlow()?.collectLatest { tileGrid ->
-                    if (tileGrid.tiles.isNotEmpty()) {
-                        Log.d(TAG, "new tile grid")
-                        // Flow out the GeoJSON describing our current grid
-                        _state.update { it.copy(tileGridGeoJson = tileGrid.generateGeoJson()) }
-                    } else {
-                        _state.update { it.copy(tileGridGeoJson = "") }
-                    }
-                }
-            }
         }
 
         private fun stopMonitoringLocation() {

--- a/app/src/test/java/org/scottishtecharmy/soundscape/BusStopTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/BusStopTest.kt
@@ -4,24 +4,23 @@ import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
 import org.scottishtecharmy.soundscape.geoengine.GeoEngine
+import org.scottishtecharmy.soundscape.geoengine.GridState.Companion.createFromGeoJson
+import org.scottishtecharmy.soundscape.geoengine.TreeId
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
-import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
-import org.scottishtecharmy.soundscape.geoengine.utils.getBusStopsFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getFovFeatureCollection
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
 
 class BusStopTest {
 
     @Test
     fun busStopTest(){
-        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val featureCollectionTest = moshi.adapter(FeatureCollection::class.java)
-            .fromJson(GeoJsonIntersectionStraight.intersectionStraightAheadFeatureCollection)
+        val gridState = createFromGeoJson(GeoJsonIntersectionStraight.intersectionStraightAheadFeatureCollection)
 
         // extract bus stops for tile
-        val busStopFeatureCollection = getBusStopsFeatureCollectionFromTileFeatureCollection(featureCollectionTest!!)
+        val busStopFeatureCollection = gridState.getFeatureCollection(TreeId.BUS_STOPS)
         // There are only two bus stops in this tile
         Assert.assertEquals(2, busStopFeatureCollection.features.size)
 
@@ -29,6 +28,7 @@ class BusStopTest {
         // about it apart from correcting them individually in OSM and then hoping the backend picks it up correctly.
         // This is a good examples as the points are way off their actual location in the real world.
         // One appears to be in a garden and the other is on the wrong side of the road!
+        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
         val busStopString = moshi.adapter(FeatureCollection::class.java).toJson(busStopFeatureCollection)
         println("Bus stops in tile: $busStopString")
 

--- a/app/src/test/java/org/scottishtecharmy/soundscape/BusStopTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/BusStopTest.kt
@@ -3,12 +3,12 @@ package org.scottishtecharmy.soundscape
 import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
+import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
-import org.scottishtecharmy.soundscape.geoengine.utils.distance
 import org.scottishtecharmy.soundscape.geoengine.utils.getBusStopsFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getFovFeatureCollection
 
@@ -34,27 +34,23 @@ class BusStopTest {
 
         // However we can get some dodgy info for the user so...
         // pretend the device is here, pointing along the road and our field of view
-        val currentLocation = LngLatAlt(-2.655732516651227,51.430910659124464)
-        val deviceHeading = 225.0
-        val fovDistance = 50.0
+        val userGeometry = GeoEngine.UserGeometry(
+            LngLatAlt(-2.655732516651227,51.430910659124464),
+            225.0,
+            50.0
+        )
+
         // we can reuse the intersection code as bus stops are GeoJSON Points just like Intersections
         val fovBusStopFeatureCollection = getFovFeatureCollection(
-            currentLocation,
-            deviceHeading,
-            fovDistance,
+            userGeometry,
             FeatureTree(busStopFeatureCollection)
         )
         Assert.assertEquals(2, fovBusStopFeatureCollection.features.size)
         // we can detect the nearest bus stop and give a distance/direction but as mentioned above the OSM
         // bus stop location data for this example is rubbish so not sure how useful this is to the user?
-        val nearestBusStop = FeatureTree(fovBusStopFeatureCollection).getNearestFeature(currentLocation)
+        val nearestBusStop = FeatureTree(fovBusStopFeatureCollection).getNearestFeature(userGeometry.location)
         val busStopLocation = nearestBusStop!!.geometry as Point
-        val distanceToBusStop = distance(
-            currentLocation.latitude,
-            currentLocation.longitude,
-            busStopLocation.coordinates.latitude,
-            busStopLocation.coordinates.longitude
-        )
+        val distanceToBusStop = userGeometry.location.distance(busStopLocation.coordinates)
         Assert.assertEquals(9.08, distanceToBusStop, 0.1)
 
         // Here's the naptan stuff stored in the bus stop properties which might be

--- a/app/src/test/java/org/scottishtecharmy/soundscape/ComplexIntersections.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/ComplexIntersections.kt
@@ -1,16 +1,11 @@
 package org.scottishtecharmy.soundscape
 
-import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
+import org.scottishtecharmy.soundscape.geoengine.GridState
 import org.scottishtecharmy.soundscape.geoengine.callouts.ComplexIntersectionApproach
-import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
-import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
-import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
-import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionsFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.callouts.getRoadsDescriptionFromFov
-import org.scottishtecharmy.soundscape.geoengine.utils.getRoadsFeatureCollectionFromTileFeatureCollection
 
 class ComplexIntersections {
 
@@ -26,40 +21,32 @@ class ComplexIntersections {
         val deviceHeading = 320.0
         val fovDistance = 50.0
 
-        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val featureCollectionTest = moshi.adapter(FeatureCollection::class.java)
-            .fromJson(GeoJSONDataComplexIntersection1.complexintersection1GeoJSON)
-
-        // Get the roads from the tile
-        val testRoadsCollectionFromTileFeatureCollection =
-            getRoadsFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest!!
-            )
-
-        // Get the intersections from the tile
-        val testIntersectionsCollectionFromTileFeatureCollection =
-            getIntersectionsFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest
-            )
-
+        val gridState = GridState.createFromGeoJson(GeoJSONDataComplexIntersection1.complexintersection1GeoJSON)
         val roadRelativeDirections = getRoadsDescriptionFromFov(
-            FeatureTree(testRoadsCollectionFromTileFeatureCollection),
-            FeatureTree(testIntersectionsCollectionFromTileFeatureCollection),
+            gridState,
             currentLocation,
             deviceHeading,
             fovDistance,
-            ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION).intersectionRoads
+            ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION
+        ).intersectionRoads
 
-
-        Assert.assertEquals(3, roadRelativeDirections.features.size )
+        Assert.assertEquals(3, roadRelativeDirections.features.size)
 
         Assert.assertEquals(0, roadRelativeDirections.features[0].properties!!["Direction"])
-        Assert.assertEquals("Flax Bourton Road", roadRelativeDirections.features[0].properties!!["name"])
+        Assert.assertEquals(
+            "Flax Bourton Road",
+            roadRelativeDirections.features[0].properties!!["name"]
+        )
         Assert.assertEquals(3, roadRelativeDirections.features[1].properties!!["Direction"])
-        Assert.assertEquals("Clevedon Road", roadRelativeDirections.features[1].properties!!["name"])
+        Assert.assertEquals(
+            "Clevedon Road",
+            roadRelativeDirections.features[1].properties!!["name"]
+        )
         Assert.assertEquals(7, roadRelativeDirections.features[2].properties!!["Direction"])
-        Assert.assertEquals("Clevedon Road", roadRelativeDirections.features[2].properties!!["name"])
-
+        Assert.assertEquals(
+            "Clevedon Road",
+            roadRelativeDirections.features[2].properties!!["name"]
+        )
     }
 
     @Test
@@ -73,39 +60,36 @@ class ComplexIntersections {
         val deviceHeading = 45.0
         val fovDistance = 50.0
 
-        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val featureCollectionTest = moshi.adapter(FeatureCollection::class.java)
-            .fromJson(GeoJSONDataComplexIntersection.complexIntersectionGeoJSON)
-
-        // Get the roads from the tile
-        val testRoadsCollectionFromTileFeatureCollection =
-            getRoadsFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest!!
-            )
-
-        // Get the intersections from the tile
-        val testIntersectionsCollectionFromTileFeatureCollection =
-            getIntersectionsFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest
-            )
+        val gridState = GridState.createFromGeoJson(GeoJSONDataComplexIntersection.complexIntersectionGeoJSON)
         val roadRelativeDirections = getRoadsDescriptionFromFov(
-            FeatureTree(testRoadsCollectionFromTileFeatureCollection),
-            FeatureTree(testIntersectionsCollectionFromTileFeatureCollection),
+            gridState,
             currentLocation,
             deviceHeading,
             fovDistance,
-            ComplexIntersectionApproach.INTERSECTION_WITH_MOST_OSM_IDS).intersectionRoads
+            ComplexIntersectionApproach.INTERSECTION_WITH_MOST_OSM_IDS
+        ).intersectionRoads
 
-        Assert.assertEquals(4, roadRelativeDirections.features.size )
+        Assert.assertEquals(4, roadRelativeDirections.features.size)
         //
         Assert.assertEquals(1, roadRelativeDirections.features[0].properties!!["Direction"])
-        Assert.assertEquals("Clevedon Road", roadRelativeDirections.features[0].properties!!["name"])
+        Assert.assertEquals(
+            "Clevedon Road",
+            roadRelativeDirections.features[0].properties!!["name"]
+        )
         Assert.assertEquals(3, roadRelativeDirections.features[1].properties!!["Direction"])
-        Assert.assertEquals("Beggar Bush Lane", roadRelativeDirections.features[1].properties!!["name"])
+        Assert.assertEquals(
+            "Beggar Bush Lane",
+            roadRelativeDirections.features[1].properties!!["name"]
+        )
         Assert.assertEquals(5, roadRelativeDirections.features[2].properties!!["Direction"])
-        Assert.assertEquals("Clevedon Road", roadRelativeDirections.features[2].properties!!["name"])
+        Assert.assertEquals(
+            "Clevedon Road",
+            roadRelativeDirections.features[2].properties!!["name"]
+        )
         Assert.assertEquals(7, roadRelativeDirections.features[3].properties!!["Direction"])
-        Assert.assertEquals("Weston Road", roadRelativeDirections.features[3].properties!!["name"])
-
+        Assert.assertEquals(
+            "Weston Road",
+            roadRelativeDirections.features[3].properties!!["name"]
+        )
     }
 }

--- a/app/src/test/java/org/scottishtecharmy/soundscape/ComplexIntersections.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/ComplexIntersections.kt
@@ -18,10 +18,10 @@ class ComplexIntersections {
         // multiple gd_intersections detected in the FoV so we need to determine which ones to ignore
         // and which ones are useful to call out to the user
         // Fake location, heading and Field of View for testing
-        val currentLocation = LngLatAlt(-2.697291022799874,51.44378095087524)
-        val deviceHeading = 320.0
-        val fovDistance = 50.0
-        val userGeometry = GeoEngine.UserGeometry(currentLocation, deviceHeading, false, false, fovDistance)
+        val userGeometry = GeoEngine.UserGeometry(
+            LngLatAlt(-2.697291022799874,51.44378095087524),
+            320.0,
+            50.0)
 
         val gridState = GridState.createFromGeoJson(GeoJSONDataComplexIntersection1.complexintersection1GeoJSON)
         val roadRelativeDirections = getRoadsDescriptionFromFov(
@@ -56,10 +56,10 @@ class ComplexIntersections {
         // and which ones are useful to call out to the user
         // https://geojson.io/#map=18.65/51.4405486/-2.6851813
         // Fake location, heading and Field of View for testing
-        val currentLocation = LngLatAlt(-2.6854420947740323, 51.44036284885249)
-        val deviceHeading = 45.0
-        val fovDistance = 50.0
-        val userGeometry = GeoEngine.UserGeometry(currentLocation, deviceHeading, false, false, fovDistance)
+        val userGeometry = GeoEngine.UserGeometry(
+            LngLatAlt(-2.6854420947740323, 51.44036284885249),
+            45.0,
+            50.0)
 
         val gridState = GridState.createFromGeoJson(GeoJSONDataComplexIntersection.complexIntersectionGeoJSON)
         val roadRelativeDirections = getRoadsDescriptionFromFov(

--- a/app/src/test/java/org/scottishtecharmy/soundscape/ComplexIntersections.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/ComplexIntersections.kt
@@ -2,6 +2,7 @@ package org.scottishtecharmy.soundscape
 
 import org.junit.Assert
 import org.junit.Test
+import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.GridState
 import org.scottishtecharmy.soundscape.geoengine.callouts.ComplexIntersectionApproach
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
@@ -20,13 +21,12 @@ class ComplexIntersections {
         val currentLocation = LngLatAlt(-2.697291022799874,51.44378095087524)
         val deviceHeading = 320.0
         val fovDistance = 50.0
+        val userGeometry = GeoEngine.UserGeometry(currentLocation, deviceHeading, false, false, fovDistance)
 
         val gridState = GridState.createFromGeoJson(GeoJSONDataComplexIntersection1.complexintersection1GeoJSON)
         val roadRelativeDirections = getRoadsDescriptionFromFov(
             gridState,
-            currentLocation,
-            deviceHeading,
-            fovDistance,
+            userGeometry,
             ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION
         ).intersectionRoads
 
@@ -59,13 +59,12 @@ class ComplexIntersections {
         val currentLocation = LngLatAlt(-2.6854420947740323, 51.44036284885249)
         val deviceHeading = 45.0
         val fovDistance = 50.0
+        val userGeometry = GeoEngine.UserGeometry(currentLocation, deviceHeading, false, false, fovDistance)
 
         val gridState = GridState.createFromGeoJson(GeoJSONDataComplexIntersection.complexIntersectionGeoJSON)
         val roadRelativeDirections = getRoadsDescriptionFromFov(
             gridState,
-            currentLocation,
-            deviceHeading,
-            fovDistance,
+            userGeometry,
             ComplexIntersectionApproach.INTERSECTION_WITH_MOST_OSM_IDS
         ).intersectionRoads
 

--- a/app/src/test/java/org/scottishtecharmy/soundscape/CrossingTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/CrossingTest.kt
@@ -3,12 +3,12 @@ package org.scottishtecharmy.soundscape
 import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
+import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
-import org.scottishtecharmy.soundscape.geoengine.utils.distance
 import org.scottishtecharmy.soundscape.geoengine.utils.getCrossingsFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getFovFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getNearestRoad
@@ -33,28 +33,23 @@ class CrossingTest {
         println("Crossings in tile: $crossingString")
 
         // usual fake our device location and heading
-        val currentLocation = LngLatAlt(-2.6920313574678403, 51.43745588326692)
-        val deviceHeading = 45.0
-        val fovDistance = 50.0
+        val userGeometry = GeoEngine.UserGeometry(
+            LngLatAlt(-2.6920313574678403, 51.43745588326692),
+            45.0,
+            50.0
+        )
 
         // We can reuse the intersection code as crossings are GeoJSON Points just like Intersections
         //  but there will be more complex crossings so I'll need to check some other tiles
         val fovCrossingFeatureCollection = getFovFeatureCollection(
-            currentLocation,
-            deviceHeading,
-            fovDistance,
+            userGeometry,
             FeatureTree(crossingsFeatureCollection)
         )
         Assert.assertEquals(1, fovCrossingFeatureCollection.features.size)
 
-        val nearestCrossing = FeatureTree(fovCrossingFeatureCollection).getNearestFeature(currentLocation)
+        val nearestCrossing = FeatureTree(fovCrossingFeatureCollection).getNearestFeature(userGeometry.location)
         val crossingLocation = nearestCrossing!!.geometry as Point
-        val distanceToCrossing = distance(
-            currentLocation.latitude,
-            currentLocation.longitude,
-            crossingLocation.coordinates.latitude,
-            crossingLocation.coordinates.longitude
-        )
+        val distanceToCrossing = userGeometry.location.distance(crossingLocation.coordinates)
 
         // Confirm which road the crossing is on
         val nearestRoadToCrossing = getNearestRoad(

--- a/app/src/test/java/org/scottishtecharmy/soundscape/CrossingTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/CrossingTest.kt
@@ -4,31 +4,29 @@ import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
 import org.scottishtecharmy.soundscape.geoengine.GeoEngine
+import org.scottishtecharmy.soundscape.geoengine.GridState.Companion.createFromGeoJson
+import org.scottishtecharmy.soundscape.geoengine.TreeId
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
-import org.scottishtecharmy.soundscape.geoengine.utils.getCrossingsFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getFovFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getNearestRoad
-import org.scottishtecharmy.soundscape.geoengine.utils.getRoadsFeatureCollectionFromTileFeatureCollection
 
 class CrossingTest {
 
     @Test
     fun simpleCrossingTest(){
-        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val featureCollectionTest = moshi.adapter(FeatureCollection::class.java)
-            .fromJson(GeoJsonDataReal.featureCollectionJsonRealSoundscapeGeoJson)
+        val gridState = createFromGeoJson(GeoJsonDataReal.featureCollectionJsonRealSoundscapeGeoJson)
+
         // Get all the roads from the tile
-        val testRoadsCollectionFromTileFeatureCollection = getRoadsFeatureCollectionFromTileFeatureCollection(
-            featureCollectionTest!!
-        )
+        val testRoadsCollectionFromTileFeatureCollection = gridState.getFeatureCollection(TreeId.ROADS)
         // extract crossings for tile
-        val crossingsFeatureCollection = getCrossingsFromTileFeatureCollection(featureCollectionTest)
+        val crossingsFeatureCollection = gridState.getFeatureCollection(TreeId.CROSSINGS)
         Assert.assertEquals(2, crossingsFeatureCollection.features.size)
 
+        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
         val crossingString = moshi.adapter(FeatureCollection::class.java).toJson(crossingsFeatureCollection)
         println("Crossings in tile: $crossingString")
 

--- a/app/src/test/java/org/scottishtecharmy/soundscape/DijkstraTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/DijkstraTest.kt
@@ -3,6 +3,8 @@ package org.scottishtecharmy.soundscape
 import com.squareup.moshi.Moshi
 import org.junit.Test
 import org.junit.Assert
+import org.scottishtecharmy.soundscape.geoengine.GridState.Companion.createFromGeoJson
+import org.scottishtecharmy.soundscape.geoengine.TreeId
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
@@ -11,7 +13,6 @@ import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geoengine.utils.dijkstraWithLoops
 import org.scottishtecharmy.soundscape.geoengine.utils.featureCollectionToGraphWithNodeMap
 import org.scottishtecharmy.soundscape.geoengine.utils.getPathCoordinates
-import org.scottishtecharmy.soundscape.geoengine.utils.getRoadsFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getShortestRoute
 
 
@@ -126,19 +127,17 @@ class DijkstraTest {
     @Test
     fun testDijkstra2(){
         // Get the data for the entire tile
-        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val entireFeatureCollectionTest = moshi.adapter(FeatureCollection::class.java)
-            .fromJson(GeoJSONStreetPreviewTest.streetPreviewTest)
+        val gridState = createFromGeoJson(GeoJSONStreetPreviewTest.streetPreviewTest)
         val startLocation = LngLatAlt( -2.695517313268283,
             51.44082881061331)
         val endLocation = LngLatAlt(-2.6930021169370093,51.43942502273583)
         // get the roads Feature Collection.
-        val testRoadsCollection = getRoadsFeatureCollectionFromTileFeatureCollection(
-            entireFeatureCollectionTest!!
-        )
+        val testRoadsCollection = gridState.getFeatureCollection(TreeId.ROADS)
+
         val shortestRoute = getShortestRoute(startLocation, endLocation, testRoadsCollection)
         Assert.assertEquals(368, shortestRoute.features[0].properties?.get("length"))
         // Visualise the shortest route
+        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
         val routeString = moshi.adapter(FeatureCollection::class.java).toJson(shortestRoute)
         println("Shortest path: $routeString")
 

--- a/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTest.kt
@@ -4,6 +4,7 @@ import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.junit.Assert
 import org.junit.Test
+import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.GridState
 import org.scottishtecharmy.soundscape.geoengine.callouts.ComplexIntersectionApproach
 import org.scottishtecharmy.soundscape.geoengine.callouts.getRoadsDescriptionFromFov
@@ -17,11 +18,10 @@ class IntersectionsTest {
                           fovDistance: Double) : FeatureCollection {
 
         val gridState = GridState.createFromGeoJson(geoJsonResource)
+        val userGeometry = GeoEngine.UserGeometry(currentLocation, deviceHeading, false, false, fovDistance)
         return  getRoadsDescriptionFromFov(
                     gridState,
-                    currentLocation,
-                    deviceHeading,
-                    fovDistance,
+                    userGeometry,
                     ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION
                 ).intersectionRoads
     }

--- a/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTest.kt
@@ -18,7 +18,7 @@ class IntersectionsTest {
                           fovDistance: Double) : FeatureCollection {
 
         val gridState = GridState.createFromGeoJson(geoJsonResource)
-        val userGeometry = GeoEngine.UserGeometry(currentLocation, deviceHeading, false, false, fovDistance)
+        val userGeometry = GeoEngine.UserGeometry(currentLocation, deviceHeading, fovDistance)
         return  getRoadsDescriptionFromFov(
                     gridState,
                     userGeometry,

--- a/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTest.kt
@@ -1,15 +1,11 @@
 package org.scottishtecharmy.soundscape
 
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
-import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
-import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionsFeatureCollectionFromTileFeatureCollection
-import org.scottishtecharmy.soundscape.geoengine.utils.getRoadsFeatureCollectionFromTileFeatureCollection
-import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
+import org.scottishtecharmy.soundscape.geoengine.GridState
 import org.scottishtecharmy.soundscape.geoengine.callouts.ComplexIntersectionApproach
-import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geoengine.callouts.getRoadsDescriptionFromFov
 
 
@@ -20,31 +16,14 @@ class IntersectionsTest {
                           deviceHeading: Double,
                           fovDistance: Double) : FeatureCollection {
 
-        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val featureCollectionTest = moshi.adapter(FeatureCollection::class.java)
-            .fromJson(geoJsonResource)
-
-        // Get the roads from the tile
-        val testRoadsTree = FeatureTree(
-            getRoadsFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest!!
-            )
-        )
-
-        // Get the intersections from the tile
-        val testIntersectionsTree = FeatureTree(
-            getIntersectionsFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest
-            )
-        )
-
-        return getRoadsDescriptionFromFov(testRoadsTree,
-            testIntersectionsTree,
-            currentLocation,
-            deviceHeading,
-            fovDistance,
-            ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION
-        ).intersectionRoads
+        val gridState = GridState.createFromGeoJson(geoJsonResource)
+        return  getRoadsDescriptionFromFov(
+                    gridState,
+                    currentLocation,
+                    deviceHeading,
+                    fovDistance,
+                    ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION
+                ).intersectionRoads
     }
 
     @Test

--- a/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTestMvt.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTestMvt.kt
@@ -14,7 +14,7 @@ class IntersectionsTestMvt {
                           fovDistance: Double) : FeatureCollection {
 
         val gridState = getGridStateForLocation(currentLocation)
-        val userGeometry = GeoEngine.UserGeometry(currentLocation, deviceHeading, false, false, fovDistance)
+        val userGeometry = GeoEngine.UserGeometry(currentLocation, deviceHeading, fovDistance)
         return getRoadsDescriptionFromFov(
                     gridState,
                     userGeometry,

--- a/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTestMvt.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTestMvt.kt
@@ -2,6 +2,7 @@ package org.scottishtecharmy.soundscape
 
 import org.junit.Assert
 import org.junit.Test
+import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.callouts.ComplexIntersectionApproach
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geoengine.callouts.getRoadsDescriptionFromFov
@@ -13,11 +14,10 @@ class IntersectionsTestMvt {
                           fovDistance: Double) : FeatureCollection {
 
         val gridState = getGridStateForLocation(currentLocation)
+        val userGeometry = GeoEngine.UserGeometry(currentLocation, deviceHeading, false, false, fovDistance)
         return getRoadsDescriptionFromFov(
                     gridState,
-                    currentLocation,
-                    deviceHeading,
-                    fovDistance,
+                    userGeometry,
                     ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION
                 ).intersectionRoads
     }

--- a/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTestMvt.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTestMvt.kt
@@ -3,11 +3,8 @@ package org.scottishtecharmy.soundscape
 import org.junit.Assert
 import org.junit.Test
 import org.scottishtecharmy.soundscape.geoengine.callouts.ComplexIntersectionApproach
-import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
-import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionsFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.callouts.getRoadsDescriptionFromFov
-import org.scottishtecharmy.soundscape.geoengine.utils.getRoadsFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 
 class IntersectionsTestMvt {
@@ -15,27 +12,14 @@ class IntersectionsTestMvt {
                           deviceHeading: Double,
                           fovDistance: Double) : FeatureCollection {
 
-        val featureCollectionTest = getGeoJsonForLocation(currentLocation)
-
-        // Get the roads from the tile
-        val testRoadsTree = FeatureTree(
-            getRoadsFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest
-            )
-        )
-        // Get the intersections from the tile
-        val testIntersectionsTree = FeatureTree(
-            getIntersectionsFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest
-            )
-        )
-        return getRoadsDescriptionFromFov(testRoadsTree,
-            testIntersectionsTree,
-            currentLocation,
-            deviceHeading,
-            fovDistance,
-            ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION
-        ).intersectionRoads
+        val gridState = getGridStateForLocation(currentLocation)
+        return getRoadsDescriptionFromFov(
+                    gridState,
+                    currentLocation,
+                    deviceHeading,
+                    fovDistance,
+                    ComplexIntersectionApproach.NEAREST_NON_TRIVIAL_INTERSECTION
+                ).intersectionRoads
     }
     @Test
     fun intersectionsStraightAheadType(){

--- a/app/src/test/java/org/scottishtecharmy/soundscape/MarkersTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/MarkersTest.kt
@@ -2,22 +2,23 @@ package org.scottishtecharmy.soundscape
 
 import com.squareup.moshi.Moshi
 import org.junit.Test
+import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
-import org.scottishtecharmy.soundscape.geoengine.utils.distanceToIntersection
 import org.scottishtecharmy.soundscape.geoengine.utils.getFovTrianglePoints
 
 class MarkersTest {
 
     @Test
     fun markersTest() {
-        val currentLocation = LngLatAlt(-2.6930121073553437,
-            51.43943095899127)
-        val deviceHeading = 10.0
-        val fovDistance = 50.0
+        val userGeometry = GeoEngine.UserGeometry(
+            LngLatAlt(-2.6930121073553437,51.43943095899127),
+            10.0,
+            50.0
+        )
 
         val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
         val markersFeatureCollectionTest = moshi.adapter(FeatureCollection::class.java)
@@ -25,13 +26,13 @@ class MarkersTest {
         val markersTree = FeatureTree(markersFeatureCollectionTest)
 
         // I'm just reusing the Intersection functions here for the markers test
-        val points = getFovTrianglePoints(currentLocation, deviceHeading, fovDistance)
+        val points = getFovTrianglePoints(userGeometry)
         val nearestMarker = markersTree.getNearestFeatureWithinTriangle(
-            currentLocation,
+            userGeometry.location,
             points.left,
             points.right)
         val nearestPoint = nearestMarker!!.geometry as Point
-        val nearestMarkerDistance = distanceToIntersection(currentLocation, nearestPoint)
+        val nearestMarkerDistance = userGeometry.location.distance(nearestPoint.coordinates)
 
         println("Approaching ${nearestMarker.properties!!["marker"]} marker at $nearestMarkerDistance meters")
 

--- a/app/src/test/java/org/scottishtecharmy/soundscape/MvtTileTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/MvtTileTest.kt
@@ -1,6 +1,7 @@
 package org.scottishtecharmy.soundscape
 
 import org.junit.Test
+import org.scottishtecharmy.soundscape.geoengine.GridState
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.InterpolatedPointsJoiner
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.vectorTileToGeoJson
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
@@ -9,7 +10,6 @@ import org.scottishtecharmy.soundscape.geoengine.utils.getLatLonTileWithOffset
 import org.scottishtecharmy.soundscape.geoengine.utils.searchFeaturesByName
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
-import org.scottishtecharmy.soundscape.geojsonparser.geojson.LineString
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geojsonparser.moshi.GeoJsonObjectMoshiAdapter
 import vector_tile.VectorTile
@@ -59,10 +59,10 @@ private fun vectorTileToGeoJsonFromFile(
     return featureCollection
 }
 
-fun getGeoJsonForLocation(
+fun getGridStateForLocation(
     location: LngLatAlt,
     soundscapeBackend: Boolean = false
-): FeatureCollection {
+): GridState {
 
     var gridSize = 2
     if (soundscapeBackend) {
@@ -96,12 +96,7 @@ fun getGeoJsonForLocation(
     // Add lines to connect all of the interpolated points
     joiner.addJoiningLines(featureCollection)
 
-    val adapter = GeoJsonObjectMoshiAdapter()
-    val outputFile = FileOutputStream("${grid.tiles[0].tileX}-${grid.tiles[1].tileX}x${grid.tiles[0].tileY}-${grid.tiles[3].tileY}.geojson")
-    outputFile.write(adapter.toJson(featureCollection).toByteArray())
-    outputFile.close()
-
-    return featureCollection
+    return GridState.createFromFeatureCollection(featureCollection)
 }
 
 class MvtTileTest {

--- a/app/src/test/java/org/scottishtecharmy/soundscape/RoundaboutsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/RoundaboutsTest.kt
@@ -5,6 +5,8 @@ import org.junit.Assert
 import org.junit.Test
 import org.scottishtecharmy.soundscape.dto.Circle
 import org.scottishtecharmy.soundscape.geoengine.GeoEngine
+import org.scottishtecharmy.soundscape.geoengine.GridState.Companion.createFromGeoJson
+import org.scottishtecharmy.soundscape.geoengine.TreeId
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
@@ -24,11 +26,9 @@ import org.scottishtecharmy.soundscape.geoengine.utils.getFovFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getFovTrianglePoints
 import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionRoadNames
 import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionRoadNamesRelativeDirections
-import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionsFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getNearestRoad
 import org.scottishtecharmy.soundscape.geoengine.utils.getRelativeDirectionsPolygons
 import org.scottishtecharmy.soundscape.geoengine.utils.getRoadBearingToIntersection
-import org.scottishtecharmy.soundscape.geoengine.utils.getRoadsFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.lineStringIsCircular
 import org.scottishtecharmy.soundscape.geoengine.utils.polygonContainsCoordinates
 import org.scottishtecharmy.soundscape.geoengine.utils.removeDuplicateOsmIds
@@ -49,13 +49,8 @@ class RoundaboutsTest {
             50.0
         )
 
-        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val featureCollectionTest = moshi.adapter(FeatureCollection::class.java)
-            .fromJson(GeoJSONRoundabout.featureCollectionRoundabout)
-        val testRoadsCollectionFromTileFeatureCollection =
-            getRoadsFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest!!
-            )
+        val gridState = createFromGeoJson(GeoJSONRoundabout.featureCollectionRoundabout)
+        val testRoadsCollectionFromTileFeatureCollection = gridState.getFeatureCollection(TreeId.ROADS)
 
         // create FOV to pickup the road(s) and roundabout
         val fovRoadsFeatureCollection = getFovFeatureCollection(
@@ -83,12 +78,7 @@ class RoundaboutsTest {
                 roundaboutExitRoads.addFeature(road)
             }
         }
-        val testIntersectionsCollectionFromTileFeatureCollection =
-            getIntersectionsFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest
-            )
-
-
+        val testIntersectionsCollectionFromTileFeatureCollection = gridState.getFeatureCollection(TreeId.INTERSECTIONS)
         val fovIntersectionsFeatureCollection = getFovFeatureCollection(
             userGeometry,
             FeatureTree(testIntersectionsCollectionFromTileFeatureCollection)
@@ -170,6 +160,7 @@ class RoundaboutsTest {
         fovRoadsFeatureCollection.addFeature(featureFOVTriangle)
 
         // copy and paste into GeoJSON.io
+        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
         val roundabouts =
             moshi.adapter(FeatureCollection::class.java).toJson(fovRoadsFeatureCollection)
         println(roundabouts)
@@ -187,25 +178,18 @@ class RoundaboutsTest {
             50.0
         )
 
-        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val featureCollectionTest = moshi.adapter(FeatureCollection::class.java)
-            .fromJson(GeoJSONRoundaboutMini.featureCollectionRoundaboutMini)
+        val gridState = createFromGeoJson(GeoJSONRoundaboutMini.featureCollectionRoundaboutMini)
 
         // Get the roads from the tile
-        val testRoadsCollectionFromTileFeatureCollection =
-            getRoadsFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest!!
-            )
+        val testRoadsCollectionFromTileFeatureCollection = gridState.getFeatureCollection(TreeId.ROADS)
+
         // create FOV to pickup the roads
         val fovRoadsFeatureCollection = getFovFeatureCollection(
             userGeometry,
             FeatureTree(testRoadsCollectionFromTileFeatureCollection)
         )
         // Get the intersections from the tile
-        val testIntersectionsCollectionFromTileFeatureCollection =
-            getIntersectionsFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest
-            )
+        val testIntersectionsCollectionFromTileFeatureCollection = gridState.getFeatureCollection(TreeId.INTERSECTIONS)
 
         // get the nearest intersection in the FoV and the roads that make up the intersection
         val points = getFovTrianglePoints(userGeometry)
@@ -269,17 +253,10 @@ class RoundaboutsTest {
             50.0
         )
 
-        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val featureCollectionTest = moshi.adapter(FeatureCollection::class.java)
-            .fromJson(GeoJSONRoundabout.featureCollectionRoundabout)
+        val gridState = createFromGeoJson(GeoJSONRoundabout.featureCollectionRoundabout)
+        val testRoadsCollectionFromTileFeatureCollection = gridState.getFeatureCollection(TreeId.ROADS)
+        val testIntersectionsCollectionFromTileFeatureCollection = gridState.getFeatureCollection(TreeId.INTERSECTIONS)
 
-        val testRoadsCollectionFromTileFeatureCollection =
-            getRoadsFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest!!
-            )
-        val testIntersectionsCollectionFromTileFeatureCollection = getIntersectionsFeatureCollectionFromTileFeatureCollection(
-            featureCollectionTest
-        )
         // create FOV to pickup the road(s) and roundabout (this won't detect every road as we are too far away)
         val fovRoadsFeatureCollection = getFovFeatureCollection(
             userGeometry,
@@ -361,6 +338,7 @@ class RoundaboutsTest {
                 )
                 // temp see the relative directions polygons and bounding box of roundabout
                 //intersectionRelativeDirectionsPolygons.addFeature(featurePolygonBB)
+                val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
                 val relativeDirectionPolygons =
                     moshi.adapter(FeatureCollection::class.java).toJson(intersectionRelativeDirectionsPolygons)
                 println("relative directions polygons: $relativeDirectionPolygons")
@@ -492,6 +470,7 @@ class RoundaboutsTest {
         fovRoadsFeatureCollection.addFeature(featureFOVTriangle)
 
         // copy and paste into GeoJSON.io
+        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
         val roundabouts =
             moshi.adapter(FeatureCollection::class.java).toJson(fovRoadsFeatureCollection)
         println(roundabouts)

--- a/app/src/test/java/org/scottishtecharmy/soundscape/SearchTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/SearchTest.kt
@@ -1,11 +1,9 @@
 package org.scottishtecharmy.soundscape
 
-import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
-import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
-import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
-import org.scottishtecharmy.soundscape.geoengine.utils.getPointsOfInterestFeatureCollectionFromTileFeatureCollection
+import org.scottishtecharmy.soundscape.geoengine.GridState.Companion.createFromGeoJson
+import org.scottishtecharmy.soundscape.geoengine.TreeId
 import org.scottishtecharmy.soundscape.geoengine.utils.searchFeaturesByName
 
 class SearchTest {
@@ -13,13 +11,9 @@ class SearchTest {
     @Test
     fun testSearch() {
         // This does a really crude search through the "name" property of the POI features
-        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val featureCollectionTest = moshi.adapter(FeatureCollection::class.java)
-            .fromJson(GeoJSONData3x3gridnoduplicates.tileGrid)
-        val testPoiCollection =
-            getPointsOfInterestFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest!!
-            )
+        val gridState = createFromGeoJson(GeoJSONData3x3gridnoduplicates.tileGrid)
+        val testPoiCollection = gridState.getFeatureCollection(TreeId.POIS)
+
         // As there isn't much going on in the tiles then it should return the local village shop/coffee place
         val searchResults = searchFeaturesByName(testPoiCollection, "honey")
         Assert.assertEquals(1, searchResults.features.size)

--- a/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckIntersectionLayers.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckIntersectionLayers.kt
@@ -4,6 +4,8 @@ import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
 import org.scottishtecharmy.soundscape.geoengine.GeoEngine
+import org.scottishtecharmy.soundscape.geoengine.GridState
+import org.scottishtecharmy.soundscape.geoengine.TreeId
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
@@ -12,16 +14,13 @@ import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
 import org.scottishtecharmy.soundscape.geoengine.utils.RelativeDirections
 import org.scottishtecharmy.soundscape.geoengine.utils.createTriangleFOV
-import org.scottishtecharmy.soundscape.geoengine.utils.getCrossingsFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getFovFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getFovTrianglePoints
 import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionRoadNames
 import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionRoadNamesRelativeDirections
-import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionsFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getNearestRoad
 import org.scottishtecharmy.soundscape.geoengine.utils.getRelativeDirectionsPolygons
 import org.scottishtecharmy.soundscape.geoengine.utils.getRoadBearingToIntersection
-import org.scottishtecharmy.soundscape.geoengine.utils.getRoadsFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.sortedByDistanceTo
 
 class VisuallyCheckIntersectionLayers {
@@ -38,22 +37,16 @@ class VisuallyCheckIntersectionLayers {
         )
 
         // Get the tile feature collection from the GeoJSON
-        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val featureCollectionTest = moshi.adapter(FeatureCollection::class.java)
-            .fromJson(GeoJSONDataComplexIntersection1.complexintersection1GeoJSON)
+        val gridState = GridState.createFromGeoJson(GeoJSONDataComplexIntersection1.complexintersection1GeoJSON)
+
         // Get all the intersections from the tile
-        val testIntersectionsCollectionFromTileFeatureCollection =
-            getIntersectionsFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest!!
-            )
+        val testIntersectionsCollectionFromTileFeatureCollection = gridState.getFeatureCollection(TreeId.INTERSECTIONS)
+
         // Get all the roads from the tile
-        val testRoadsCollectionFromTileFeatureCollection = getRoadsFeatureCollectionFromTileFeatureCollection(
-            featureCollectionTest
-        )
+        val testRoadsCollectionFromTileFeatureCollection = gridState.getFeatureCollection(TreeId.ROADS)
+
         // Get all the crossings from the tile
-        val testCrossingsCollectionFromTileFeatureCollection = getCrossingsFromTileFeatureCollection(
-            featureCollectionTest
-        )
+        val testCrossingsCollectionFromTileFeatureCollection = gridState.getFeatureCollection(TreeId.CROSSINGS)
 
         // Create a FOV triangle to pick up the intersections
         val fovIntersectionsFeatureCollection = getFovFeatureCollection(
@@ -173,6 +166,7 @@ class VisuallyCheckIntersectionLayers {
         fovRoadsFeatureCollection.addFeature(featureFOVTriangle)
         fovCrossingsFeatureCollection.addFeature(featureFOVTriangle)
 
+        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
         val fovIntersections = moshi.adapter(FeatureCollection::class.java).toJson(fovIntersectionsFeatureCollection)
         // copy and paste into GeoJSON.io
         println("FOV Intersections: $fovIntersections")

--- a/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckOutput.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckOutput.kt
@@ -10,15 +10,11 @@ import org.scottishtecharmy.soundscape.geoengine.utils.RelativeDirections
 import org.scottishtecharmy.soundscape.geoengine.utils.circleToPolygon
 import org.scottishtecharmy.soundscape.geoengine.utils.cleanTileGeoJSON
 import org.scottishtecharmy.soundscape.geoengine.utils.createTriangleFOV
-import org.scottishtecharmy.soundscape.geoengine.utils.getAheadBehindDirectionPolygons
 import org.scottishtecharmy.soundscape.geoengine.utils.getBoundingBoxCorners
 import org.scottishtecharmy.soundscape.geoengine.utils.getCenterOfBoundingBox
-import org.scottishtecharmy.soundscape.geoengine.utils.getCombinedDirectionPolygons
 import org.scottishtecharmy.soundscape.geoengine.utils.getEntrancesFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getFovFeatureCollection
-import org.scottishtecharmy.soundscape.geoengine.utils.getIndividualDirectionPolygons
 import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionsFeatureCollectionFromTileFeatureCollection
-import org.scottishtecharmy.soundscape.geoengine.utils.getLeftRightDirectionPolygons
 import org.scottishtecharmy.soundscape.geoengine.utils.getPathsFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getPoiFeatureCollectionBySuperCategory
 import org.scottishtecharmy.soundscape.geoengine.utils.getPointsOfInterestFeatureCollectionFromTileFeatureCollection
@@ -30,6 +26,7 @@ import org.scottishtecharmy.soundscape.geoengine.utils.getXYTile
 import org.scottishtecharmy.soundscape.geoengine.utils.tileToBoundingBox
 import com.squareup.moshi.Moshi
 import org.junit.Test
+import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.utils.getFovTrianglePoints
 
 // Functions to output GeoJSON strings that can be put into the very useful Geojson.io
@@ -347,9 +344,11 @@ class VisuallyCheckOutput {
 
         // Fake device location and pretend the device is pointing East.
         // -2.6577997643930757, 51.43041390383118
-        val currentLocation = LngLatAlt(-2.6573400576040456, 51.430456817236575)
-        val deviceHeading = 90.0
-        val fovDistance = 50.0
+        val userGeometry = GeoEngine.UserGeometry(
+            LngLatAlt(-2.6573400576040456, 51.430456817236575),
+            90.0,
+            50.0
+        )
 
         val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
         val featureCollectionTest = moshi.adapter(FeatureCollection::class.java)
@@ -365,16 +364,14 @@ class VisuallyCheckOutput {
         // Create a FOV triangle to pick up the intersection (this intersection is a transition from
         // Weston Road to Long Ashton Road)
         val fovIntersectionsFeatureCollection = getFovFeatureCollection(
-            currentLocation,
-            deviceHeading,
-            fovDistance,
+            userGeometry,
             FeatureTree(testIntersectionsCollectionFromTileFeatureCollection)
         )
         // *************************************************************
 
-        val points = getFovTrianglePoints(currentLocation, deviceHeading, fovDistance)
+        val points = getFovTrianglePoints(userGeometry)
         val polygonTriangleFOV = createTriangleFOV(
-            currentLocation,
+            userGeometry.location,
             points.left,
             points.right
         )
@@ -405,9 +402,11 @@ class VisuallyCheckOutput {
 
         // Fake device location and pretend the device is pointing East.
         // -2.6577997643930757, 51.43041390383118
-        val currentLocation = LngLatAlt(-2.6573400576040456, 51.430456817236575)
-        val deviceHeading = 90.0
-        val fovDistance = 50.0
+        val userGeometry = GeoEngine.UserGeometry(
+            LngLatAlt(-2.6573400576040456, 51.430456817236575),
+            90.0,
+            50.0
+        )
 
         val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
         val featureCollectionTest = moshi.adapter(FeatureCollection::class.java)
@@ -423,16 +422,14 @@ class VisuallyCheckOutput {
         // Create a FOV triangle to pick up the roads in the FoV roads.
         // In this case Weston Road and Long Ashton Road
         val fovRoadsFeatureCollection = getFovFeatureCollection(
-            currentLocation,
-            deviceHeading,
-            fovDistance,
+            userGeometry,
             FeatureTree(testRoadsCollectionFromTileFeatureCollection)
         )
         // *************************************************************
 
-        val points = getFovTrianglePoints(currentLocation, deviceHeading, fovDistance)
+        val points = getFovTrianglePoints(userGeometry)
         val polygonTriangleFOV = createTriangleFOV(
-            currentLocation,
+            userGeometry.location,
             points.left,
             points.right
         )
@@ -464,9 +461,11 @@ class VisuallyCheckOutput {
 
         // Fake device location and pretend the device is pointing East.
         // -2.6577997643930757, 51.43041390383118
-        val currentLocation = LngLatAlt(-2.6573400576040456, 51.430456817236575)
-        val deviceHeading = 90.0
-        val fovDistance = 50.0
+        val userGeometry = GeoEngine.UserGeometry(
+            LngLatAlt(-2.6573400576040456, 51.430456817236575),
+            90.0,
+            50.0
+        )
 
         val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
         val featureCollectionTest = moshi.adapter(FeatureCollection::class.java)
@@ -482,16 +481,14 @@ class VisuallyCheckOutput {
         // Create a FOV triangle to pick up the poi in the FoV.
         // In this case a couple of buildings
         val fovPoiFeatureCollection = getFovFeatureCollection(
-            currentLocation,
-            deviceHeading,
-            fovDistance,
+            userGeometry,
             FeatureTree(testPoiCollectionFromTileFeatureCollection)
         )
         // *************************************************************
 
-        val points = getFovTrianglePoints(currentLocation, deviceHeading, fovDistance)
+        val points = getFovTrianglePoints(userGeometry)
         val polygonTriangleFOV = createTriangleFOV(
-            currentLocation,
+            userGeometry.location,
             points.left,
             points.right
         )
@@ -516,11 +513,12 @@ class VisuallyCheckOutput {
     @Test
     fun relativeDirectionsCombined(){
         val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val location = LngLatAlt(-2.657279900280031, 51.430461188129385)
-        val deviceHeading = 0.0
-        val distance = 50.0
-
-        val combinedDirectionPolygons  = getCombinedDirectionPolygons(location, deviceHeading, distance)
+        val userGeometry = GeoEngine.UserGeometry(
+            LngLatAlt(-2.657279900280031, 51.430461188129385),
+            0.0,
+            50.0
+        )
+        val combinedDirectionPolygons  = getRelativeDirectionsPolygons(userGeometry, RelativeDirections.COMBINED)
 
         val relativeDirectionTrianglesString = moshi.adapter(FeatureCollection::class.java)
             .toJson(combinedDirectionPolygons)
@@ -533,11 +531,13 @@ class VisuallyCheckOutput {
     @Test
     fun relativeDirectionsIndividual(){
         val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val location = LngLatAlt(-2.657279900280031, 51.430461188129385)
-        val deviceHeading = 90.0
-        val distance = 50.0
+        val userGeometry = GeoEngine.UserGeometry(
+            LngLatAlt(-2.657279900280031, 51.430461188129385),
+            90.0,
+            50.0
+        )
 
-        val individualRelativeDirections = getIndividualDirectionPolygons(location, deviceHeading, distance)
+        val individualRelativeDirections = getRelativeDirectionsPolygons(userGeometry, RelativeDirections.INDIVIDUAL)
 
         val relativeDirectionTrianglesString = moshi.adapter(FeatureCollection::class.java)
             .toJson(individualRelativeDirections)
@@ -549,13 +549,15 @@ class VisuallyCheckOutput {
     @Test
     fun relativeDirectionsAheadBehind(){
         val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val location = LngLatAlt(-2.657279900280031, 51.430461188129385)
-        val deviceHeading = 90.0
-        val distance = 50.0
+        val userGeometry = GeoEngine.UserGeometry(
+            LngLatAlt(-2.657279900280031, 51.430461188129385),
+            90.0,
+            50.0
+        )
 
         // Issue here is because of the bias towards "ahead" and "behind" you end up with a wide but shallow field of view
         // Probably better to do some trig to provide the distance to keep the depth of the field of view constant?
-        val aheadBehindRelativeDirections = getAheadBehindDirectionPolygons(location, deviceHeading, distance)
+        val aheadBehindRelativeDirections  = getRelativeDirectionsPolygons(userGeometry, RelativeDirections.AHEAD_BEHIND)
 
         val relativeDirectionTrianglesString = moshi.adapter(FeatureCollection::class.java)
             .toJson(aheadBehindRelativeDirections)
@@ -568,11 +570,13 @@ class VisuallyCheckOutput {
     @Test
     fun relativeDirectionsLeftRight(){
         val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val location = LngLatAlt(-2.657279900280031, 51.430461188129385)
-        val deviceHeading = 90.0
-        val distance = 50.0
+        val userGeometry = GeoEngine.UserGeometry(
+            LngLatAlt(-2.657279900280031, 51.430461188129385),
+            90.0,
+            50.0
+        )
 
-        val leftRightRelativeDirections = getLeftRightDirectionPolygons(location, deviceHeading, distance)
+        val leftRightRelativeDirections  = getRelativeDirectionsPolygons(userGeometry, RelativeDirections.LEFT_RIGHT)
 
         val relativeDirectionTrianglesString = moshi.adapter(FeatureCollection::class.java)
             .toJson(leftRightRelativeDirections)
@@ -583,14 +587,14 @@ class VisuallyCheckOutput {
     @Test
     fun relativeDirectionsAll(){
         val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val location = LngLatAlt(-2.657279900280031, 51.430461188129385)
-        val deviceHeading = 90.0
-        val distance = 50.0
+        val userGeometry = GeoEngine.UserGeometry(
+            LngLatAlt(-2.657279900280031, 51.430461188129385),
+            90.0,
+            50.0
+        )
 
         // A wrapper around the individual functions
-        val relativeDirections = getRelativeDirectionsPolygons(
-            location, deviceHeading, distance, RelativeDirections.COMBINED
-        )
+        val relativeDirections = getRelativeDirectionsPolygons(userGeometry, RelativeDirections.COMBINED)
         val relativeDirectionTrianglesString = moshi.adapter(FeatureCollection::class.java)
             .toJson(relativeDirections)
 

--- a/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckOutput.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckOutput.kt
@@ -12,21 +12,18 @@ import org.scottishtecharmy.soundscape.geoengine.utils.cleanTileGeoJSON
 import org.scottishtecharmy.soundscape.geoengine.utils.createTriangleFOV
 import org.scottishtecharmy.soundscape.geoengine.utils.getBoundingBoxCorners
 import org.scottishtecharmy.soundscape.geoengine.utils.getCenterOfBoundingBox
-import org.scottishtecharmy.soundscape.geoengine.utils.getEntrancesFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getFovFeatureCollection
-import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionsFeatureCollectionFromTileFeatureCollection
-import org.scottishtecharmy.soundscape.geoengine.utils.getPathsFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getPoiFeatureCollectionBySuperCategory
-import org.scottishtecharmy.soundscape.geoengine.utils.getPointsOfInterestFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getPolygonOfBoundingBox
 import org.scottishtecharmy.soundscape.geoengine.utils.getRelativeDirectionsPolygons
-import org.scottishtecharmy.soundscape.geoengine.utils.getRoadsFeatureCollectionFromTileFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.getTilesForRegion
 import org.scottishtecharmy.soundscape.geoengine.utils.getXYTile
 import org.scottishtecharmy.soundscape.geoengine.utils.tileToBoundingBox
 import com.squareup.moshi.Moshi
 import org.junit.Test
 import org.scottishtecharmy.soundscape.geoengine.GeoEngine
+import org.scottishtecharmy.soundscape.geoengine.GridState
+import org.scottishtecharmy.soundscape.geoengine.TreeId
 import org.scottishtecharmy.soundscape.geoengine.utils.getFovTrianglePoints
 
 // Functions to output GeoJSON strings that can be put into the very useful Geojson.io
@@ -196,10 +193,8 @@ class VisuallyCheckOutput {
         )
         // get the roads Feature Collection.
         // Crossings are counted as roads by original Soundscape
-        val testRoadsCollection = getRoadsFeatureCollectionFromTileFeatureCollection(
-            moshi.adapter(FeatureCollection::class.java)
-                .fromJson(cleanTileFeatureCollection)!!
-            )
+        val gridState = GridState.createFromGeoJson(cleanTileFeatureCollection)
+        val testRoadsCollection = gridState.getFeatureCollection(TreeId.ROADS)
         val roads = moshi.adapter(FeatureCollection::class.java).toJson(testRoadsCollection)
         // copy and paste into GeoJSON.io
         println(roads)
@@ -221,10 +216,9 @@ class VisuallyCheckOutput {
             moshi.adapter(FeatureCollection::class.java).toJson(entireFeatureCollectionTest)
         )
         // get the Intersections Feature Collection.
-        val testIntersectionsCollection = getIntersectionsFeatureCollectionFromTileFeatureCollection(
-            moshi.adapter(FeatureCollection::class.java)
-                .fromJson(cleanTileFeatureCollection)!!
-        )
+        val gridState = GridState.createFromGeoJson(cleanTileFeatureCollection)
+        val testIntersectionsCollection = gridState.getFeatureCollection(TreeId.INTERSECTIONS)
+
         val intersections = moshi.adapter(FeatureCollection::class.java).toJson(testIntersectionsCollection)
         // copy and paste into GeoJSON.io
         println(intersections)
@@ -246,10 +240,9 @@ class VisuallyCheckOutput {
             moshi.adapter(FeatureCollection::class.java).toJson(entireFeatureCollectionTest)
         )
         // get the POI Feature Collection.
-        val testPoiCollection = getPointsOfInterestFeatureCollectionFromTileFeatureCollection(
-            moshi.adapter(FeatureCollection::class.java)
-                .fromJson(cleanTileFeatureCollection)!!
-        )
+        val gridState = GridState.createFromGeoJson(cleanTileFeatureCollection)
+        val testPoiCollection = gridState.getFeatureCollection(TreeId.POIS)
+
         val poi = moshi.adapter(FeatureCollection::class.java).toJson(testPoiCollection)
         // copy and paste into GeoJSON.io
         println(poi)
@@ -271,10 +264,9 @@ class VisuallyCheckOutput {
             moshi.adapter(FeatureCollection::class.java).toJson(entireFeatureCollectionTest)
         )
         // get the paths Feature Collection.
-        val testPathCollection = getPathsFeatureCollectionFromTileFeatureCollection(
-            moshi.adapter(FeatureCollection::class.java)
-                .fromJson(cleanTileFeatureCollection)!!
-        )
+        val gridState = GridState.createFromGeoJson(cleanTileFeatureCollection)
+        val testPathCollection = gridState.getFeatureCollection(TreeId.ROADS_AND_PATHS)
+
         val paths = moshi.adapter(FeatureCollection::class.java).toJson(testPathCollection)
         // copy and paste into GeoJSON.io
         println(paths)
@@ -296,10 +288,9 @@ class VisuallyCheckOutput {
         // get the entrances Feature Collection.
         // Entrances are weird as it is a single Feature made up of MultiPoints and osm_ids
         // I'm assuming osm_ids correlate to the polygon which has the entrance but haven't checked this yet
-        val testEntrancesCollection = getEntrancesFeatureCollectionFromTileFeatureCollection(
-            moshi.adapter(FeatureCollection::class.java)
-                .fromJson(cleanTileFeatureCollection)!!
-        )
+        val gridState = GridState.createFromGeoJson(cleanTileFeatureCollection)
+        val testEntrancesCollection = gridState.getFeatureCollection(TreeId.ENTRANCES)
+
         val entrances = moshi.adapter(FeatureCollection::class.java).toJson(testEntrancesCollection)
         // copy and paste into GeoJSON.io
         println(entrances)
@@ -319,10 +310,9 @@ class VisuallyCheckOutput {
             moshi.adapter(FeatureCollection::class.java).toJson(entireFeatureCollectionTest)
         )
         // get the poi Feature Collection.
-        val testPoiCollection = getPointsOfInterestFeatureCollectionFromTileFeatureCollection(
-            moshi.adapter(FeatureCollection::class.java)
-                .fromJson(cleanTileFeatureCollection)!!
-        )
+        val gridState = GridState.createFromGeoJson(cleanTileFeatureCollection)
+        val testPoiCollection = gridState.getFeatureCollection(TreeId.POIS)
+
         // select super category
         //"information", "object", "place", "landmark", "mobility", "safety"
         val testSuperCategoryPoiCollection =
@@ -350,14 +340,9 @@ class VisuallyCheckOutput {
             50.0
         )
 
-        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val featureCollectionTest = moshi.adapter(FeatureCollection::class.java)
-            .fromJson(GeoJsonIntersectionStraight.intersectionStraightAheadFeatureCollection)
-        // Get the intersections from the tile
-        val testIntersectionsCollectionFromTileFeatureCollection =
-            getIntersectionsFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest!!
-            )
+        val gridState = GridState.createFromGeoJson(GeoJsonIntersectionStraight.intersectionStraightAheadFeatureCollection)
+        val testIntersectionsCollectionFromTileFeatureCollection = gridState.getFeatureCollection(TreeId.INTERSECTIONS)
+
         // ********* This is the only line that is useful. The rest of it is
         // ********* outputting the triangle that represents the FoV
         //
@@ -385,6 +370,7 @@ class VisuallyCheckOutput {
 
         fovIntersectionsFeatureCollection.addFeature(featureFOVTriangle)
 
+        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
         val fovIntersections = moshi.adapter(FeatureCollection::class.java).toJson(fovIntersectionsFeatureCollection)
         // copy and paste into GeoJSON.io
         println(fovIntersections)
@@ -408,14 +394,9 @@ class VisuallyCheckOutput {
             50.0
         )
 
-        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val featureCollectionTest = moshi.adapter(FeatureCollection::class.java)
-            .fromJson(GeoJsonIntersectionStraight.intersectionStraightAheadFeatureCollection)
-        // Get the roads from the tile
-        val testRoadsCollectionFromTileFeatureCollection =
-            getRoadsFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest!!
-            )
+        val gridState = GridState.createFromGeoJson(GeoJsonIntersectionStraight.intersectionStraightAheadFeatureCollection)
+        val testRoadsCollectionFromTileFeatureCollection = gridState.getFeatureCollection(TreeId.ROADS)
+
         // ********* This is the only line that is useful. The rest of it is
         // ********* outputting the triangle that represents the FoV
         //
@@ -443,6 +424,7 @@ class VisuallyCheckOutput {
 
         fovRoadsFeatureCollection.addFeature(featureFOVTriangle)
 
+        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
         val fovRoads = moshi.adapter(FeatureCollection::class.java).toJson(fovRoadsFeatureCollection)
         // copy and paste into GeoJSON.io
         println(fovRoads)
@@ -467,14 +449,9 @@ class VisuallyCheckOutput {
             50.0
         )
 
-        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val featureCollectionTest = moshi.adapter(FeatureCollection::class.java)
-            .fromJson(GeoJsonIntersectionStraight.intersectionStraightAheadFeatureCollection)
-        // Get the poi from the tile
-        val testPoiCollectionFromTileFeatureCollection =
-            getPointsOfInterestFeatureCollectionFromTileFeatureCollection(
-                featureCollectionTest!!
-            )
+        val gridState = GridState.createFromGeoJson(GeoJsonIntersectionStraight.intersectionStraightAheadFeatureCollection)
+        val testPoiCollectionFromTileFeatureCollection = gridState.getFeatureCollection(TreeId.POIS)
+
         // ********* This is the only line that is useful. The rest of it is
         // ********* outputting the triangle that represents the FoV
         //
@@ -502,6 +479,7 @@ class VisuallyCheckOutput {
 
         fovPoiFeatureCollection.addFeature(featureFOVTriangle)
 
+        val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
         val fovPoi = moshi.adapter(FeatureCollection::class.java).toJson(fovPoiFeatureCollection)
         // copy and paste into GeoJSON.io
         println(fovPoi)


### PR DESCRIPTION
The GeoEngine creates either a ProtomapsGridState or a SoundscapeBackendGridState which hide away creating the FeatureTrees from data downloaded from those servers. The FeatureTrees can be accessed via getFeatureTree or via various search functions which have been moved into the GridState class. These all now call checkContext which ensures that the code is being called on the single thread allowed to access the FeatureTrees.