### PR TITLE
Add some flow control for text-to-speech and callouts

### DIFF
--- a/app/src/main/cpp/AudioEngine.h
+++ b/app/src/main/cpp/AudioEngine.h
@@ -25,6 +25,8 @@ namespace soundscape {
         void AddBeacon(PositionedAudio *beacon, bool queued = false);
         void RemoveBeacon(PositionedAudio *beacon);
 
+        void Eof(long long id);
+
         const static BeaconDescriptor msc_BeaconDescriptors[];
 
         void GetListenerPosition(double &heading, double &latitude, double &longitude) const
@@ -35,9 +37,9 @@ namespace soundscape {
         }
 
         void ClearQueue();
+        unsigned int GetQueueDepth();
 
         FMOD_VECTOR TranslateToFmodVector(double longitude, double latitude);
-        void TranslateFmodVector(FMOD_VECTOR &location);
 
     private:
         FMOD::System * m_pSystem;

--- a/app/src/main/java/org/scottishtecharmy/soundscape/audio/AudioEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/audio/AudioEngine.kt
@@ -10,6 +10,7 @@ interface AudioEngine {
     fun createTextToSpeech(text: String, latitude: Double = Double.NaN, longitude: Double = Double.NaN) : Long
     fun createEarcon(asset: String, latitude: Double = Double.NaN, longitude: Double = Double.NaN) : Long
     fun clearTextToSpeechQueue()
+    fun getQueueDepth() : Long
     fun updateGeometry(listenerLatitude: Double, listenerLongitude: Double, listenerHeading: Double)
     fun setBeaconType(beaconType: String)
     fun getListOfBeaconTypes() : Array<String>

--- a/app/src/main/java/org/scottishtecharmy/soundscape/audio/NativeAudioEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/audio/NativeAudioEngine.kt
@@ -42,6 +42,7 @@ class NativeAudioEngine @Inject constructor(): AudioEngine, TextToSpeech.OnInitL
     private external fun createNativeTextToSpeech(engineHandle: Long, latitude: Double, longitude: Double, ttsSocket: Int) :  Long
     private external fun createNativeEarcon(engineHandle: Long, asset:String, latitude: Double, longitude: Double) :  Long
     private external fun clearNativeTextToSpeechQueue(engineHandle: Long)
+    private external fun getQueueDepth(engineHandle: Long) : Long
     private external fun updateGeometry(engineHandle: Long, latitude: Double, longitude: Double, heading: Double)
     private external fun setBeaconType(engineHandle: Long, beaconType: String)
     private external fun getListOfBeacons() : Array<String>
@@ -286,6 +287,16 @@ class NativeAudioEngine @Inject constructor(): AudioEngine, TextToSpeech.OnInitL
             }
         }
     }
+
+    override fun getQueueDepth() : Long {
+        synchronized(engineMutex) {
+            if (engineHandle != 0L) {
+                return getQueueDepth(engineHandle)
+            }
+        }
+        return 0
+    }
+
     override fun getAvailableSpeechLanguages() : Set<Locale> {
         if (!textToSpeechInitialized)
             return emptySet()

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -227,11 +227,14 @@ class GeoEngine {
                         createSuperCategoriesSet()
                     )
 
-                    // Run any auto callouts that we need
-                    val callouts = autoCallout.updateLocation(getCurrentUserGeometry(), gridState)
-                    if (callouts.isNotEmpty()) {
-                        // Tell the service that we've got some callouts to tell the user about
-                        soundscapeService.speakCallout(callouts)
+                    // So long as the AudioEngine is not already busy, run any auto callouts that we need
+                    if(!soundscapeService.isAudioEngineBusy()) {
+                        val callouts =
+                            autoCallout.updateLocation(getCurrentUserGeometry(), gridState)
+                        if (callouts.isNotEmpty()) {
+                            // Tell the service that we've got some callouts to tell the user about
+                            soundscapeService.speakCallout(callouts)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -363,6 +363,16 @@ class SoundscapeService : MediaSessionService() {
 //        routePlayer.setupCurrentRoute()
     }
 
+    /**
+     * isAudioEngineBusy returns true if there is more than one entry in the
+     * audio engine queue. The queue consists of earcons and text-to-speech.
+     */
+    fun isAudioEngineBusy() : Boolean {
+        val depth = audioEngine.getQueueDepth()
+        //Log.d(TAG, "Queue depth: $depth")
+        return (depth > 1)
+    }
+
     fun speakCallout(callouts: List<PositionedString>) {
         audioEngine.createEarcon(NativeAudioEngine.EARCON_MODE_ENTER)
         for(result in callouts) {


### PR DESCRIPTION
The immediately useful change here is that the auto callout code now calls isAudioEngineBusy before generating any more output. If there is already text-to-speech playing out, then it won't generate any more. This aims to prevent a backup of audio description.
The other change is the start of a callback when audio playout completes, but so far this is only within the C++ code and doesn't make it back to the kotlin code.