### PR TITLE
Wire up RoutePlayer and add Help text in menu

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -150,9 +150,6 @@ class MainActivity : AppCompatActivity() {
                             intent.action = ""
                         }
                     }
-
-                    // Pick the current route
-                    setupCurrentRoute()
                 }
             }
         }
@@ -263,10 +260,6 @@ class MainActivity : AppCompatActivity() {
             startSoundscapeService()
             soundscapeServiceConnection.tryToBindToServiceIfRunning(applicationContext)
         }
-    }
-
-    fun setupCurrentRoute() {
-        soundscapeServiceConnection.soundscapeService?.setupCurrentRoute()
     }
 
     /**

--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.services.SoundscapeBinder
 import org.scottishtecharmy.soundscape.services.SoundscapeService
-import org.scottishtecharmy.soundscape.geoengine.utils.TileGrid
 import javax.inject.Inject
 
 @ActivityRetainedScoped
@@ -41,6 +40,10 @@ class SoundscapeServiceConnection @Inject constructor() {
     fun setStreetPreviewMode(on : Boolean, latitude: Double = 0.0, longitude: Double = 0.0) {
         Log.d(TAG, "setStreetPreviewMode $on")
         soundscapeService?.setStreetPreviewMode(on, latitude, longitude)
+    }
+
+    fun startRoute(routeName: String) {
+        soundscapeService?.startRoute(routeName)
     }
 
     // needed to communicate with the service.

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/DrawerContent.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/DrawerContent.kt
@@ -76,7 +76,7 @@ fun DrawerContent(
             icon = Icons.Rounded.Settings,
         )
         DrawerMenuItem(
-            onClick = { notAvailableToast() },
+            onClick = { onNavigate(HomeRoutes.Help.route + "/home") },
             label = stringResource(R.string.menu_help_and_tutorials),
             Icons.AutoMirrored.Rounded.HelpOutline,
         )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeRoutes.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeRoutes.kt
@@ -32,4 +32,8 @@ sealed class HomeRoutes(
         route = "edit_route_screen",
         title = "EditDetailsScreen",
     )
+    data object Help : HomeRoutes(
+        route = "help_screen",
+        title = "HelpScreen",
+    )
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
@@ -17,6 +17,7 @@ import androidx.navigation.compose.composable
 import com.google.gson.GsonBuilder
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
+import org.scottishtecharmy.soundscape.screens.home.home.HelpScreen
 import org.scottishtecharmy.soundscape.screens.home.home.Home
 import org.scottishtecharmy.soundscape.screens.home.locationDetails.LocationDetailsScreen
 import org.scottishtecharmy.soundscape.screens.home.locationDetails.generateLocationDetailsRoute
@@ -170,6 +171,24 @@ fun HomeScreen(
                 routeDescription = uiState.description,
                 navController = navController,
                 viewModel = editRouteViewModel,
+                modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing)
+            )
+        }
+
+        composable(HomeRoutes.RouteDetails.route + "/{routeName}") { backStackEntry ->
+            val routeName = backStackEntry.arguments?.getString("routeName") ?: ""
+            RouteDetailsScreenVM(
+                routeName = routeName,
+                navController = navController,
+                modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing)
+            )
+        }
+
+        composable(HomeRoutes.Help.route + "/{topic}") { backStackEntry ->
+            val topic = backStackEntry.arguments?.getString("topic") ?: ""
+            HelpScreen(
+                topic = topic,
+                navController = navController,
                 modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing)
             )
         }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HelpScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HelpScreen.kt
@@ -1,0 +1,616 @@
+package org.scottishtecharmy.soundscape.screens.home.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ChevronRight
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import org.scottishtecharmy.soundscape.R
+import org.scottishtecharmy.soundscape.screens.home.HomeRoutes
+import org.scottishtecharmy.soundscape.screens.markers_routes.components.CustomAppBar
+import org.scottishtecharmy.soundscape.ui.theme.Foreground2
+import org.scottishtecharmy.soundscape.ui.theme.OnSurface
+import org.scottishtecharmy.soundscape.ui.theme.PurpleGradientDark
+import org.scottishtecharmy.soundscape.ui.theme.SoundscapeTheme
+
+private enum class SectionType{
+    Title,          // A non-clickable title of a group of other text
+    Link,           // A clickable text link
+    Paragraph,      // A paragraph of text
+    Faq             // A FAQ question with its answer in the section
+}
+private data class Section(
+    val textId: Int,                      // There's always text, this is the resource id for it
+    val type: SectionType,
+    val faqAnswer: Int = -1             // The resource id of the answer to a FAQ question
+)
+private data class Sections(
+    val titleId: Int,
+    val sections: List<Section>
+)
+
+// This is a list of all the possible Sections that can be displayed as part of the help screen.
+// Each one has a unique titleId which is used to identify it in the route.
+private val helpPages = listOf(
+    Sections(
+        R.string.beacon_audio_beacon,
+        listOf(
+            Section(R.string.help_text_section_title_what, SectionType.Title),
+            Section(R.string.help_text_destination_beacons_what, SectionType.Paragraph),
+
+            Section(R.string.help_text_section_title_when, SectionType.Title),
+            Section(R.string.help_text_destination_beacons_when, SectionType.Paragraph),
+
+            Section(R.string.help_text_section_title_how, SectionType.Title),
+            Section(R.string.help_text_destination_beacons_how_1, SectionType.Paragraph),
+            Section(R.string.help_text_destination_beacons_how_2, SectionType.Paragraph),
+            Section(R.string.help_text_destination_beacons_how_3, SectionType.Paragraph)
+        )
+    ),
+
+    Sections(
+        R.string.voice_voices,
+        listOf(
+            Section(R.string.help_config_voices_content, SectionType.Paragraph),
+        )
+    ),
+
+    Sections(
+        R.string.help_remote_page_title,
+        listOf(
+            Section(R.string.help_text_section_title_what, SectionType.Title),
+            Section(R.string.help_text_remote_control_what, SectionType.Paragraph),
+
+            Section(R.string.help_text_section_title_when, SectionType.Title),
+            Section(R.string.help_text_remote_control_when, SectionType.Paragraph),
+
+            Section(R.string.help_text_section_title_how, SectionType.Title),
+            Section(R.string.help_text_remote_control_how, SectionType.Paragraph),
+        )
+    ),
+
+    Sections(
+        R.string.help_explore_page_title,
+        listOf(
+            Section(R.string.help_text_section_title_what, SectionType.Title),
+            Section(R.string.help_text_ahead_of_me_what, SectionType.Paragraph),
+
+            Section(R.string.help_text_section_title_when, SectionType.Title),
+            Section(R.string.help_text_ahead_of_me_when, SectionType.Paragraph),
+
+            Section(R.string.help_text_section_title_how, SectionType.Title),
+            Section(R.string.help_text_ahead_of_me_how, SectionType.Paragraph),
+        )
+    ),
+
+    Sections(
+        R.string.help_orient_page_title,
+        listOf(
+            Section(R.string.help_text_section_title_what, SectionType.Title),
+            Section(R.string.help_text_around_me_what, SectionType.Paragraph),
+
+            Section(R.string.help_text_section_title_when, SectionType.Title),
+            Section(R.string.help_text_around_me_when, SectionType.Paragraph),
+
+            Section(R.string.help_text_section_title_how, SectionType.Title),
+            Section(R.string.help_text_around_me_how, SectionType.Paragraph),
+        )
+    ),
+
+    Sections(
+        R.string.callouts_automatic_callouts,
+        listOf(
+            Section(R.string.help_text_section_title_what, SectionType.Title),
+            Section(R.string.help_text_automatic_callouts_what, SectionType.Paragraph),
+
+            Section(R.string.help_text_section_title_when, SectionType.Title),
+            Section(R.string.help_text_automatic_callouts_when_1, SectionType.Paragraph),
+            Section(R.string.help_text_automatic_callouts_when_2, SectionType.Paragraph),
+            Section(R.string.help_text_automatic_callouts_when_3, SectionType.Paragraph),
+
+            Section(R.string.help_text_section_title_how, SectionType.Title),
+            Section(R.string.help_text_automatic_callouts_how_1, SectionType.Paragraph),
+            Section(R.string.help_text_automatic_callouts_how_2, SectionType.Paragraph),
+        )
+    ),
+
+    Sections(
+        R.string.directions_my_location,
+        listOf(
+            Section(R.string.help_text_section_title_what, SectionType.Title),
+            Section(R.string.help_text_my_location_what, SectionType.Paragraph),
+
+            Section(R.string.help_text_section_title_when, SectionType.Title),
+            Section(R.string.help_text_my_location_when, SectionType.Paragraph),
+
+            Section(R.string.help_text_section_title_how, SectionType.Title),
+            Section(R.string.help_text_my_location_how, SectionType.Paragraph),
+        )
+    ),
+
+    Sections(
+        R.string.routes_title,
+        listOf(
+            Section(R.string.help_text_section_title_what, SectionType.Title),
+            Section(R.string.help_text_routes_content_what, SectionType.Paragraph),
+
+            Section(R.string.help_text_section_title_when, SectionType.Title),
+            Section(R.string.help_text_routes_content_when, SectionType.Paragraph),
+
+            Section(R.string.help_text_section_title_how, SectionType.Title),
+            Section(R.string.help_text_routes_content_how_1, SectionType.Paragraph),
+            Section(R.string.help_text_routes_content_how_2, SectionType.Paragraph),
+            Section(R.string.help_text_routes_content_how_3, SectionType.Paragraph),
+        )
+    ),
+
+    Sections(
+        R.string.callouts_nearby_markers,
+        listOf(
+            Section(R.string.help_text_section_title_what, SectionType.Title),
+            Section(R.string.help_text_nearby_markers_what, SectionType.Paragraph),
+
+            Section(R.string.help_text_section_title_when, SectionType.Title),
+            Section(R.string.help_text_nearby_markers_when, SectionType.Paragraph),
+
+            Section(R.string.help_text_section_title_how, SectionType.Title),
+            Section(R.string.help_text_nearby_markers_how, SectionType.Paragraph),
+        )
+    ),
+
+    Sections(
+        R.string.markers_title,
+        listOf(
+            Section(R.string.help_text_markers_content_1, SectionType.Paragraph),
+            Section(R.string.help_text_markers_content_2, SectionType.Paragraph),
+            Section(R.string.help_text_markers_content_3, SectionType.Paragraph),
+        )
+    ),
+
+    Sections(
+        R.string.help_creating_markers_page_title,
+        listOf(
+            Section(R.string.help_text_creating_markers_content_1, SectionType.Paragraph),
+            Section(R.string.help_text_creating_markers_content_2, SectionType.Paragraph),
+        )
+    ),
+
+    Sections(
+        R.string.help_edit_markers_page_title,
+        listOf(
+            Section(R.string.help_text_customizing_markers_content_1, SectionType.Paragraph),
+            Section(R.string.help_text_customizing_markers_content_2, SectionType.Paragraph),
+        )
+    ),
+
+    Sections(
+        R.string.faq_tips_title,
+        listOf(
+            Section(R.string.faq_tip_finding_bus_stops, SectionType.Paragraph),
+            Section(R.string.faq_tip_setting_beacon_on_address, SectionType.Paragraph),
+            Section(R.string.faq_tip_create_marker_at_bus_stop, SectionType.Paragraph),
+            Section(R.string.faq_tip_beacon_quiet, SectionType.Paragraph),
+            Section(R.string.faq_tip_hold_phone_flat, SectionType.Paragraph),
+            Section(R.string.faq_tip_turning_beacon_off, SectionType.Paragraph),
+            Section(R.string.faq_tip_turning_off_auto_callouts, SectionType.Paragraph),
+            //Section(R.string.faq_tip_two_finger_double_tap, SectionType.Paragraph), Currently unsupported on Android
+        )
+    ),
+
+    Sections(
+        R.string.help_offline_page_title,
+        listOf(
+            Section(R.string.help_offline_page_title, SectionType.Title),
+            Section(R.string.help_offline_description, SectionType.Paragraph),
+            Section(R.string.help_offline_limitations_heading, SectionType.Title),
+            Section(R.string.help_offline_limitations_description, SectionType.Paragraph),
+            Section(R.string.help_offline_troubleshooting_heading, SectionType.Title),
+            Section(R.string.help_offline_troubleshooting_description, SectionType.Paragraph),
+        )
+    ),
+
+    Sections(
+        R.string.menu_help_and_tutorials,
+        listOf(
+            Section(R.string.help_configuration_section_title, SectionType.Title),
+            Section(R.string.voice_voices, SectionType.Link),
+            Section(R.string.help_remote_page_title, SectionType.Link),
+
+            Section(R.string.settings_help_section_beacons_and_pois, SectionType.Title),
+            Section(R.string.beacon_audio_beacon, SectionType.Link),
+            Section(R.string.callouts_automatic_callouts, SectionType.Link),
+
+            Section(R.string.settings_help_section_home_screen_buttons, SectionType.Title),
+            Section(R.string.directions_my_location, SectionType.Link),
+            Section(R.string.help_orient_page_title, SectionType.Link),
+            Section(R.string.help_explore_page_title, SectionType.Link),
+            Section(R.string.callouts_nearby_markers, SectionType.Link),
+
+            Section(R.string.search_view_markers, SectionType.Title),
+            Section(R.string.markers_title, SectionType.Link),
+            Section(R.string.routes_title, SectionType.Link),
+            Section(R.string.help_creating_markers_page_title, SectionType.Link),
+            Section(R.string.help_edit_markers_page_title, SectionType.Link),
+
+            Section(R.string.faq_title, SectionType.Title),
+            Section(R.string.faq_title, SectionType.Link),
+            Section(R.string.faq_tips_title, SectionType.Link),
+            Section(R.string.help_offline_page_title, SectionType.Link),
+        )
+    ),
+
+    Sections(
+        R.string.faq_title,
+        listOf(
+            Section(R.string.faq_section_what_is_soundscape, SectionType.Title),
+            Section(R.string.faq_when_to_use_soundscape_question, SectionType.Faq, faqAnswer = R.string.faq_when_to_use_soundscape_answer),
+            Section(R.string.faq_markers_function_question, SectionType.Faq, faqAnswer = R.string.faq_markers_function_answer),
+
+            Section(R.string.faq_section_getting_the_best_experience, SectionType.Title),
+            Section(R.string.faq_what_can_I_set_question, SectionType.Faq, faqAnswer = R.string.faq_what_can_I_set_answer),
+            Section(R.string.faq_how_to_use_beacon_question, SectionType.Faq, faqAnswer = R.string.faq_how_to_use_beacon_answer),
+            Section(R.string.faq_why_does_beacon_disappear_question, SectionType.Faq, faqAnswer = R.string.faq_why_does_beacon_disappear_answer),
+            Section(R.string.faq_beacon_on_address_question, SectionType.Faq, faqAnswer = R.string.faq_beacon_on_address_answer),
+            Section(R.string.faq_beacon_on_home_question, SectionType.Faq, faqAnswer = R.string.faq_beacon_on_home_answer),
+            Section(R.string.faq_how_close_to_destination_question, SectionType.Faq, faqAnswer = R.string.faq_how_close_to_destination_answer),
+            Section(R.string.faq_turn_beacon_back_on_question, SectionType.Faq, faqAnswer = R.string.faq_turn_beacon_back_on_answer),
+            Section(R.string.faq_road_names_question, SectionType.Faq, faqAnswer = R.string.faq_road_names_answer),
+            Section(R.string.faq_why_not_every_business_question, SectionType.Faq, faqAnswer = R.string.faq_why_not_every_business_answer),
+            Section(R.string.faq_callouts_stopping_in_vehicle_question, SectionType.Faq, faqAnswer = R.string.faq_callouts_stopping_in_vehicle_answer),
+            Section(R.string.faq_miss_a_callout_question, SectionType.Faq, faqAnswer = R.string.faq_miss_a_callout_answer),
+
+            Section(R.string.faq_section_how_soundscape_works, SectionType.Title),
+            Section(R.string.faq_supported_phones_question, SectionType.Faq, faqAnswer = R.string.faq_supported_phones_answer),
+            Section(R.string.faq_supported_headsets_question, SectionType.Faq, faqAnswer = R.string.faq_supported_headsets_answer),
+            Section(R.string.faq_battery_impact_question, SectionType.Faq, faqAnswer = R.string.faq_battery_impact_answer),
+            Section(R.string.faq_sleep_mode_battery_question, SectionType.Faq, faqAnswer = R.string.faq_sleep_mode_battery_answer),
+            Section(R.string.faq_snooze_mode_battery_question, SectionType.Faq, faqAnswer = R.string.faq_snooze_mode_battery_answer),
+            Section(R.string.faq_headset_battery_impact_question, SectionType.Faq, faqAnswer = R.string.faq_headset_battery_impact_answer),
+            Section(R.string.faq_background_battery_impact_question, SectionType.Faq, faqAnswer = R.string.faq_background_battery_impact_answer),
+            Section(R.string.faq_mobile_data_use_question, SectionType.Faq, faqAnswer = R.string.faq_mobile_data_use_answer),
+            Section(R.string.faq_difference_from_map_apps_question, SectionType.Faq, faqAnswer = R.string.faq_difference_from_map_apps_answer),
+            Section(R.string.faq_use_with_wayfinding_apps_question, SectionType.Faq, faqAnswer = R.string.faq_use_with_wayfinding_apps_answer),
+            Section(R.string.faq_controlling_what_you_hear_question, SectionType.Faq, faqAnswer = R.string.faq_controlling_what_you_hear_answer),
+            Section(R.string.faq_holding_phone_flat_question, SectionType.Faq, faqAnswer = R.string.faq_holding_phone_flat_answer),
+            Section(R.string.faq_what_is_osm_question, SectionType.Faq, faqAnswer = R.string.faq_what_is_osm_answer),
+        )
+    )
+)
+
+@Composable
+fun HelpScreen(
+    topic: String,
+    navController: NavHostController,
+    modifier: Modifier
+) {
+    // Find our page
+    var sections = Sections(0, emptyList())
+    if (topic.startsWith("page")) {
+        // Parse page title id from route
+        val id = topic.substring(4).toInt()
+        for (page in helpPages) {
+            if(page.titleId == id) {
+                sections = page
+            }
+        }
+    } else if(topic.startsWith("faq")) {
+        // Parse faq answer id from route
+        val id = topic.substring(3).toInt()
+        sections = Sections(R.string.faq_title_abbreviated, listOf(Section(id, SectionType.Paragraph)))
+    } else {
+        // Default to home
+        for (page in helpPages) {
+            if(page.titleId == R.string.menu_help_and_tutorials) {
+                sections = page
+            }
+        }
+    }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            CustomAppBar(
+                title = stringResource(sections.titleId),
+                navigationButtonTitle = stringResource(R.string.ui_back_button_title),
+                onNavigateUp = { navController.popBackStack() },
+            )
+        },
+        content = { padding ->
+            Box(
+                modifier = Modifier
+                    .padding(padding)
+            ) {
+                // Help topic page
+                LazyColumn(
+                    modifier = modifier
+                        .fillMaxWidth()
+                        .background(PurpleGradientDark)
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    items(sections.sections) { section ->
+                        when (section.type) {
+                            SectionType.Title -> {
+                                Text(
+                                    text = stringResource(section.textId),
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = Foreground2,
+                                )
+                            }
+
+                            SectionType.Paragraph -> {
+                                Text(
+                                    text = AnnotatedString.fromHtml(stringResource(section.textId)),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = OnSurface,
+                                )
+                            }
+
+                            SectionType.Link, SectionType.Faq -> {
+                                Button(
+                                    onClick = {
+                                        if (section.type == SectionType.Faq) {
+                                            navController.navigate("${HomeRoutes.Help.route}/faq${section.faqAnswer}")
+                                        } else {
+                                            navController.navigate("${HomeRoutes.Help.route}/page${section.textId}")
+                                        }
+                                    },
+                                    modifier = Modifier
+                                        .fillMaxWidth(),
+                                    shape = RoundedCornerShape(2.dp),
+                                ) {
+                                    Box(
+                                        Modifier.weight(6f)
+                                    ) {
+                                        Text(
+                                            text = stringResource(section.textId),
+                                            textAlign = TextAlign.Start,
+                                            style = MaterialTheme.typography.titleMedium,
+                                            color = OnSurface,
+                                        )
+                                    }
+                                    Box(
+                                        Modifier.weight(1f)
+                                    ) {
+                                        Icon(
+                                            Icons.Rounded.ChevronRight,
+                                            null,
+                                            tint = Color.White,
+                                            modifier = Modifier.align(Alignment.CenterEnd)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun HomeHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "page${R.string.menu_help_and_tutorials}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun BeaconHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "page${R.string.beacon_audio_beacon}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun VoicesHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "page${R.string.voice_voices}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RemoteHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "page${R.string.help_remote_page_title}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun AheadOfMeHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "page${R.string.help_explore_page_title}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun AroundMeHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "page${R.string.help_orient_page_title}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun AutomaticCalloutsHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "page${R.string.callouts_automatic_callouts}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MyLocationHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "page${R.string.directions_my_location}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RoutesContentHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "page${R.string.routes_title}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MarkersHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "page${R.string.markers_title}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CreatingMarkersHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "page${R.string.help_creating_markers_page_title}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NearbyMarkersHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "page${R.string.callouts_nearby_markers}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun EditingMarkersHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "page${R.string.help_edit_markers_page_title}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun FaqHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "page${R.string.faq_title}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun FaqAnswerHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "faq${R.string.faq_when_to_use_soundscape_answer}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TipsHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "page${R.string.faq_tips_title}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun OfflineHelpPreview() {
+    SoundscapeTheme {
+        HelpScreen(
+            topic = "page${R.string.help_offline_page_title}",
+            navController = rememberNavController(),
+            modifier = Modifier
+        )
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/routedetailsscreen/RouteDetailsScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/routedetailsscreen/RouteDetailsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.rememberNavController
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.database.local.model.RouteData
@@ -54,6 +55,7 @@ fun RouteDetailsScreenVM(
         modifier,
         uiState,
         getRouteByName = { viewModel.getRouteByName(routeName) },
+        startRoute = { viewModel.startRoute(routeName) },
         clearErrorMessage = { viewModel.clearErrorMessage() }
     )
 }
@@ -65,6 +67,7 @@ fun RouteDetailsScreen(
     modifier: Modifier,
     uiState: RouteDetailsUiState,
     getRouteByName: (routeName: String) -> Unit,
+    startRoute: (routeName: String) -> Unit,
     clearErrorMessage: () -> Unit,
 ) {
     // Observe the UI state from the ViewModel
@@ -151,7 +154,16 @@ fun RouteDetailsScreen(
                                 iconText = stringResource(R.string.route_detail_action_start_route),
                                 fontSize = 28.sp,
                                 fontWeight = FontWeight.Bold,
-                                onClick = { /*TODO*/ })
+                                onClick = {
+                                    startRoute(route.name)
+                                    // Pop up to the home screen
+                                    navController.navigate(HomeRoutes.Home.route) {
+                                        popUpTo(navController.graph.findStartDestination().id) {
+                                            inclusive = true
+                                        }
+                                        launchSingleTop = true
+                                    }
+                                })
                             IconWithTextButton(
                                 icon = Icons.Default.Edit,
                                 iconModifier = Modifier.size(40.dp),
@@ -202,6 +214,7 @@ fun RoutesDetailsPopulatedPreview() {
                 selectedRoute = RouteData("Route 2", "Description 2")
             ),
             getRouteByName = {},
+            startRoute = {},
             clearErrorMessage = {}
         )
     }
