### PR TITLE
Initial decode of iOS exported route and import into database

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,6 +59,14 @@
             </intent-filter>
 
             <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="content"/>
+                <data android:mimeType="application/json" />
+            </intent-filter>
+
+            <intent-filter>
                 <!-- geo intents to set a beacon -->
                 <data android:scheme="geo" />
                 <action android:name="android.intent.action.VIEW"/>
@@ -73,6 +81,21 @@
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE" />
             </intent-filter>
+
+            <!--
+            Once we have share.soundscape.services (or similar) server set up, then we can uncomment
+            this and test deep linking. This is so that iOS shared markers such as:
+                https://share.soundscape.services/v1/sharemarker?nickname=Anderson%20Strathearn&name=&lat=55.9478065&lon=-3.2086401
+            can be supported. It will need some additional parsing in SoundscapeIntents.
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https"
+                    android:host="share.soundscape.services"
+                    android:pathPrefix="/v1/sharemarker" />
+            </intent-filter>
+            -->
         </activity>
 
         <service

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geojsonparser/geojson/LngLatAlt.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geojsonparser/geojson/LngLatAlt.kt
@@ -50,8 +50,6 @@ open class LngLatAlt(
 
     /**
      * Distance to a LineString from current location.
-     * @param pointCoordinates
-     * LngLatAlt of current location
      * @param lineStringCoordinates
      * LineString that we are working out the distance from
      * @return The distance of the point to the LineString
@@ -61,9 +59,24 @@ open class LngLatAlt(
         nearestPoint: LngLatAlt? = null
     ): Double {
 
-        return distanceToLine(
-            lineStringCoordinates.coordinates[0],
-            lineStringCoordinates.coordinates[1],
-            nearestPoint)
+        var shortestDistance = Double.MAX_VALUE
+        var bestNearestPoint = LngLatAlt()
+        for(i in 1 until lineStringCoordinates.coordinates.size - 1) {
+            val nearestPointOnSegment = LngLatAlt()
+            val distance = distanceToLine(
+                lineStringCoordinates.coordinates[i-1],
+                lineStringCoordinates.coordinates[i],
+                nearestPointOnSegment)
+
+            if(distance < shortestDistance) {
+                shortestDistance = distance
+                bestNearestPoint = nearestPointOnSegment
+            }
+        }
+        if(nearestPoint != null) {
+            nearestPoint.longitude = bestNearestPoint.longitude
+            nearestPoint.latitude = bestNearestPoint.latitude
+        }
+        return shortestDistance
     }
 }


### PR DESCRIPTION
This is based on a sample file from when a route was exported from the iOS app. This commit registers application/json for the app and then tries to decode it with the assumption that it matches the format in the sample file. RouteData and RoutePoint don't have fields for all of those in the JSON, though we may add them in future.

With this code in place the shared file can be 'opened' on the phone and it will run Soundscape and import the route. 