### PR TITLE
Add the start of reverse geocoding to describe current location <wip>

### DIFF
--- a/app/src/androidTest/java/org/scottishtecharmy/soundscape/AudioEngineTest.kt
+++ b/app/src/androidTest/java/org/scottishtecharmy/soundscape/AudioEngineTest.kt
@@ -6,6 +6,7 @@ import org.scottishtecharmy.soundscape.audio.AudioEngine
 import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
 import org.junit.Assert
 import org.junit.Test
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 
 class AudioEngineTest {
 
@@ -60,14 +61,14 @@ class AudioEngineTest {
     fun soundBeacon() {
         val audioEngine = initializeAudioEngine()
 
-        val beacon = audioEngine.createBeacon(1.0, 0.0)
+        val beacon = audioEngine.createBeacon(LngLatAlt(1.0, 0.0))
         moveListener(audioEngine, 4000)
         audioEngine.destroyBeacon(beacon)
 
         audioEngine.createTextToSpeech("Beacon here!")
         moveListener(audioEngine, 4000)
 
-        val beacon3 = audioEngine.createBeacon(1.0, 0.0)
+        val beacon3 = audioEngine.createBeacon(LngLatAlt(1.0, 0.0))
         moveListener(audioEngine, 4000)
         audioEngine.destroyBeacon(beacon3)
 
@@ -85,7 +86,7 @@ class AudioEngineTest {
             Log.d(TAG, "Test beacon type $beaconType")
             audioEngine.setBeaconType(beaconType)
 
-            val beacon = audioEngine.createBeacon(1.0, 0.0)
+            val beacon = audioEngine.createBeacon(LngLatAlt(1.0, 0.0))
             moveListener(audioEngine, 6000)
             audioEngine.destroyBeacon(beacon)
         }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeIntents.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeIntents.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.runBlocking
 import org.scottishtecharmy.soundscape.database.local.RealmConfiguration
 import org.scottishtecharmy.soundscape.database.local.dao.RoutesDao
 import org.scottishtecharmy.soundscape.database.repository.RoutesRepository
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.Navigator
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.home.locationDetails.generateLocationDetailsRoute
@@ -46,8 +47,7 @@ class SoundscapeIntents
                             val ld =
                                 LocationDescription(
                                     addressName = address.getAddressLine(0),
-                                    latitude = address.latitude,
-                                    longitude = address.longitude,
+                                    location = LngLatAlt(address.longitude, address.latitude)
                                 )
                             navigator.navigate(generateLocationDetailsRoute(ld))
                         }
@@ -64,8 +64,7 @@ class SoundscapeIntents
                     val ld =
                         LocationDescription(
                             addressName = address.getAddressLine(0),
-                            latitude = address.latitude,
-                            longitude = address.longitude,
+                            location = LngLatAlt(address.longitude, address.latitude)
                         )
                     navigator.navigate(generateLocationDetailsRoute(ld))
                 }
@@ -168,8 +167,7 @@ class SoundscapeIntents
                             // Switch to Street Preview mode
                             mainActivity.soundscapeServiceConnection.setStreetPreviewMode(
                                 true,
-                                latitude.toDouble(),
-                                longitude.toDouble(),
+                                LngLatAlt(longitude.toDouble(), latitude.toDouble())
                             )
                         } else {
                             try {
@@ -180,8 +178,7 @@ class SoundscapeIntents
                                 val ld =
                                     LocationDescription(
                                         addressName = URLEncoder.encode(uriData, "utf-8"),
-                                        latitude = latitude.toDouble(),
-                                        longitude = longitude.toDouble(),
+                                        location = LngLatAlt(longitude.toDouble(), latitude.toDouble())
                                     )
                                 mainActivity.navigator.navigate(generateLocationDetailsRoute(ld))
                             }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.services.SoundscapeBinder
 import org.scottishtecharmy.soundscape.services.SoundscapeService
-import org.scottishtecharmy.soundscape.geoengine.utils.TileGrid
 import javax.inject.Inject
 
 @ActivityRetainedScoped
@@ -38,9 +37,9 @@ class SoundscapeServiceConnection @Inject constructor() {
         return soundscapeService?.streetPreviewFlow
     }
 
-    fun setStreetPreviewMode(on : Boolean, latitude: Double = 0.0, longitude: Double = 0.0) {
+    fun setStreetPreviewMode(on : Boolean, location: LngLatAlt? = null) {
         Log.d(TAG, "setStreetPreviewMode $on")
-        soundscapeService?.setStreetPreviewMode(on, latitude, longitude)
+        soundscapeService?.setStreetPreviewMode(on, location)
     }
 
     // needed to communicate with the service.

--- a/app/src/main/java/org/scottishtecharmy/soundscape/audio/AudioEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/audio/AudioEngine.kt
@@ -2,10 +2,11 @@ package org.scottishtecharmy.soundscape.audio
 
 import android.content.SharedPreferences
 import android.speech.tts.Voice
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import java.util.Locale
 
 interface AudioEngine {
-    fun createBeacon(latitude: Double, longitude: Double) : Long
+    fun createBeacon(location: LngLatAlt) : Long
     fun destroyBeacon(beaconHandle : Long)
     fun createTextToSpeech(text: String, latitude: Double = Double.NaN, longitude: Double = Double.NaN) : Long
     fun createEarcon(asset: String, latitude: Double = Double.NaN, longitude: Double = Double.NaN) : Long

--- a/app/src/main/java/org/scottishtecharmy/soundscape/audio/NativeAudioEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/audio/NativeAudioEngine.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.scottishtecharmy.soundscape.MainActivity
 import org.scottishtecharmy.soundscape.R
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.utils.getCurrentLocale
 import java.util.Locale
 import javax.inject.Inject
@@ -184,12 +185,12 @@ class NativeAudioEngine @Inject constructor(): AudioEngine, TextToSpeech.OnInitL
         }
     }
 
-    override fun createBeacon(latitude: Double, longitude: Double) : Long
+    override fun createBeacon(location: LngLatAlt) : Long
     {
         synchronized(engineMutex) {
             if(engineHandle != 0L) {
                 Log.d(TAG, "Call createNativeBeacon")
-                return createNativeBeacon(engineHandle, latitude, longitude)
+                return createNativeBeacon(engineHandle, location.latitude, location.longitude)
             }
 
             return 0

--- a/app/src/main/java/org/scottishtecharmy/soundscape/components/SearchItem.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/components/SearchItem.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.ui.theme.Foreground2
 import org.scottishtecharmy.soundscape.ui.theme.IntroductionTheme
@@ -103,8 +104,7 @@ fun PreviewSearchItemButton() {
                     postcodeAndLocality = "59000 Lille",
                     distance = "17 Km",
                     country = "France",
-                    latitude = 9.55,
-                    longitude = 8.00,
+                    location = LngLatAlt(8.00, 9.55)
                 )
             SearchItemButton(test, onClick = {}, Modifier.width(200.dp))
         }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
@@ -55,6 +55,7 @@ open class GridState {
     internal lateinit var tileClient: TileClient
 
     private var centralBoundingBox = BoundingBox()
+    private var totalBoundingBox = BoundingBox()
     internal var featureTrees = Array(TreeId.MAX_COLLECTION_ID.id) { FeatureTree(null) }
     @OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
     val treeContext = newSingleThreadContext("TreeContext")
@@ -63,6 +64,10 @@ open class GridState {
     open fun start(application: Application, soundscapeService: SoundscapeService) {}
     fun stop() {}
     open fun fixupCollections(featureCollections: Array<FeatureCollection>) {}
+
+    fun isLocationWithinGrid(location: LngLatAlt): Boolean {
+        return pointIsWithinBoundingBox(location, totalBoundingBox)
+    }
 
     /**
      * The tile grid service is called each time the location changes. It checks if the location
@@ -84,6 +89,7 @@ open class GridState {
             if (updateTileGrid(tileGrid, featureCollections)) {
                 // We have got a new grid, so create our new central region
                 centralBoundingBox = tileGrid.centralBoundingBox
+                totalBoundingBox = tileGrid.totalBoundingBox
 
                 fixupCollections(featureCollections)
                 classifyPois(featureCollections, enabledCategories)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileGridUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileGridUtils.kt
@@ -10,10 +10,11 @@ import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Polygon
 import org.scottishtecharmy.soundscape.geojsonparser.moshi.GeoJsonObjectMoshiAdapter
 
-class TileGrid(newTiles : MutableList<Tile>, newCentralBoundingBox : BoundingBox) {
+class TileGrid(newTiles : MutableList<Tile>,
+               var centralBoundingBox : BoundingBox,
+               var totalBoundingBox : BoundingBox) {
 
     val tiles : MutableList<Tile> = newTiles
-    var centralBoundingBox : BoundingBox = newCentralBoundingBox
 
     /**
      * Return GeoJSON that describes the tile grid and the central bounding box so that it can be
@@ -98,7 +99,15 @@ class TileGrid(newTiles : MutableList<Tile>, newCentralBoundingBox : BoundingBox
                     tiles.add(surroundingTile)
                 }
             }
-            return TileGrid(tiles, centralBoundingBox)
+
+            val totalBoundingBox = BoundingBox(
+                southWest.second,
+                southWest.first,
+                northEast.second,
+                northEast.first
+            )
+
+            return TileGrid(tiles, centralBoundingBox, totalBoundingBox)
         }
 
         /**
@@ -155,6 +164,23 @@ class TileGrid(newTiles : MutableList<Tile>, newCentralBoundingBox : BoundingBox
                 }
             }
 
+            val gridNorthWest = pixelXYToLatLon(
+                (xValues[0] * 256).toDouble(),
+                (yValues[0] * 256).toDouble(),
+                ZOOM_LEVEL
+            )
+            val gridSouthEast = pixelXYToLatLon(
+                ((xValues[1] + 1).mod(maxCoordinate) * 256).toDouble(),
+                ((yValues[1] + 1).mod(maxCoordinate) * 256).toDouble(),
+                ZOOM_LEVEL
+            )
+            val totalBoundingBox = BoundingBox(
+                gridNorthWest.second,
+                gridSouthEast.first,
+                gridSouthEast.second,
+                gridNorthWest.first
+            )
+
             // Center of grid is the top left corner of the bottom right tile
             val centerX = (xValues[1] * 256)
             val centerY = (yValues[1] * 256)
@@ -173,7 +199,7 @@ class TileGrid(newTiles : MutableList<Tile>, newCentralBoundingBox : BoundingBox
                     tiles.add(surroundingTile)
                 }
             }
-            return TileGrid(tiles, centralBoundingBox)
+            return TileGrid(tiles, centralBoundingBox, totalBoundingBox)
         }
 
         /**
@@ -194,7 +220,7 @@ class TileGrid(newTiles : MutableList<Tile>, newCentralBoundingBox : BoundingBox
                 3 -> return get3x3TileGrid(currentLocation)
             }
             assert(false)
-            return TileGrid(mutableListOf(), BoundingBox())
+            return TileGrid(mutableListOf(), BoundingBox(), BoundingBox())
         }
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geojsonparser/geojson/LngLatAlt.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geojsonparser/geojson/LngLatAlt.kt
@@ -1,6 +1,7 @@
 package org.scottishtecharmy.soundscape.geojsonparser.geojson
 
 import com.squareup.moshi.JsonClass
+import org.maplibre.android.geometry.LatLng
 import org.scottishtecharmy.soundscape.geoengine.utils.distance
 import java.io.Serializable
 
@@ -35,6 +36,10 @@ open class LngLatAlt(
         return "$longitude,$latitude"
     }
 
+    fun toLatLng(): LatLng {
+        return LatLng(latitude, longitude)
+    }
+
     fun distance(other: LngLatAlt): Double {
         return distance(latitude, longitude, other.latitude, other.longitude)
     }
@@ -50,10 +55,10 @@ open class LngLatAlt(
 
     /**
      * Distance to a LineString from current location.
-     * @param pointCoordinates
-     * LngLatAlt of current location
      * @param lineStringCoordinates
      * LineString that we are working out the distance from
+     * @param nearestPoint
+     * Point in the line nearest that had the shortest distance
      * @return The distance of the point to the LineString
      */
     fun distanceToLineString(

--- a/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/GpxDrivenProvider.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/GpxDrivenProvider.kt
@@ -17,7 +17,7 @@ import java.io.InputStream
 
 class GpxDrivenProvider  {
 
-    var locationProvider = StaticLocationProvider(0.0,0.0)
+    var locationProvider = StaticLocationProvider(LngLatAlt())
     var directionProvider = DirectionProvider()
 
     private var parsedGpx: Gpx? = null

--- a/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/StaticLocationProvider.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/StaticLocationProvider.kt
@@ -5,7 +5,7 @@ import android.location.Location
 import android.location.LocationManager
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 
-class StaticLocationProvider(private var latitude: Double, private var longitude: Double) :
+class StaticLocationProvider(private var location: LngLatAlt) :
     LocationProvider() {
 
     override fun destroy() {
@@ -13,20 +13,20 @@ class StaticLocationProvider(private var latitude: Double, private var longitude
 
     override fun start(context : Context){
         // Simply set our flow source as the passed in location with 10m accuracy so that it's not ignored
-        val location = Location(LocationManager.PASSIVE_PROVIDER)
-        location.latitude = latitude
-        location.longitude = longitude
-        location.accuracy = 10.0F
-        mutableLocationFlow.value = location
+        val passiveLocation = Location(LocationManager.PASSIVE_PROVIDER)
+        passiveLocation.latitude = location.latitude
+        passiveLocation.longitude = location.longitude
+        passiveLocation.accuracy = 10.0F
+        mutableLocationFlow.value = passiveLocation
     }
 
     override fun updateLocation(newLocation: LngLatAlt, speed: Float) {
-        val location = Location(LocationManager.PASSIVE_PROVIDER)
-        location.latitude = newLocation.latitude
-        location.longitude = newLocation.longitude
-        location.speed = speed
-        location.accuracy = 10.0F
-        mutableLocationFlow.value = location
+        val passiveLocation = Location(LocationManager.PASSIVE_PROVIDER)
+        passiveLocation.latitude = newLocation.latitude
+        passiveLocation.longitude = newLocation.longitude
+        passiveLocation.speed = speed
+        passiveLocation.accuracy = 10.0F
+        mutableLocationFlow.value = passiveLocation
     }
 
     companion object {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/network/SearchProvider.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/network/SearchProvider.kt
@@ -14,7 +14,6 @@ import retrofit2.http.Headers
 import retrofit2.http.Query
 import java.util.Locale
 import java.util.concurrent.TimeUnit
-import kotlin.time.Duration
 
 const val BASE_URL = "https://photon.komoot.io/"
 
@@ -41,6 +40,17 @@ interface PhotonSearchProvider {
         @Query("lang") language: String = Locale.getDefault().language,
         @Query("limit") limit: UInt = 5U,
         @Query("location_bias_scale") bias: Float = 0.2f
+    ): Call<FeatureCollection>
+
+    @Headers(
+        "Cache-control: max-age=0",
+        "Connection: keep-alive"
+    )
+    @GET("reverse/")
+    fun reverseGeocodeLocation(
+        @Query("lat") latitude: Double? = null,
+        @Query("lon") longitude: Double? = null,
+        @Query("lang") language: String = Locale.getDefault().language,
     ): Call<FeatureCollection>
 
     companion object {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
@@ -16,6 +16,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.google.gson.GsonBuilder
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.home.home.Home
 import org.scottishtecharmy.soundscape.screens.home.locationDetails.LocationDetailsScreen
@@ -61,12 +62,8 @@ fun HomeScreen(
                 heading = state.value.heading,
                 onNavigate = { dest -> navController.navigate(dest) },
                 onMapLongClick = { latLong ->
-                    val ld =
-                        LocationDescription(
-                            addressName = "Current location",
-                            latitude =latLong.latitude,
-                            longitude = latLong.longitude,
-                        )
+                    val location = LngLatAlt(latLong.longitude, latLong.latitude)
+                    val ld = viewModel.getLocationDescription(location) ?: LocationDescription()
                     navController.navigate(generateLocationDetailsRoute(ld))
                     true
                 },
@@ -76,6 +73,17 @@ fun HomeScreen(
                 getMyLocation = { viewModel.myLocation() },
                 getWhatsAheadOfMe = { viewModel.aheadOfMe() },
                 getWhatsAroundMe = { viewModel.whatsAroundMe() },
+                getCurrentLocationDescription = {
+                    if(state.value.location != null) {
+                        val location = LngLatAlt(
+                            state.value.location!!.longitude,
+                            state.value.location!!.latitude
+                        )
+                        viewModel.getLocationDescription(location) ?: LocationDescription()
+                    } else {
+                        LocationDescription()
+                    }
+                },
                 searchText = searchText.value,
                 isSearching = state.value.isSearching,
                 onToggleSearch = viewModel::onToggleSearch,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
@@ -56,8 +56,7 @@ fun HomeScreen(
         composable(HomeRoutes.Home.route) {
             val context = LocalContext.current
             Home(
-                latitude = state.value.location?.latitude,
-                longitude = state.value.location?.longitude,
+                location = state.value.location,
                 beaconLocation = state.value.beaconLocation,
                 heading = state.value.heading,
                 onNavigate = { dest -> navController.navigate(dest) },
@@ -133,8 +132,7 @@ fun HomeScreen(
                         }
                     }
                 },
-                latitude = state.value.location?.latitude,
-                longitude = state.value.location?.longitude,
+                location = state.value.location,
                 navController = navController,
                 heading = state.value.heading,
                 modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing),

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/data/LocationDescription.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/data/LocationDescription.kt
@@ -1,12 +1,13 @@
 package org.scottishtecharmy.soundscape.screens.home.data
 
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+
 data class LocationDescription(
     var addressName: String? = null,
     val streetNumberAndName: String? = null,
     val postcodeAndLocality: String? = null,
     val country: String? = null,
     var distance: String? = null,
-    var latitude: Double = Double.NaN,
-    var longitude: Double = Double.NaN,
+    var location: LngLatAlt = LngLatAlt(),
     val marker: Boolean = false
 )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/data/LocationDescription.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/data/LocationDescription.kt
@@ -1,12 +1,12 @@
 package org.scottishtecharmy.soundscape.screens.home.data
 
 data class LocationDescription(
-    val addressName: String? = null,
+    var addressName: String? = null,
     val streetNumberAndName: String? = null,
     val postcodeAndLocality: String? = null,
     val country: String? = null,
-    val distance: String? = null,
-    val latitude: Double = Double.NaN,
-    val longitude: Double = Double.NaN,
+    var distance: String? = null,
+    var latitude: Double = Double.NaN,
+    var longitude: Double = Double.NaN,
     val marker: Boolean = false
 )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
@@ -43,6 +43,7 @@ import org.maplibre.android.geometry.LatLng
 import org.scottishtecharmy.soundscape.MainActivity
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.components.MainSearchBar
+import org.scottishtecharmy.soundscape.database.local.model.Location
 import org.scottishtecharmy.soundscape.screens.home.DrawerContent
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.home.locationDetails.generateLocationDetailsRoute
@@ -62,6 +63,7 @@ fun HomePreview() {
         getMyLocation = {},
         getWhatsAroundMe = {},
         getWhatsAheadOfMe = {},
+        getCurrentLocationDescription = { LocationDescription() },
         shareLocation = {},
         rateSoundscape = {},
         streetPreviewEnabled = false,
@@ -86,6 +88,7 @@ fun Home(
     getMyLocation: () -> Unit,
     getWhatsAroundMe: () -> Unit,
     getWhatsAheadOfMe: () -> Unit,
+    getCurrentLocationDescription: () -> LocationDescription,
     shareLocation: () -> Unit,
     rateSoundscape: () -> Unit,
     streetPreviewEnabled: Boolean,
@@ -138,6 +141,7 @@ fun Home(
                 heading = heading,
                 modifier = Modifier.padding(innerPadding),
                 onNavigate = onNavigate,
+                getCurrentLocationDescription = getCurrentLocationDescription,
                 searchBar = {
                     MainSearchBar(
                         searchText = searchText,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
@@ -43,7 +43,7 @@ import org.maplibre.android.geometry.LatLng
 import org.scottishtecharmy.soundscape.MainActivity
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.components.MainSearchBar
-import org.scottishtecharmy.soundscape.database.local.model.Location
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.DrawerContent
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.home.locationDetails.generateLocationDetailsRoute
@@ -53,8 +53,7 @@ import org.scottishtecharmy.soundscape.screens.home.locationDetails.generateLoca
 @Composable
 fun HomePreview() {
     Home(
-        latitude = null,
-        longitude = null,
+        location = null,
         beaconLocation = null,
         heading = 0.0f,
         onNavigate = {},
@@ -78,9 +77,8 @@ fun HomePreview() {
 
 @Composable
 fun Home(
-    latitude: Double?,
-    longitude: Double?,
-    beaconLocation: LatLng?,
+    location: LngLatAlt?,
+    beaconLocation: LngLatAlt?,
     heading: Float,
     onNavigate: (String) -> Unit,
     onMapLongClick: (LatLng) -> Boolean,
@@ -135,8 +133,7 @@ fun Home(
             contentWindowInsets = WindowInsets(0, 0, 0, 0),
         ) { innerPadding ->
             HomeContent(
-                latitude = latitude,
-                longitude = longitude,
+                location = location,
                 beaconLocation = beaconLocation,
                 heading = heading,
                 modifier = Modifier.padding(innerPadding),
@@ -158,8 +155,7 @@ fun Home(
                                         postcodeAndLocality = item.postcodeAndLocality,
                                         country = item.country,
                                         distance = item.distance,
-                                        latitude = item.latitude,
-                                        longitude = item.longitude,
+                                        location = item.location,
                                     ),
                                 ),
                             )
@@ -237,7 +233,7 @@ fun HomeTopAppBar(
                 onCheckedChange = { state ->
                     if (!state) {
                         (context as MainActivity).soundscapeServiceConnection.setStreetPreviewMode(
-                            false,
+                            false
                         )
                     }
                 },

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
@@ -11,15 +11,15 @@ import org.maplibre.android.annotations.Marker
 import org.maplibre.android.geometry.LatLng
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.components.NavigationButton
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.HomeRoutes
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.home.locationDetails.generateLocationDetailsRoute
 
 @Composable
 fun HomeContent(
-    latitude: Double?,
-    longitude: Double?,
-    beaconLocation: LatLng?,
+    location: LngLatAlt?,
+    beaconLocation: LngLatAlt?,
     heading: Float,
     onNavigate: (String) -> Unit,
     onMapLongClick: (LatLng) -> Boolean,
@@ -47,8 +47,7 @@ fun HomeContent(
                     val ld =
                         LocationDescription(
                             addressName = "Barrowland Ballroom",
-                            latitude = 55.8552688,
-                            longitude = -4.2366753,
+                            location = LngLatAlt(-4.2366753, 55.8552688)
                         )
                     onNavigate(generateLocationDetailsRoute(ld))
                 },
@@ -64,20 +63,20 @@ fun HomeContent(
             // Current location
             NavigationButton(
                 onClick = {
-                    if (latitude != null && longitude != null) {
+                    if (location != null) {
                         val ld = getCurrentLocationDescription()
                         onNavigate(generateLocationDetailsRoute(ld))
                     }
                 },
                 text = stringResource(R.string.search_use_current_location),
             )
-            if (latitude != null && longitude != null) {
+            if (location != null) {
                 MapContainerLibre(
                     beaconLocation = beaconLocation,
-                    mapCenter = LatLng(latitude, longitude),
+                    mapCenter = location,
                     allowScrolling = false,
                     mapViewRotation = 0.0F,
-                    userLocation = LatLng(latitude, longitude),
+                    userLocation = location,
                     userSymbolRotation = heading,
                     onMapLongClick = onMapLongClick,
                     onMarkerClick = onMarkerClick,
@@ -92,8 +91,7 @@ fun HomeContent(
 @Composable
 fun PreviewHomeContent() {
     HomeContent(
-        latitude = null,
-        longitude = null,
+        location = null,
         beaconLocation = null,
         heading = 0.0f,
         onNavigate = {},

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
@@ -24,6 +24,7 @@ fun HomeContent(
     onNavigate: (String) -> Unit,
     onMapLongClick: (LatLng) -> Boolean,
     onMarkerClick: (Marker) -> Boolean,
+    getCurrentLocationDescription: () -> LocationDescription,
     searchBar: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     tileGridGeoJson: String,
@@ -64,14 +65,8 @@ fun HomeContent(
             NavigationButton(
                 onClick = {
                     if (latitude != null && longitude != null) {
-                        val ld =
-                            LocationDescription(
-                                // TODO handle LocationDescription instantiation in viewmodel ?
-                                addressName = "Current location",
-                                latitude = latitude,
-                                longitude = longitude,
-                            )
-                        onNavigate(generateLocationDetailsRoute(ld)) // TODO handle at top level the generateLocationDetailsRoute ?
+                        val ld = getCurrentLocationDescription()
+                        onNavigate(generateLocationDetailsRoute(ld))
                     }
                 },
                 text = stringResource(R.string.search_use_current_location),
@@ -106,5 +101,6 @@ fun PreviewHomeContent() {
         onMarkerClick = { true },
         searchBar = {},
         tileGridGeoJson = "",
+        getCurrentLocationDescription = { LocationDescription() }
     )
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
@@ -30,6 +30,7 @@ import org.maplibre.android.style.sources.GeoJsonSource
 import org.maplibre.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.BuildConfig
 import org.scottishtecharmy.soundscape.R
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import java.io.File
 
 const val USER_POSITION_MARKER_NAME = "USER_POSITION_MARKER_NAME"
@@ -47,12 +48,12 @@ const val USER_POSITION_MARKER_NAME = "USER_POSITION_MARKER_NAME"
  */
 @Composable
 fun MapContainerLibre(
-    mapCenter: LatLng,
+    mapCenter: LngLatAlt,
     allowScrolling: Boolean,
     mapViewRotation: Float,
-    userLocation: LatLng,
+    userLocation: LngLatAlt,
     userSymbolRotation: Float,
-    beaconLocation: LatLng?,
+    beaconLocation: LngLatAlt?,
     modifier: Modifier = Modifier,
     onMapLongClick: (LatLng) -> Boolean,
     onMarkerClick: (Marker) -> Boolean,
@@ -64,13 +65,13 @@ fun MapContainerLibre(
         // been disallowed
         val cp = CameraPosition.Builder().bearing(mapViewRotation.toDouble())
         if(!allowScrolling)
-            cp.target(mapCenter)
+            cp.target(mapCenter.toLatLng())
         cp.build()
     }
 
     val symbolOptions = remember(userLocation, userSymbolRotation) {
         SymbolOptions()
-            .withLatLng(userLocation)
+            .withLatLng(userLocation.toLatLng())
             .withIconImage(USER_POSITION_MARKER_NAME)
             .withIconAnchor("center")
             .withIconRotate(userSymbolRotation)
@@ -157,7 +158,7 @@ fun MapContainerLibre(
             }
 
             mapLibre.cameraPosition = CameraPosition.Builder()
-                .target(mapCenter)
+                .target(mapCenter.toLatLng())
                 .zoom(15.0) // we set the zoom only at init
                 .bearing(mapViewRotation.toDouble())
                 .build()
@@ -169,7 +170,7 @@ fun MapContainerLibre(
             if (beaconLocation != null && beaconLocationMarker.value == null) {
                 // first time beacon is created
                 val markerOptions = MarkerOptions()
-                    .position(beaconLocation)
+                    .position(beaconLocation.toLatLng())
                 beaconLocationMarker.value = mapLibre.addMarker(markerOptions)
             }
         }
@@ -185,7 +186,7 @@ fun MapContainerLibre(
                     mapLibre.cameraPosition = cameraPosition
                     symbol.value?.let { sym ->
                         // We have a symbol, so update it
-                        sym.latLng = userLocation
+                        sym.latLng = userLocation.toLatLng()
                         sym.iconRotate = userSymbolRotation
                         symbolManager.value?.update(sym)
                     }
@@ -194,13 +195,13 @@ fun MapContainerLibre(
                         // beacon to display
                         beaconLocationMarker.value?.let { currentBeaconMarker ->
                             // update beacon position
-                            currentBeaconMarker.position = beaconLocation
+                            currentBeaconMarker.position = beaconLocation.toLatLng()
                             mapLibre.updateMarker(currentBeaconMarker)
                         } ?: {
                             // new beacon to display
                             val markerOptions =
                                 MarkerOptions()
-                                    .position(beaconLocation)
+                                    .position(beaconLocation.toLatLng())
                             beaconLocationMarker.value = mapLibre.addMarker(markerOptions)
                         }
                     } else {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.google.gson.GsonBuilder
-import org.maplibre.android.geometry.LatLng
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.HomeRoutes
@@ -58,8 +57,7 @@ fun generateLocationDetailsRoute(locationDescription: LocationDescription): Stri
 @Composable
 fun LocationDetailsScreen(
     locationDescription : LocationDescription,
-    latitude : Double?,
-    longitude: Double?,
+    location : LngLatAlt?,
     heading : Float,
     onNavigateUp: () -> Unit,
     navController: NavHostController,
@@ -72,25 +70,23 @@ fun LocationDetailsScreen(
         onNavigateUp = onNavigateUp,
         navController = navController,
         locationDescription = locationDescription,
-        createBeacon = { lat, lng ->
-            viewModel.createBeacon(lat, lng)
+        createBeacon = { loc ->
+            viewModel.createBeacon(loc)
         },
         saveMarker = { description ->
             viewModel.createMarker(description)
         },
-        enableStreetPreview = { lat, lng ->
-            viewModel.enableStreetPreview(lat, lng)
+        enableStreetPreview = { loc ->
+            viewModel.enableStreetPreview(loc)
         },
-        getLocationDescription = { location ->
-            viewModel.getLocationDescription(location) ?:
+        getLocationDescription = { locationForDescription ->
+            viewModel.getLocationDescription(locationForDescription) ?:
                 LocationDescription(
                     addressName = context.getString(R.string.general_error_location_services_find_location_error),
-                    latitude = location.latitude,
-                    longitude = location.longitude
+                    location = locationForDescription
                 )
         },
-        latitude = latitude,
-        longitude = longitude,
+        location = location,
         heading = heading,
         modifier = modifier
     )
@@ -101,12 +97,11 @@ fun LocationDetails(
                     locationDescription : LocationDescription,
                     onNavigateUp: () -> Unit,
                     navController: NavHostController,
-                    latitude: Double?,
-                    longitude: Double?,
+                    location: LngLatAlt?,
                     heading: Float,
-                    createBeacon: (latitude: Double, longitude: Double) -> Unit,
+                    createBeacon: (location: LngLatAlt) -> Unit,
                     saveMarker: (description: LocationDescription) -> Unit,
-                    enableStreetPreview: (latitude: Double, longitude: Double) -> Unit,
+                    enableStreetPreview: (location: LngLatAlt) -> Unit,
                     getLocationDescription: (location: LngLatAlt) -> LocationDescription,
                     modifier: Modifier = Modifier) {
 
@@ -136,15 +131,11 @@ fun LocationDetails(
         }
 
         MapContainerLibre(
-            beaconLocation =
-                LatLng(
-                    locationDescription.latitude,
-                    locationDescription.longitude,
-                ),
+            beaconLocation = locationDescription.location,
             allowScrolling = true,
             onMapLongClick = { latLong ->
-                val location = LngLatAlt(latLong.longitude, latLong.latitude)
-                val ld = getLocationDescription(location)
+                val clickLocation = LngLatAlt(latLong.longitude, latLong.latitude)
+                val ld = getLocationDescription(clickLocation)
 
                 // This effectively replaces the current screen with the new one
                 navController.navigate(generateLocationDetailsRoute(ld)) {
@@ -159,16 +150,8 @@ fun LocationDetails(
             },
             onMarkerClick = { false },
             // Center on the beacon
-            mapCenter =
-                LatLng(
-                    locationDescription.latitude,
-                    locationDescription.longitude,
-                ),
-            userLocation =
-                LatLng(
-                    latitude ?: 0.0,
-                    longitude ?: 0.0,
-                ),
+            mapCenter = locationDescription.location,
+            userLocation = location?:LngLatAlt(),
             mapViewRotation = 0.0F,
             userSymbolRotation = heading,
             modifier =
@@ -182,10 +165,10 @@ fun LocationDetails(
 
 @Composable
 private fun LocationDescriptionButtonsSection(
-    createBeacon: (latitude: Double, longitude: Double) -> Unit,
+    createBeacon: (location: LngLatAlt) -> Unit,
     saveMarker: (description: LocationDescription) -> Unit,
     locationDescription: LocationDescription,
-    enableStreetPreview: (latitude: Double, longitude: Double) -> Unit,
+    enableStreetPreview: (location: LngLatAlt) -> Unit,
     onNavigateUp: () -> Unit,
 ) {
     Column(
@@ -195,7 +178,7 @@ private fun LocationDescriptionButtonsSection(
             icon = Icons.Filled.LocationOn,
             text = stringResource(R.string.create_an_audio_beacon),
         ) {
-            createBeacon(locationDescription.latitude, locationDescription.longitude)
+            createBeacon(locationDescription.location)
         }
 
         IconWithTextButton(
@@ -209,10 +192,7 @@ private fun LocationDescriptionButtonsSection(
             icon = Icons.Filled.Navigation,
             text = stringResource(R.string.user_activity_street_preview_title),
         ) {
-            enableStreetPreview(
-                locationDescription.latitude,
-                locationDescription.longitude,
-            )
+            enableStreetPreview(locationDescription.location)
             onNavigateUp()
         }
     }
@@ -319,25 +299,23 @@ fun LocationDetailsPreview() {
             LocationDescription(
                 addressName = "Pizza hut",
                 distance = "3,5 km",
-                latitude = 0.0,
-                longitude = 0.0,
+                location = LngLatAlt(),
                 streetNumberAndName = "139 boulevard gambetta",
                 postcodeAndLocality = "59000 Lille",
                 country = "France",
             ),
-            createBeacon = { _, _ ->
+            createBeacon = { _ ->
             },
             saveMarker = { _ ->
             },
-            enableStreetPreview = { _, _ ->
+            enableStreetPreview = { _ ->
             },
             getLocationDescription = { _ ->
                 LocationDescription()
             },
             onNavigateUp = {},
             navController = NavHostController(LocalContext.current),
-            latitude = null,
-            longitude = null,
+            location = null,
             heading = 0.0F,
         )
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
@@ -36,6 +36,7 @@ import androidx.navigation.NavHostController
 import com.google.gson.GsonBuilder
 import org.maplibre.android.geometry.LatLng
 import org.scottishtecharmy.soundscape.R
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.HomeRoutes
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.home.home.MapContainerLibre
@@ -65,6 +66,8 @@ fun LocationDetailsScreen(
     viewModel: LocationDetailsViewModel = hiltViewModel(),
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
+
     LocationDetails(
         onNavigateUp = onNavigateUp,
         navController = navController,
@@ -77,6 +80,14 @@ fun LocationDetailsScreen(
         },
         enableStreetPreview = { lat, lng ->
             viewModel.enableStreetPreview(lat, lng)
+        },
+        getLocationDescription = { location ->
+            viewModel.getLocationDescription(location) ?:
+                LocationDescription(
+                    addressName = context.getString(R.string.general_error_location_services_find_location_error),
+                    latitude = location.latitude,
+                    longitude = location.longitude
+                )
         },
         latitude = latitude,
         longitude = longitude,
@@ -96,6 +107,7 @@ fun LocationDetails(
                     createBeacon: (latitude: Double, longitude: Double) -> Unit,
                     saveMarker: (description: LocationDescription) -> Unit,
                     enableStreetPreview: (latitude: Double, longitude: Double) -> Unit,
+                    getLocationDescription: (location: LngLatAlt) -> LocationDescription,
                     modifier: Modifier = Modifier) {
 
     Column(
@@ -131,12 +143,9 @@ fun LocationDetails(
                 ),
             allowScrolling = true,
             onMapLongClick = { latLong ->
-                val ld =
-                    LocationDescription(
-                        addressName ="Selected location",
-                        latitude = latLong.latitude,
-                        longitude = latLong.longitude,
-                    )
+                val location = LngLatAlt(latLong.longitude, latLong.latitude)
+                val ld = getLocationDescription(location)
+
                 // This effectively replaces the current screen with the new one
                 navController.navigate(generateLocationDetailsRoute(ld)) {
                     var popupDestination = HomeRoutes.Home.route
@@ -321,6 +330,9 @@ fun LocationDetailsPreview() {
             saveMarker = { _ ->
             },
             enableStreetPreview = { _, _ ->
+            },
+            getLocationDescription = { _ ->
+                LocationDescription()
             },
             onNavigateUp = {},
             navController = NavHostController(LocalContext.current),

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/markersscreen/MarkersScreenList.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/markersscreen/MarkersScreenList.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.home.locationDetails.generateLocationDetailsRoute
 import org.scottishtecharmy.soundscape.screens.markers_routes.navigation.ScreensForMarkersAndRoutes
@@ -62,8 +63,10 @@ fun MarkersList(
                             val ld =
                                 LocationDescription(
                                     addressName = marker.name,
-                                    latitude = marker.location!!.latitude,
-                                    longitude = marker.location!!.longitude,
+                                    location = LngLatAlt(
+                                        marker.location!!.longitude,
+                                        marker.location!!.latitude
+                                    ),
                                     marker = true
                                 )
                             // This effectively replaces the current screen with the new one

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/audiobeacons/AudioBeaconsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/audiobeacons/AudioBeaconsViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.scottishtecharmy.soundscape.MainActivity
 import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import javax.inject.Inject
 
 @HiltViewModel
@@ -36,7 +37,7 @@ class AudioBeaconsViewModel @Inject constructor(@ApplicationContext val context:
         audioEngine.setBeaconType(type)
         if(beacon != 0L)
             audioEngine.destroyBeacon(beacon)
-        beacon = audioEngine.createBeacon(1.0, 0.0)
+        beacon = audioEngine.createBeacon(LngLatAlt(1.0, 0.0))
         _state.value = state.value.copy(selectedBeacon = type)
         // Store the preference for future use
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/RoutePlayer.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/RoutePlayer.kt
@@ -11,6 +11,7 @@ import org.scottishtecharmy.soundscape.database.local.dao.RoutesDao
 import org.scottishtecharmy.soundscape.database.local.model.RouteData
 import org.scottishtecharmy.soundscape.database.repository.RoutesRepository
 import org.scottishtecharmy.soundscape.geoengine.utils.distance
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 
 class RoutePlayer(val service: SoundscapeService) {
     private var currentRouteData: RouteData? = null
@@ -59,7 +60,7 @@ class RoutePlayer(val service: SoundscapeService) {
             service.audioEngine.clearTextToSpeechQueue()
             service.audioEngine.createTextToSpeech("Move to marker ${index+1}, ${route.waypoints[index].name}", location.latitude, location.longitude)
 
-            service.createBeacon(location.latitude, location.longitude)
+            service.createBeacon(LngLatAlt(location.latitude, location.longitude))
 }
     }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -111,14 +111,16 @@ class SoundscapeService : MediaSessionService() {
         return binder!!
     }
 
-    fun setStreetPreviewMode(on: Boolean, latitude: Double, longitude: Double) {
+    fun setStreetPreviewMode(on: Boolean, location: LngLatAlt?) {
         directionProvider.destroy()
         locationProvider.destroy()
         geoEngine.stop()
         if (on) {
             // Use static location, but phone's direction
-            locationProvider = StaticLocationProvider(latitude, longitude)
-            directionProvider = AndroidDirectionProvider(this)
+            if(location != null) {
+                locationProvider = StaticLocationProvider(location)
+                directionProvider = AndroidDirectionProvider(this)
+            }
         } else {
             // Switch back to phone's location and direction
             locationProvider = AndroidLocationProvider(this)
@@ -312,13 +314,15 @@ class SoundscapeService : MediaSessionService() {
             Realm.deleteRealm(config)
         }*/
 
-    fun createBeacon(latitude: Double, longitude: Double) {
+    fun createBeacon(location: LngLatAlt?) {
+        if(location == null) return
+
         if (audioBeacon != 0L) {
             audioEngine.destroyBeacon(audioBeacon)
         }
-        audioBeacon = audioEngine.createBeacon(latitude, longitude)
+        audioBeacon = audioEngine.createBeacon(location)
         // Report any change in beacon back to application
-        _beaconFlow.value = LngLatAlt(longitude, latitude)
+        _beaconFlow.value = location
     }
 
     fun destroyBeacon() {
@@ -405,7 +409,7 @@ class SoundscapeService : MediaSessionService() {
 
     /**
      * streetPreviewGo is called when the 'GO' button is pressed when in StreetPreview mode.
-     * It indicates that the user has selected the direction of travel in which they wich to move.
+     * It indicates that the user has selected the direction of travel in which they which to move.
      */
     fun streetPreviewGo() {
         geoEngine.streetPreviewGo()

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -44,6 +44,7 @@ import org.scottishtecharmy.soundscape.locationprovider.AndroidLocationProvider
 import org.scottishtecharmy.soundscape.locationprovider.DirectionProvider
 import org.scottishtecharmy.soundscape.locationprovider.LocationProvider
 import org.scottishtecharmy.soundscape.locationprovider.StaticLocationProvider
+import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -80,7 +81,7 @@ class SoundscapeService : MediaSessionService() {
     private var audioBeacon: Long = 0
 
     // Geo engine
-    var geoEngine = GeoEngine()
+    private var geoEngine = GeoEngine()
 
     // Flow to return beacon location
     private val _beaconFlow = MutableStateFlow<LngLatAlt?>(null)
@@ -355,6 +356,10 @@ class SoundscapeService : MediaSessionService() {
             val results = geoEngine.aheadOfMe()
             speakCallout(results)
         }
+    }
+
+    fun getLocationDescription(location: LngLatAlt) : LocationDescription? {
+        return geoEngine.getLocationDescription(location)
     }
 
     private lateinit var routePlayer : RoutePlayer

--- a/app/src/main/java/org/scottishtecharmy/soundscape/utils/LocationExt.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/utils/LocationExt.kt
@@ -1,14 +1,15 @@
 package org.scottishtecharmy.soundscape.utils
 
-import android.location.Location
+import android.content.Context
+import org.scottishtecharmy.soundscape.geoengine.formatDistanceAsString
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
-import java.util.Locale
 
 fun ArrayList<Feature>.toLocationDescriptions(
-    currentLocationLatitude: Double,
-    currentLocationLongitude: Double,
+    currentLocation: LngLatAlt,
+    localizedContext: Context
 ): List<LocationDescription> =
     mapNotNull { feature ->
         feature.properties?.let { properties ->
@@ -26,16 +27,11 @@ fun ArrayList<Feature>.toLocationDescriptions(
                     ).joinToString(" ").nullIfEmpty(),
                 country = properties["country"]?.toString()?.nullIfEmpty(),
                 distance =
-                    formatDistance(
-                        calculateDistance(
-                            lat1 = currentLocationLatitude,
-                            lon1 = currentLocationLongitude,
-                            lat2 = (feature.geometry as Point).coordinates.latitude,
-                            lon2 = (feature.geometry as Point).coordinates.longitude,
-                        ),
+                    formatDistanceAsString(
+                        currentLocation.distance((feature.geometry as Point).coordinates),
+                        localizedContext
                     ),
-                latitude = (feature.geometry as Point).coordinates.latitude,
-                longitude = (feature.geometry as Point).coordinates.longitude,
+                location = (feature.geometry as Point).coordinates,
             )
         }
     }
@@ -51,20 +47,4 @@ fun LocationDescription.buildAddressFormat(): String? {
         addressFormat.isEmpty() -> null
         else -> addressFormat.joinToString("\n")
     }
-}
-
-private fun calculateDistance(
-    lat1: Double,
-    lon1: Double,
-    lat2: Double,
-    lon2: Double,
-): Float {
-    val results = FloatArray(1)
-    Location.distanceBetween(lat1, lon1, lat2, lon2, results)
-    return results[0]
-}
-
-private fun formatDistance(distanceInMeters: Float): String {
-    val distanceInKm = distanceInMeters / 1000
-    return String.format(Locale.getDefault(), "%.1f km", distanceInKm)
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
@@ -21,12 +21,12 @@ class LocationDetailsViewModel @Inject constructor(
 
     private var serviceConnection : SoundscapeServiceConnection? = null
 
-    fun createBeacon(latitude: Double, longitude: Double) {
-        soundscapeServiceConnection.soundscapeService?.createBeacon(latitude, longitude)
+    fun createBeacon(location: LngLatAlt) {
+        soundscapeServiceConnection.soundscapeService?.createBeacon(location)
     }
 
-    fun enableStreetPreview(latitude: Double, longitude: Double) {
-        soundscapeServiceConnection.setStreetPreviewMode(true, latitude, longitude)
+    fun enableStreetPreview(location: LngLatAlt) {
+        soundscapeServiceConnection.setStreetPreviewMode(true, location)
 
     }
 
@@ -35,8 +35,13 @@ class LocationDetailsViewModel @Inject constructor(
             var name = locationDescription.addressName
             if(name == null) name = locationDescription.streetNumberAndName
             name = name ?: "Unknown"
-            val marker = RoutePoint(name,
-                                    Location(locationDescription.latitude, locationDescription.longitude))
+            val marker = RoutePoint(
+                name,
+                Location(
+                    locationDescription.location.latitude,
+                    locationDescription.location.longitude
+                )
+            )
             try {
                 routesRepository.insertWaypoint(marker)
                 Log.d("LocationDetailsViewModel", "Marker saved successfully: ${marker.name}")

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
@@ -9,14 +9,13 @@ import org.scottishtecharmy.soundscape.SoundscapeServiceConnection
 import org.scottishtecharmy.soundscape.database.local.model.Location
 import org.scottishtecharmy.soundscape.database.local.model.RoutePoint
 import org.scottishtecharmy.soundscape.database.repository.RoutesRepository
-import org.scottishtecharmy.soundscape.screens.home.Navigator
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import javax.inject.Inject
 
 @HiltViewModel
 class LocationDetailsViewModel @Inject constructor(
     private val soundscapeServiceConnection : SoundscapeServiceConnection,
-    private val navigator : Navigator,
     private val routesRepository: RoutesRepository
     ): ViewModel() {
 
@@ -47,8 +46,11 @@ class LocationDetailsViewModel @Inject constructor(
         }
     }
 
+    fun getLocationDescription(location: LngLatAlt) : LocationDescription? {
+        return soundscapeServiceConnection.soundscapeService?.getLocationDescription(location)
+    }
+
     init {
-        navigator.navigate("")
         serviceConnection = soundscapeServiceConnection
         viewModelScope.launch {
             soundscapeServiceConnection.serviceBoundState.collect {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeState.kt
@@ -1,12 +1,11 @@
 package org.scottishtecharmy.soundscape.viewmodels.home
 
-import android.location.Location
 import org.maplibre.android.geometry.LatLng
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 
 data class HomeState(
     var heading: Float = 0.0f,
-    var location: Location? = null,
+    var location: LatLng? = null,
     var beaconLocation: LatLng? = null,
     var streetPreviewMode: Boolean = false,
     var tileGridGeoJson: String = "",

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeState.kt
@@ -1,12 +1,12 @@
 package org.scottishtecharmy.soundscape.viewmodels.home
 
-import org.maplibre.android.geometry.LatLng
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 
 data class HomeState(
     var heading: Float = 0.0f,
-    var location: LatLng? = null,
-    var beaconLocation: LatLng? = null,
+    var location: LngLatAlt? = null,
+    var beaconLocation: LngLatAlt? = null,
     var streetPreviewMode: Boolean = false,
     var tileGridGeoJson: String = "",
     var isSearching: Boolean = false,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeViewModel.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.launch
 import org.maplibre.android.annotations.Marker
 import org.maplibre.android.geometry.LatLng
 import org.scottishtecharmy.soundscape.SoundscapeServiceConnection
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.utils.blankOrEmpty
 import org.scottishtecharmy.soundscape.utils.toLocationDescriptions
 import java.net.URLEncoder
@@ -88,7 +90,7 @@ class HomeViewModel
                 soundscapeServiceConnection.getLocationFlow()?.collectLatest { value ->
                     if (value != null) {
                         Log.d(TAG, "Location $value")
-                        _state.update { it.copy(location = value) }
+                        _state.update { it.copy(location = LatLng(value.latitude, value.longitude)) }
                     }
                 }
             }
@@ -183,6 +185,10 @@ class HomeViewModel
             viewModelScope.launch {
                 soundscapeServiceConnection.soundscapeService?.whatsAroundMe()
             }
+        }
+
+        fun getLocationDescription(location: LngLatAlt) : LocationDescription? {
+            return soundscapeServiceConnection.soundscapeService?.getLocationDescription(location)
         }
 
         fun shareLocation(context: Context) {


### PR DESCRIPTION
I'm a little wary of the UI side of this, but I think the GeoEngine approach seems okay. The `localReverseGeocode` is similar to what the iOS app does.

When creating markers we want to be able to describe the location so that the marker name makes sense. The approach here is to:

1. Generate a description based on the local tile data if we have it
2. Request the photon server reverse geocodes the location

The latter generally gives a better response, but is slower as it involves a roundtrip to the server.