@@ -217,6 +230,7 @@ fun RoutesDetailsLoadingPreview() {
             uiState = RouteDetailsUiState(isLoading = true),
             modifier = Modifier,
             getRouteByName = {},
+            startRoute = {},
             clearErrorMessage = {}
         )
     }
@@ -232,6 +246,7 @@ fun RoutesDetailsEmptyPreview() {
             modifier = Modifier,
             uiState = RouteDetailsUiState(),
             getRouteByName = {},
+            startRoute = {},
             clearErrorMessage = {}
         )
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/routedetailsscreen/RouteDetailsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/routedetailsscreen/RouteDetailsViewModel.kt
@@ -7,15 +7,16 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.scottishtecharmy.soundscape.SoundscapeServiceConnection
 import org.scottishtecharmy.soundscape.database.repository.RoutesRepository
 import javax.inject.Inject
 
 
 @HiltViewModel
 class RouteDetailsViewModel @Inject constructor(
-    private val routesRepository: RoutesRepository
+    private val routesRepository: RoutesRepository,
+    private val soundscapeServiceConnection: SoundscapeServiceConnection
 ) : ViewModel() {
-
     private val _uiState = MutableStateFlow(RouteDetailsUiState())
     val uiState: StateFlow<RouteDetailsUiState> = _uiState.asStateFlow()
 
@@ -59,6 +60,10 @@ class RouteDetailsViewModel @Inject constructor(
                 )
             }
         }
+    }
+
+    fun startRoute(routeName: String) {
+        soundscapeServiceConnection.startRoute(routeName)
     }
 
     fun clearErrorMessage() {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/RoutePlayer.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/RoutePlayer.kt
@@ -17,14 +17,14 @@ class RoutePlayer(val service: SoundscapeService) {
     private var currentMarker = -1
     private val coroutineScope = CoroutineScope(Job())
 
-    fun setupCurrentRoute() {
+    fun startRoute(routeName: String) {
         val realm = RealmConfiguration.getMarkersInstance()
         val routesDao = RoutesDao(realm)
         val routesRepository = RoutesRepository(routesDao)
 
-        Log.e(TAG, "setupCurrentRoute")
+        Log.e(TAG, "startRoute")
         coroutineScope.launch {
-            val dbRoutes = routesRepository.getRoutes()
+            val dbRoutes = routesRepository.getRoute(routeName)
             if(dbRoutes.isNotEmpty()) {
                 currentRouteData = dbRoutes[0].copyFromRealm()
             }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -80,7 +80,7 @@ class SoundscapeService : MediaSessionService() {
     private var audioBeacon: Long = 0
 
     // Geo engine
-    var geoEngine = GeoEngine()
+    private var geoEngine = GeoEngine()
 
     // Flow to return beacon location
     private val _beaconFlow = MutableStateFlow<LngLatAlt?>(null)
@@ -358,9 +358,9 @@ class SoundscapeService : MediaSessionService() {
     }
 
     private lateinit var routePlayer : RoutePlayer
-    fun setupCurrentRoute() {
-//        routePlayer = RoutePlayer(this)
-//        routePlayer.setupCurrentRoute()
+    fun startRoute(routeName: String) {
+        routePlayer = RoutePlayer(this)
+        routePlayer.startRoute(routeName)
     }
 
     /**

--- a/app/src/screenshotTest/kotlin/org/scottishtecharmy/soundscape/PreviewTest.kt
+++ b/app/src/screenshotTest/kotlin/org/scottishtecharmy/soundscape/PreviewTest.kt
@@ -3,6 +3,8 @@ package org.scottishtecharmy.soundscape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import org.scottishtecharmy.soundscape.screens.home.home.FaqHelpPreview
+import org.scottishtecharmy.soundscape.screens.home.home.HomeHelpPreview
 import org.scottishtecharmy.soundscape.screens.home.home.HomePreview
 import org.scottishtecharmy.soundscape.screens.home.settings.SettingsPreview
 import org.scottishtecharmy.soundscape.screens.markers_routes.screens.MarkersAndRoutesPreview
@@ -196,6 +198,26 @@ class RoutesScreenPopulatedPreviewTestClass {
     fun RoutesScreenPopulatedPreviewTest() {
         SoundscapeTheme {
             RoutesScreenPopulatedPreview()
+        }
+    }
+}
+
+class HelpScreenPreviewTestClass {
+    @CustomPreviews
+    @Composable
+    fun HelpScreenPreviewTest() {
+        SoundscapeTheme {
+            HomeHelpPreview()
+        }
+    }
+}
+
+class FaqPreviewTestClass {
+    @CustomPreviews
+    @Composable
+    fun FaqPreviewTest() {
+        SoundscapeTheme {
+            FaqHelpPreview()
         }
     }
 }


### PR DESCRIPTION
Two independent commits here, one to wire up RoutePlayer to "Play Route" and the other to add all of the iOS based help resources to the drawer menu.