### PR TITLE
Add travel heading to UserGeometry and move into its own file

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -341,7 +341,7 @@ class GeoEngine {
                         if(feature == null) continue
                         val poiLocation = getDistanceToFeature(userGeometry.location, feature)
                         val name = getTextForFeature(localizedContext, feature)
-                        val text = "${name.text}. ${localizedContext.getString(R.string.distance_format_meters, poiLocation.distance.toString())}"
+                        val text = "${name.text}. ${formatDistance(poiLocation.distance, localizedContext)}"
                         list.add(
                             PositionedString(
                                 text,
@@ -559,4 +559,14 @@ fun getTextForFeature(localizedContext: Context, feature: Feature) : TextForFeat
     }
 
     return TextForFeature(text, generic)
+}
+
+fun formatDistance(distance: Double, localizedContext: Context) : String {
+    if(distance > 1000) {
+        val km = (distance.toInt() / 100).toFloat() / 10
+        return localizedContext.getString(R.string.distance_format_km, km.toString())
+    } else {
+        val metres = distance.toInt()
+        return  localizedContext.getString(R.string.distance_format_meters, metres.toString())
+    }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -74,114 +74,7 @@ class GeoEngine {
 
     private val streetPreview = StreetPreview()
 
-    /** UserGeometry contains all of the data relating to the location and motion of the user. It's
-     * aim is to reduces the number of arguments to many of the API calls and to concentrate some of
-     * the logic around heading choice.
-     *
-     * @param phoneHeading is the direction in which the phone is pointing
-     * @param travelHeading is the direction in which the phone is moving
-     * @param headHeading is the direction in which the head tracking is pointing
-     *
-     * On iOS there were two types of heading prioritization:
-     *  collection: course (travel?), user (phone?), device (head?)
-     *  presentation:user (phone?), course (travel?), device (head?)
-     *
-     * It's very hard to follow the Heading code, but because head tracking isn't always (usually)
-     * present and I think `user` must be the phone direction and `device` the head tracking
-     * direction.
-     *
-     *  presentationHeading is used for audio beacons. This makes sense - it's the direction of the
-     *  phone that is used, though I'm surprised it ever uses directly of travel.
-     *  collectionHeading is used for intersections - the direction of travel is most significant
-     *  here.
-     *
-     * However, if the user has thrown their phone into their bag, we need to detect this and ignore
-     * the phone direction.
-     */
-    enum class HeadingMode {
-        Auto,
-        Phone,
-        Travel
-    }
-
-    class UserGeometry(val location: LngLatAlt = LngLatAlt(),
-                       var phoneHeading: Double = 0.0,
-                       val fovDistance: Double = 50.0,
-                       val inVehicle: Boolean = false,
-                       val inMotion: Boolean = false,
-                       val speed: Double = 0.0,
-                       private val headingMode: HeadingMode = HeadingMode.Auto,
-                       private var travelHeading: Double = Double.NaN,
-                       private var headHeading: Double = Double.NaN,
-                       private val inStreetPreview: Boolean = false)
-    {
-        private val automotiveRangeMultiplier = 6.0
-        private val streetPreviewRangeIncrement = 10.0
-
-        private fun transform(distance: Double) : Double {
-            if(inVehicle) return distance * automotiveRangeMultiplier
-            if(inStreetPreview) return distance + streetPreviewRangeIncrement
-            return distance
-        }
-
-        fun heading() : Double {
-            when(headingMode) {
-                HeadingMode.Auto -> {
-                    if(speed > 0.2 && !travelHeading.isNaN())
-                        return travelHeading
-
-                    return phoneHeading
-                }
-                HeadingMode.Phone -> return phoneHeading
-                HeadingMode.Travel -> return travelHeading
-            }
-        }
-
-        /**
-         * getSearchDistance returns the distance to use when searching for POIs
-         */
-        fun getSearchDistance() : Double {
-            return transform(50.0)
-        }
-
-        /**
-         * getTriggerRange returns the distance to use when detecting POIs to call out
-         */
-        fun getTriggerRange(category: String) : Double {
-            return when(category) {
-                "object",
-                "safety" -> transform(10.0)
-
-                "place",
-                "information",
-                "mobility" -> transform(20.0)
-
-                "landmark" -> transform(50.0)
-
-                else -> transform(0.0)
-            }
-        }
-
-        /**
-         * getTriggerRange returns the distance if a POI is still in proximity after a callout
-         */
-        fun getProximityRange(category: String) : Double {
-            return when(category) {
-                "object",
-                "safety" -> transform(20.0)
-
-                "place",
-                "information",
-                "mobility" -> transform(30.0)
-
-                "landmark" -> transform(100.0)
-
-                else -> transform(0.0)
-            }
-        }
-    }
-
-    private fun getCurrentUserGeometry(headingMode: HeadingMode) : UserGeometry {
+    private fun getCurrentUserGeometry(headingMode: UserGeometry.HeadingMode) : UserGeometry {
         return UserGeometry(
             location = locationProvider.get(),
             phoneHeading = directionProvider.getCurrentDirection().toDouble(),
@@ -278,7 +171,7 @@ class GeoEngine {
                     // falling back to use the phone direction.
                     if(!soundscapeService.isAudioEngineBusy()) {
                         val callouts =
-                            autoCallout.updateLocation(getCurrentUserGeometry(HeadingMode.Auto), gridState)
+                            autoCallout.updateLocation(getCurrentUserGeometry(UserGeometry.HeadingMode.Auto), gridState)
                         if (callouts.isNotEmpty()) {
                             // Tell the service that we've got some callouts to tell the user about
                             soundscapeService.speakCallout(callouts)
@@ -387,7 +280,7 @@ class GeoEngine {
             results = runBlocking {
                 withContext(gridState.treeContext) {
 
-                    val userGeometry = getCurrentUserGeometry(HeadingMode.Phone)
+                    val userGeometry = getCurrentUserGeometry(UserGeometry.HeadingMode.Phone)
 
                     // Direction order is: behind(0) left(1) ahead(2) right(3)
                     val featuresByDirection: Array<Feature?> = arrayOfNulls(4)
@@ -485,7 +378,7 @@ class GeoEngine {
                     val list: MutableList<PositionedString> = mutableListOf()
 
                     // get device direction
-                    val userGeometry = getCurrentUserGeometry(HeadingMode.Phone)
+                    val userGeometry = getCurrentUserGeometry(UserGeometry.HeadingMode.Phone)
 
                     // Detect if there is a road or an intersection in the FOV
                     val roadsDescription = getRoadsDescriptionFromFov(
@@ -569,7 +462,7 @@ class GeoEngine {
         val engine = this
         CoroutineScope(Job()).launch(gridState.treeContext) {
             // Get our current location and figure out what GO means
-            val userGeometry = getCurrentUserGeometry(HeadingMode.Phone)
+            val userGeometry = getCurrentUserGeometry(UserGeometry.HeadingMode.Phone)
             val choices = streetPreview.getDirectionChoices(engine, userGeometry.location)
             var heading = 0.0
             if(choices.isNotEmpty()) {
@@ -612,7 +505,7 @@ class GeoEngine {
         val engine = this
         CoroutineScope(Job()).launch(gridState.treeContext) {
             // Get our current location and figure out what GO means
-            val userGeometry = getCurrentUserGeometry(HeadingMode.Phone)
+            val userGeometry = getCurrentUserGeometry(UserGeometry.HeadingMode.Phone)
             streetPreview.go(userGeometry, engine)
         }
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/StreetPreview.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/StreetPreview.kt
@@ -70,7 +70,7 @@ class StreetPreview {
                 // Find the choice with the closest heading to our own
                 var diff: Double
                 for ((index, choice) in choices.withIndex()) {
-                    diff = abs(choice.heading - userGeometry.heading)
+                    diff = abs(choice.heading - userGeometry.heading())
                     if (diff < bestHeadingDiff) {
                         bestHeadingDiff = diff
                         bestIndex = index

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/StreetPreview.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/StreetPreview.kt
@@ -35,7 +35,7 @@ class StreetPreview {
         previewState = PreviewState.INITIAL
     }
 
-    fun go(userGeometry: GeoEngine.UserGeometry, engine: GeoEngine) {
+    fun go(userGeometry: UserGeometry, engine: GeoEngine) {
         when (previewState) {
 
             PreviewState.INITIAL -> {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/UserGeometry.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/UserGeometry.kt
@@ -1,0 +1,110 @@
+package org.scottishtecharmy.soundscape.geoengine
+
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+
+/** UserGeometry contains all of the data relating to the location and motion of the user. It's
+ * aim is to reduces the number of arguments to many of the API calls and to concentrate some of
+ * the logic around heading choice.
+ *
+ * @param phoneHeading is the direction in which the phone is pointing
+ * @param travelHeading is the direction in which the phone is moving
+ * @param headHeading is the direction in which the head tracking is pointing
+ *
+ * On iOS there were two types of heading prioritization:
+ *  collection: course (travel?), user (phone?), device (head?)
+ *  presentation:user (phone?), course (travel?), device (head?)
+ *
+ * It's very hard to follow the Heading code, but because head tracking isn't always (usually)
+ * present and I think `user` must be the phone direction and `device` the head tracking
+ * direction.
+ *
+ *  presentationHeading is used for audio beacons. This makes sense - it's the direction of the
+ *  phone that is used, though I'm surprised it ever uses directly of travel.
+ *  collectionHeading is used for intersections - the direction of travel is most significant
+ *  here.
+ *
+ * However, if the user has thrown their phone into their bag, we need to detect this and ignore
+ * the phone direction.
+ */
+class UserGeometry(val location: LngLatAlt = LngLatAlt(),
+                   var phoneHeading: Double = 0.0,
+                   val fovDistance: Double = 50.0,
+                   val inVehicle: Boolean = false,
+                   val inMotion: Boolean = false,
+                   val speed: Double = 0.0,
+                   private val headingMode: HeadingMode = HeadingMode.Auto,
+                   private var travelHeading: Double = Double.NaN,
+                   private var headHeading: Double = Double.NaN,
+                   private val inStreetPreview: Boolean = false)
+{
+    private val automotiveRangeMultiplier = 6.0
+    private val streetPreviewRangeIncrement = 10.0
+
+    private fun transform(distance: Double) : Double {
+        if(inVehicle) return distance * automotiveRangeMultiplier
+        if(inStreetPreview) return distance + streetPreviewRangeIncrement
+        return distance
+    }
+
+    fun heading() : Double {
+        when(headingMode) {
+            HeadingMode.Auto -> {
+                if(speed > 0.2 && !travelHeading.isNaN())
+                    return travelHeading
+
+                return phoneHeading
+            }
+            HeadingMode.Phone -> return phoneHeading
+            HeadingMode.Travel -> return travelHeading
+        }
+    }
+
+    /**
+     * getSearchDistance returns the distance to use when searching for POIs
+     */
+    fun getSearchDistance() : Double {
+        return transform(50.0)
+    }
+
+    /**
+     * getTriggerRange returns the distance to use when detecting POIs to call out
+     */
+    fun getTriggerRange(category: String) : Double {
+        return when(category) {
+            "object",
+            "safety" -> transform(10.0)
+
+            "place",
+            "information",
+            "mobility" -> transform(20.0)
+
+            "landmark" -> transform(50.0)
+
+            else -> transform(0.0)
+        }
+    }
+
+    /**
+     * getTriggerRange returns the distance if a POI is still in proximity after a callout
+     */
+    fun getProximityRange(category: String) : Double {
+        return when(category) {
+            "object",
+            "safety" -> transform(20.0)
+
+            "place",
+            "information",
+            "mobility" -> transform(30.0)
+
+            "landmark" -> transform(100.0)
+
+            else -> transform(0.0)
+        }
+    }
+
+    enum class HeadingMode {
+        Auto,
+        Phone,
+        Travel
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/AutoCallout.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/AutoCallout.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.withContext
 import org.scottishtecharmy.soundscape.MainActivity.Companion.ALLOW_CALLOUTS_KEY
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine.UserGeometry
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.GridState
 import org.scottishtecharmy.soundscape.geoengine.PositionedString
 import org.scottishtecharmy.soundscape.geoengine.TreeId

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/AutoCallout.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/AutoCallout.kt
@@ -74,7 +74,7 @@ class AutoCallout(
         if(nearestRoad != null) {
             val properties = nearestRoad.properties
             if (properties != null) {
-                val orientation = userGeometry.heading
+                val orientation = userGeometry.heading()
                 var roadName = properties["name"]
                 if (roadName == null) {
                     roadName = properties["highway"]

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/IntersectionUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/IntersectionUtils.kt
@@ -2,15 +2,14 @@ package org.scottishtecharmy.soundscape.geoengine.callouts
 
 import android.content.Context
 import org.scottishtecharmy.soundscape.R
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.TreeId
 import org.scottishtecharmy.soundscape.geoengine.GridState
 import org.scottishtecharmy.soundscape.geoengine.PositionedString
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.filters.CalloutHistory
 import org.scottishtecharmy.soundscape.geoengine.filters.TrackedCallout
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geoengine.utils.RelativeDirections
-import org.scottishtecharmy.soundscape.geoengine.utils.Triangle
 import org.scottishtecharmy.soundscape.geoengine.utils.checkWhetherIntersectionIsOfInterest
 import org.scottishtecharmy.soundscape.geoengine.utils.getFovTriangle
 import org.scottishtecharmy.soundscape.geoengine.utils.getIntersectionRoadNames
@@ -32,7 +31,7 @@ enum class ComplexIntersectionApproach {
 }
 
 data class RoadsDescription(val nearestRoad: Feature? = null,
-                            val userGeometry: GeoEngine.UserGeometry = GeoEngine.UserGeometry(),
+                            val userGeometry: UserGeometry = UserGeometry(),
                             val intersection: Feature? = null,
                             val intersectionRoads: FeatureCollection = FeatureCollection())
 
@@ -49,7 +48,7 @@ data class RoadsDescription(val nearestRoad: Feature? = null,
  * intersection.
  */
 fun getRoadsDescriptionFromFov(gridState: GridState,
-                               userGeometry: GeoEngine.UserGeometry,
+                               userGeometry: UserGeometry,
                                approach: ComplexIntersectionApproach
 ) : RoadsDescription {
 
@@ -115,7 +114,7 @@ fun getRoadsDescriptionFromFov(gridState: GridState,
 
     // Create a set of relative direction polygons
     val intersectionLocation = intersection!!.geometry as Point
-    val geometry = GeoEngine.UserGeometry(
+    val geometry = UserGeometry(
         intersectionLocation.coordinates,
         nearestRoadBearing,
         5.0

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/IntersectionUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/IntersectionUtils.kt
@@ -111,7 +111,7 @@ fun getRoadsDescriptionFromFov(gridState: GridState,
     val nearestIntersection = removeDuplicates(sortedFovIntersections.features[0])
 
     // Find the bearing that we're coming in at - measured to the nearest intersection
-    val nearestRoadBearing = getRoadBearingToIntersection(nearestIntersection, nearestRoad, userGeometry.heading)
+    val nearestRoadBearing = getRoadBearingToIntersection(nearestIntersection, nearestRoad, userGeometry.heading())
 
     // Create a set of relative direction polygons
     val intersectionLocation = intersection!!.geometry as Point

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/filters/LocationUpdateFilter.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/filters/LocationUpdateFilter.kt
@@ -1,6 +1,6 @@
 package org.scottishtecharmy.soundscape.geoengine.filters
 
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 
 /**
  * This class acts as a filter for throttling the frequency of computation which is initiated by
@@ -9,16 +9,16 @@ import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 
 open class LocationUpdateFilter(private val minTimeMs: Long, private val minDistance: Double) {
 
-    private var lastLocation : GeoEngine.UserGeometry? = null
+    private var lastLocation : UserGeometry? = null
     private var lastTime = 0L
 
-    fun update(userGeometry: GeoEngine.UserGeometry)
+    fun update(userGeometry: UserGeometry)
     {
         lastTime = System.currentTimeMillis()
         lastLocation = userGeometry
     }
 
-    private fun shouldUpdate(userGeometry: GeoEngine.UserGeometry,
+    private fun shouldUpdate(userGeometry: UserGeometry,
                              updateTimeInterval: Long,
                              updateDistanceInterval: Double)
         : Boolean {
@@ -40,12 +40,12 @@ open class LocationUpdateFilter(private val minTimeMs: Long, private val minDist
         return false
     }
 
-    fun shouldUpdate(userGeometry: GeoEngine.UserGeometry) : Boolean {
+    fun shouldUpdate(userGeometry: UserGeometry) : Boolean {
         return shouldUpdate(userGeometry, minTimeMs, minDistance)
     }
 
     private val inVehicleTimeIntervalMultiplier = 4
-    fun shouldUpdateActivity(userGeometry: GeoEngine.UserGeometry) : Boolean {
+    fun shouldUpdateActivity(userGeometry: UserGeometry) : Boolean {
         if(userGeometry.inVehicle) {
             // If travelling in a vehicle then the speed is used to determine how far has to be
             // travelled before updating and the time is increased by a multiplier.

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/filters/TrackedCallout.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/filters/TrackedCallout.kt
@@ -1,7 +1,7 @@
 package org.scottishtecharmy.soundscape.geoengine.filters
 
 import android.util.Log
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 
 class TrackedCallout(
@@ -45,7 +45,7 @@ class CalloutHistory(private val expiryPeriod : Long = 60000) {
         history.add(callout)
     }
 
-    fun trim(userGeometry: GeoEngine.UserGeometry) {
+    fun trim(userGeometry: UserGeometry) {
         val now = System.currentTimeMillis()
         // TODO : Remove hardcoded expiry time and distance should be based on category
         history.removeAll {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileUtils.kt
@@ -232,7 +232,7 @@ fun removeDuplicateOsmIds(
 }
 
 fun getFovTriangle(userGeometry: GeoEngine.UserGeometry) : Triangle {
-    val quadrant = Quadrant(userGeometry.heading)
+    val quadrant = Quadrant(userGeometry.heading())
     return Triangle(userGeometry.location,
         getDestinationCoordinate(
             userGeometry.location,
@@ -1012,10 +1012,10 @@ fun getRelativeDirectionsPolygons(
 
     val segments =
         when(relativeDirectionType){
-            RelativeDirections.COMBINED -> getCombinedDirectionSegments(userGeometry.heading)
-            RelativeDirections.INDIVIDUAL -> getIndividualDirectionSegments(userGeometry.heading)
-            RelativeDirections.AHEAD_BEHIND -> getAheadBehindDirectionSegments(userGeometry.heading)
-            RelativeDirections.LEFT_RIGHT -> getLeftRightDirectionSegments(userGeometry.heading)
+            RelativeDirections.COMBINED -> getCombinedDirectionSegments(userGeometry.heading())
+            RelativeDirections.INDIVIDUAL -> getIndividualDirectionSegments(userGeometry.heading())
+            RelativeDirections.AHEAD_BEHIND -> getAheadBehindDirectionSegments(userGeometry.heading())
+            RelativeDirections.LEFT_RIGHT -> getLeftRightDirectionSegments(userGeometry.heading())
         }
 
     return makeTriangles(segments, userGeometry)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileUtils.kt
@@ -13,7 +13,7 @@ import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Polygon
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.GeometryFactory
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geojsonparser.moshi.GeoJsonObjectMoshiAdapter
 import java.io.FileOutputStream
 import java.lang.Math.toDegrees
@@ -231,7 +231,7 @@ fun removeDuplicateOsmIds(
     return tempFeatureCollection
 }
 
-fun getFovTriangle(userGeometry: GeoEngine.UserGeometry) : Triangle {
+fun getFovTriangle(userGeometry: UserGeometry) : Triangle {
     val quadrant = Quadrant(userGeometry.heading())
     return Triangle(userGeometry.location,
         getDestinationCoordinate(
@@ -256,7 +256,7 @@ fun getFovTriangle(userGeometry: GeoEngine.UserGeometry) : Triangle {
  * @return A Feature Collection that contains the Features in the FOV triangle.
  */
 fun getFovFeatureCollection(
-    userGeometry: GeoEngine.UserGeometry,
+    userGeometry: UserGeometry,
     featureTree: FeatureTree
 ): FeatureCollection {
 
@@ -265,7 +265,7 @@ fun getFovFeatureCollection(
 }
 
 fun getNearestFovFeature(
-    userGeometry: GeoEngine.UserGeometry,
+    userGeometry: UserGeometry,
     featureTree: FeatureTree
 ): Feature? {
 
@@ -636,7 +636,7 @@ fun getLeftRightDirectionSegments(
  */
 fun makeTriangles(
     segments: Array<Segment>,
-    userGeometry: GeoEngine.UserGeometry
+    userGeometry: UserGeometry
 ): FeatureCollection{
 
     val newFeatureCollection = FeatureCollection()
@@ -1006,7 +1006,7 @@ fun searchFeaturesByName(featureCollection: FeatureCollection, query: String): F
  * @return a Feature Collection containing triangles for the relative directions.
  */
 fun getRelativeDirectionsPolygons(
-    userGeometry: GeoEngine.UserGeometry,
+    userGeometry: UserGeometry,
     relativeDirectionType: RelativeDirections
 ): FeatureCollection {
 
@@ -2082,7 +2082,7 @@ fun getSuperCategoryElements(category: String): MutableList<String> {
 }
 
 fun generateDebugFovGeoJson(
-    userGeometry: GeoEngine.UserGeometry,
+    userGeometry: UserGeometry,
     featureCollection: FeatureCollection
 ) {
     val triangle = getFovTriangle(userGeometry)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geojsonparser/geojson/LngLatAlt.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geojsonparser/geojson/LngLatAlt.kt
@@ -61,7 +61,7 @@ open class LngLatAlt(
 
         var shortestDistance = Double.MAX_VALUE
         var bestNearestPoint = LngLatAlt()
-        for(i in 1 until lineStringCoordinates.coordinates.size - 1) {
+        for(i in 1 until lineStringCoordinates.coordinates.size) {
             val nearestPointOnSegment = LngLatAlt()
             val distance = distanceToLine(
                 lineStringCoordinates.coordinates[i-1],

--- a/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/LocationProvider.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/LocationProvider.kt
@@ -31,6 +31,13 @@ abstract class LocationProvider {
         return 0.0
     }
 
+    fun getHeading(): Double {
+        mutableLocationFlow.value?.let { location ->
+            return location.bearing.toDouble()
+        }
+        return 0.0
+    }
+
     // Flow to return Location objects
     val mutableLocationFlow = MutableStateFlow<Location?>(null)
     var locationFlow: StateFlow<Location?> = mutableLocationFlow

--- a/app/src/test/java/org/scottishtecharmy/soundscape/BusStopTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/BusStopTest.kt
@@ -3,9 +3,9 @@ package org.scottishtecharmy.soundscape
 import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.GridState.Companion.createFromGeoJson
 import org.scottishtecharmy.soundscape.geoengine.TreeId
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
@@ -34,7 +34,7 @@ class BusStopTest {
 
         // However we can get some dodgy info for the user so...
         // pretend the device is here, pointing along the road and our field of view
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.655732516651227,51.430910659124464),
             225.0,
             50.0

--- a/app/src/test/java/org/scottishtecharmy/soundscape/ComplexIntersections.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/ComplexIntersections.kt
@@ -2,8 +2,8 @@ package org.scottishtecharmy.soundscape
 
 import org.junit.Assert
 import org.junit.Test
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.GridState
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.callouts.ComplexIntersectionApproach
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geoengine.callouts.getRoadsDescriptionFromFov
@@ -18,7 +18,7 @@ class ComplexIntersections {
         // multiple gd_intersections detected in the FoV so we need to determine which ones to ignore
         // and which ones are useful to call out to the user
         // Fake location, heading and Field of View for testing
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.697291022799874,51.44378095087524),
             320.0,
             50.0)
@@ -56,7 +56,7 @@ class ComplexIntersections {
         // and which ones are useful to call out to the user
         // https://geojson.io/#map=18.65/51.4405486/-2.6851813
         // Fake location, heading and Field of View for testing
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.6854420947740323, 51.44036284885249),
             45.0,
             50.0)

--- a/app/src/test/java/org/scottishtecharmy/soundscape/CrossingTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/CrossingTest.kt
@@ -3,9 +3,9 @@ package org.scottishtecharmy.soundscape
 import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.GridState.Companion.createFromGeoJson
 import org.scottishtecharmy.soundscape.geoengine.TreeId
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
@@ -31,7 +31,7 @@ class CrossingTest {
         println("Crossings in tile: $crossingString")
 
         // usual fake our device location and heading
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.6920313574678403, 51.43745588326692),
             45.0,
             50.0

--- a/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTest.kt
@@ -4,8 +4,8 @@ import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.junit.Assert
 import org.junit.Test
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.GridState
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.callouts.ComplexIntersectionApproach
 import org.scottishtecharmy.soundscape.geoengine.callouts.getRoadsDescriptionFromFov
 
@@ -18,7 +18,7 @@ class IntersectionsTest {
                           fovDistance: Double) : FeatureCollection {
 
         val gridState = GridState.createFromGeoJson(geoJsonResource)
-        val userGeometry = GeoEngine.UserGeometry(currentLocation, deviceHeading, fovDistance)
+        val userGeometry = UserGeometry(currentLocation, deviceHeading, fovDistance)
         return  getRoadsDescriptionFromFov(
                     gridState,
                     userGeometry,

--- a/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTestMvt.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTestMvt.kt
@@ -2,7 +2,7 @@ package org.scottishtecharmy.soundscape
 
 import org.junit.Assert
 import org.junit.Test
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.callouts.ComplexIntersectionApproach
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geoengine.callouts.getRoadsDescriptionFromFov
@@ -14,7 +14,7 @@ class IntersectionsTestMvt {
                           fovDistance: Double) : FeatureCollection {
 
         val gridState = getGridStateForLocation(currentLocation)
-        val userGeometry = GeoEngine.UserGeometry(currentLocation, deviceHeading, fovDistance)
+        val userGeometry = UserGeometry(currentLocation, deviceHeading, fovDistance)
         return getRoadsDescriptionFromFov(
                     gridState,
                     userGeometry,

--- a/app/src/test/java/org/scottishtecharmy/soundscape/MarkersTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/MarkersTest.kt
@@ -2,7 +2,7 @@ package org.scottishtecharmy.soundscape
 
 import com.squareup.moshi.Moshi
 import org.junit.Test
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.GeoMoshi
@@ -14,7 +14,7 @@ class MarkersTest {
 
     @Test
     fun markersTest() {
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.6930121073553437,51.43943095899127),
             10.0,
             50.0

--- a/app/src/test/java/org/scottishtecharmy/soundscape/PoiTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/PoiTest.kt
@@ -1,8 +1,8 @@
 package org.scottishtecharmy.soundscape
 
 import org.junit.Test
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.TreeId
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.utils.RelativeDirections
 import org.scottishtecharmy.soundscape.geoengine.utils.circleToPolygon
 import org.scottishtecharmy.soundscape.geoengine.utils.getRelativeDirectionsPolygons
@@ -68,7 +68,7 @@ class PoiTest {
     @Test
     fun testNearestFeature() {
 
-        val userGeometry = GeoEngine.UserGeometry(LngLatAlt(-4.317229, 55.941891),
+        val userGeometry = UserGeometry(LngLatAlt(-4.317229, 55.941891),
             0.0,
             50.0)
         val gridState = getGridStateForLocation(userGeometry.location)
@@ -105,7 +105,7 @@ class PoiTest {
     @Test
     fun testNearestFeatures() {
 
-        val userGeometry = GeoEngine.UserGeometry(LngLatAlt(-4.317229, 55.941891),
+        val userGeometry = UserGeometry(LngLatAlt(-4.317229, 55.941891),
             0.0,
             50.0)
         val gridState = getGridStateForLocation(userGeometry.location)
@@ -152,7 +152,7 @@ class PoiTest {
     @Test
     fun testFeaturesWithinRadius() {
 
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-4.317229, 55.941891),
             0.0,
             50.0
@@ -183,7 +183,7 @@ class PoiTest {
     @Test
     fun testClassification() {
         // A grid-wide test of the POI classification
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-4.317229, 55.941891),
             0.0,
             50.0

--- a/app/src/test/java/org/scottishtecharmy/soundscape/RoundaboutsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/RoundaboutsTest.kt
@@ -103,7 +103,7 @@ class RoundaboutsTest {
         val centerOfBoundingBox = getCenterOfBoundingBox(boundingBoxOfCircleCorners)
         val testNearestRoad = getNearestRoad(userGeometry.location, FeatureTree(fovRoadsFeatureCollection))
         val testNearestRoadBearing =
-            getRoadBearingToIntersection(nearestIntersection, testNearestRoad, userGeometry.heading)
+            getRoadBearingToIntersection(nearestIntersection, testNearestRoad, userGeometry.heading())
         val geometry = GeoEngine.UserGeometry(centerOfBoundingBox, testNearestRoadBearing, userGeometry.fovDistance)
         val roundaboutRoadsRelativeDirections = getRelativeDirectionsPolygons(
             geometry,
@@ -194,7 +194,7 @@ class RoundaboutsTest {
 
         val testNearestRoad = getNearestRoad(userGeometry.location, FeatureTree(fovRoadsFeatureCollection))
 
-        val testNearestRoadBearing = getRoadBearingToIntersection(cleanNearestIntersection, testNearestRoad, userGeometry.heading)
+        val testNearestRoadBearing = getRoadBearingToIntersection(cleanNearestIntersection, testNearestRoad, userGeometry.heading())
 
         val testIntersectionRoadNames = getIntersectionRoadNames(
             cleanNearestIntersection, fovRoadsFeatureCollection)
@@ -312,7 +312,7 @@ class RoundaboutsTest {
             // if the circle doesn't exist (which it doesn't in this test)
             if (roundaboutCircleRoad.features.size == 0) {
 
-                val testNearestRoadBearing = getRoadBearingToIntersection(testNearestIntersection, testNearestRoad, userGeometry.heading)
+                val testNearestRoadBearing = getRoadBearingToIntersection(testNearestIntersection, testNearestRoad, userGeometry.heading())
                 //create a relative directions polygon based on our calculated approx center of the roundabout
                 // How big do we want out polygon to be? Ideally we need the radius of the roundabout plus a few meters
                 val intersectionRelativeDirectionsPolygons = getRelativeDirectionsPolygons(

--- a/app/src/test/java/org/scottishtecharmy/soundscape/RoundaboutsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/RoundaboutsTest.kt
@@ -4,9 +4,9 @@ import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
 import org.scottishtecharmy.soundscape.dto.Circle
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.GridState.Companion.createFromGeoJson
 import org.scottishtecharmy.soundscape.geoengine.TreeId
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
@@ -44,7 +44,7 @@ class RoundaboutsTest {
     fun roundaboutsTest() {
         // This is a proof of concept so this is the simplest, cleanest roundabout I could find
         // and is only using a single tile from /16/32267/21812.json
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.747119798700794, 51.43854214667482),
             225.0,
             50.0
@@ -104,7 +104,7 @@ class RoundaboutsTest {
         val testNearestRoad = getNearestRoad(userGeometry.location, FeatureTree(fovRoadsFeatureCollection))
         val testNearestRoadBearing =
             getRoadBearingToIntersection(nearestIntersection, testNearestRoad, userGeometry.heading())
-        val geometry = GeoEngine.UserGeometry(centerOfBoundingBox, testNearestRoadBearing, userGeometry.fovDistance)
+        val geometry = UserGeometry(centerOfBoundingBox, testNearestRoadBearing, userGeometry.fovDistance)
         val roundaboutRoadsRelativeDirections = getRelativeDirectionsPolygons(
             geometry,
             RelativeDirections.COMBINED
@@ -166,7 +166,7 @@ class RoundaboutsTest {
         // Soundscape seems to turn mini roundabouts into intersections so
         // using a single tile from /16/32268/21813.json to test this and the location
         // where there is definitely a mini roundabout
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.7428307423190006,51.43595874012766),
             0.0,
             50.0
@@ -208,7 +208,7 @@ class RoundaboutsTest {
         }
         val intersectionLocation = cleanNearestIntersection!!.geometry as Point
 
-        val geometry = GeoEngine.UserGeometry(
+        val geometry = UserGeometry(
             intersectionLocation.coordinates,
             testNearestRoadBearing,
             userGeometry.fovDistance)
@@ -238,7 +238,7 @@ class RoundaboutsTest {
         // further away  -2.7474554685902604, 51.43822549502224
         // further away -2.7474735115298756, 51.4381923217035
         // closer but not complete -2.7475109456763676,51.43813340231313
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.7474554685902604, 51.43822549502224),
             200.0,
             50.0
@@ -316,7 +316,7 @@ class RoundaboutsTest {
                 //create a relative directions polygon based on our calculated approx center of the roundabout
                 // How big do we want out polygon to be? Ideally we need the radius of the roundabout plus a few meters
                 val intersectionRelativeDirectionsPolygons = getRelativeDirectionsPolygons(
-                    GeoEngine.UserGeometry(
+                    UserGeometry(
                         roundaboutCenter.center,
                         testNearestRoadBearing,
                         // TODO adding 3.0 is a fudge as the roundaboutCenter.center is not 100% accurate

--- a/app/src/test/java/org/scottishtecharmy/soundscape/StreetPreviewTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/StreetPreviewTest.kt
@@ -2,9 +2,9 @@ package org.scottishtecharmy.soundscape
 
 import com.squareup.moshi.Moshi
 import org.junit.Test
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.GridState.Companion.createFromGeoJson
 import org.scottishtecharmy.soundscape.geoengine.TreeId
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
@@ -60,7 +60,7 @@ class StreetPreviewTest {
             // fake the device heading by "looking" at the next Point
             val deviceHeading = bearingFromTwoPoints(currentLocation, nextLocation.coordinates)
             println("Device Heading: $deviceHeading")
-            val geometry = GeoEngine.UserGeometry(currentLocation, deviceHeading)
+            val geometry = UserGeometry(currentLocation, deviceHeading)
             val fovTriangle = generateFOVTriangle(geometry)
             fovFeatureCollection.addFeature(fovTriangle)
         }
@@ -107,7 +107,7 @@ class StreetPreviewTest {
 
                 val nextLocation = roadTrace.features[i++].geometry as Point
                 // fake the device heading by "looking" at the next Point
-                val userGeometry = GeoEngine.UserGeometry(
+                val userGeometry = UserGeometry(
                     currentPoint.coordinates,
                     bearingFromTwoPoints(currentPoint.coordinates, nextLocation.coordinates),
                     50.0
@@ -179,7 +179,7 @@ class StreetPreviewTest {
                                 )
                                 val nearestRoadBearing = getRoadBearingToIntersection(nearestIntersection, testNearestRoad, userGeometry.heading())
                                 val intersectionLocation = featureWithMostOsmIds!!.geometry as Point
-                                val geometry = GeoEngine.UserGeometry(
+                                val geometry = UserGeometry(
                                     intersectionLocation.coordinates,
                                     nearestRoadBearing,
                                     5.0
@@ -288,7 +288,7 @@ class StreetPreviewTest {
 
 
     private fun generateFOVTriangle(
-        userGeometry: GeoEngine.UserGeometry
+        userGeometry: UserGeometry
     ): Feature {
 
         val triangle = getFovTriangle(userGeometry)

--- a/app/src/test/java/org/scottishtecharmy/soundscape/StreetPreviewTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/StreetPreviewTest.kt
@@ -177,7 +177,7 @@ class StreetPreviewTest {
                                 val nearestIntersection = FeatureTree(fovIntersectionsFeatureCollection).getNearestFeature(
                                     userGeometry.location
                                 )
-                                val nearestRoadBearing = getRoadBearingToIntersection(nearestIntersection, testNearestRoad, userGeometry.heading)
+                                val nearestRoadBearing = getRoadBearingToIntersection(nearestIntersection, testNearestRoad, userGeometry.heading())
                                 val intersectionLocation = featureWithMostOsmIds!!.geometry as Point
                                 val geometry = GeoEngine.UserGeometry(
                                     intersectionLocation.coordinates,

--- a/app/src/test/java/org/scottishtecharmy/soundscape/TileUtilsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/TileUtilsTest.kt
@@ -15,9 +15,9 @@ import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
 import org.scottishtecharmy.soundscape.geoengine.GRID_SIZE
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.GridState.Companion.createFromGeoJson
 import org.scottishtecharmy.soundscape.geoengine.TreeId
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geoengine.utils.RelativeDirections
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
@@ -325,7 +325,7 @@ class TileUtilsTest {
     @Test
     fun getIntersectionInFovTest(){
         // Fake device location and pretend the device is pointing East.
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.6573400576040456, 51.430456817236575),
             90.0,
             50.0
@@ -347,7 +347,7 @@ class TileUtilsTest {
     @Test
     fun getRoadsInFovTest(){
         // Fake device location and pretend the device is pointing East.
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.6573400576040456, 51.430456817236575),
             90.0,
             50.0
@@ -370,7 +370,7 @@ class TileUtilsTest {
     @Test
     fun getPoiInFovTest(){
         // Fake device location and pretend the device is pointing East.
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.6573400576040456, 51.430456817236575),
             90.0,
             50.0
@@ -395,7 +395,7 @@ class TileUtilsTest {
     fun getNearestIntersectionTest(){
         // Fake device location and pretend the device is pointing East.
         // I've moved the device location so the FoV picks up a couple of intersections
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.657279900280031, 51.430461188129385),
             90.0,
             50.0
@@ -416,7 +416,7 @@ class TileUtilsTest {
     fun sortedByDistanceToTest(){
         // Fake device location and pretend the device is pointing East.
         // I've moved the device location so the FoV picks up a couple of intersections
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.657279900280031, 51.430461188129385),
             90.0,
             50.0
@@ -445,7 +445,7 @@ class TileUtilsTest {
     @Test
     fun getNearestRoadTest(){
         // Fake device location and pretend the device is pointing East.
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.657279900280031, 51.430461188129385),
             90.0,50.0
         )
@@ -470,7 +470,7 @@ class TileUtilsTest {
     @Test
     fun getNearestPoiTest(){
         // Fake device location and pretend the device is pointing East.
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.6573400576040456, 51.430456817236575),
             90.0,
             50.0
@@ -546,7 +546,7 @@ class TileUtilsTest {
     @Test
     fun getRelativeDirectionsTest(){
 
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.657279900280031, 51.430461188129385),
             0.0,
             50.0
@@ -630,7 +630,7 @@ class TileUtilsTest {
     fun getIntersectionRoadNamesTest(){
         // Fake device location and pretend the device is pointing East.
         // I've moved the device location so the FoV picks up a couple of intersections
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.657279900280031, 51.430461188129385),
             90.0,
             50.0

--- a/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckIntersectionLayers.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckIntersectionLayers.kt
@@ -3,9 +3,9 @@ package org.scottishtecharmy.soundscape
 import com.squareup.moshi.Moshi
 import org.junit.Assert
 import org.junit.Test
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.GridState
 import org.scottishtecharmy.soundscape.geoengine.TreeId
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
@@ -30,7 +30,7 @@ class VisuallyCheckIntersectionLayers {
     fun layeredIntersectionsFieldOfView1(){
 
         // Fake device location and device direction.
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.6972713998905533,51.44374766171788),
             340.0,
             50.0
@@ -94,7 +94,7 @@ class VisuallyCheckIntersectionLayers {
         val nearestRoadBearing = getRoadBearingToIntersection(nearestIntersection, testNearestRoad, userGeometry.heading())
         val intersectionLocation = featureWithMostOsmIds!!.geometry as Point
         val intersectionRelativeDirections = getRelativeDirectionsPolygons(
-            GeoEngine.UserGeometry(
+            UserGeometry(
                 LngLatAlt(
                     intersectionLocation.coordinates.longitude,
                     intersectionLocation.coordinates.latitude

--- a/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckIntersectionLayers.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckIntersectionLayers.kt
@@ -91,7 +91,7 @@ class VisuallyCheckIntersectionLayers {
 
         val triangle = getFovTriangle(userGeometry)
         val nearestIntersection = FeatureTree(fovIntersectionsFeatureCollection).getNearestFeatureWithinTriangle(triangle)
-        val nearestRoadBearing = getRoadBearingToIntersection(nearestIntersection, testNearestRoad, userGeometry.heading)
+        val nearestRoadBearing = getRoadBearingToIntersection(nearestIntersection, testNearestRoad, userGeometry.heading())
         val intersectionLocation = featureWithMostOsmIds!!.geometry as Point
         val intersectionRelativeDirections = getRelativeDirectionsPolygons(
             GeoEngine.UserGeometry(

--- a/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckOutput.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckOutput.kt
@@ -20,9 +20,9 @@ import org.scottishtecharmy.soundscape.geoengine.utils.getXYTile
 import org.scottishtecharmy.soundscape.geoengine.utils.tileToBoundingBox
 import com.squareup.moshi.Moshi
 import org.junit.Test
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
 import org.scottishtecharmy.soundscape.geoengine.GridState
 import org.scottishtecharmy.soundscape.geoengine.TreeId
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.utils.createPolygonFromTriangle
 import org.scottishtecharmy.soundscape.geoengine.utils.getFovTriangle
 
@@ -334,7 +334,7 @@ class VisuallyCheckOutput {
 
         // Fake device location and pretend the device is pointing East.
         // -2.6577997643930757, 51.43041390383118
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.6573400576040456, 51.430456817236575),
             90.0,
             50.0
@@ -384,7 +384,7 @@ class VisuallyCheckOutput {
 
         // Fake device location and pretend the device is pointing East.
         // -2.6577997643930757, 51.43041390383118
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.6573400576040456, 51.430456817236575),
             90.0,
             50.0
@@ -435,7 +435,7 @@ class VisuallyCheckOutput {
 
         // Fake device location and pretend the device is pointing East.
         // -2.6577997643930757, 51.43041390383118
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.6573400576040456, 51.430456817236575),
             90.0,
             50.0
@@ -479,7 +479,7 @@ class VisuallyCheckOutput {
     @Test
     fun relativeDirectionsCombined(){
         val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.657279900280031, 51.430461188129385),
             0.0,
             50.0
@@ -497,7 +497,7 @@ class VisuallyCheckOutput {
     @Test
     fun relativeDirectionsIndividual(){
         val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.657279900280031, 51.430461188129385),
             90.0,
             50.0
@@ -515,7 +515,7 @@ class VisuallyCheckOutput {
     @Test
     fun relativeDirectionsAheadBehind(){
         val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.657279900280031, 51.430461188129385),
             90.0,
             50.0
@@ -536,7 +536,7 @@ class VisuallyCheckOutput {
     @Test
     fun relativeDirectionsLeftRight(){
         val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.657279900280031, 51.430461188129385),
             90.0,
             50.0
@@ -553,7 +553,7 @@ class VisuallyCheckOutput {
     @Test
     fun relativeDirectionsAll(){
         val moshi = GeoMoshi.registerAdapters(Moshi.Builder()).build()
-        val userGeometry = GeoEngine.UserGeometry(
+        val userGeometry = UserGeometry(
             LngLatAlt(-2.657279900280031, 51.430461188129385),
             90.0,
             50.0

--- a/app/src/test/java/org/scottishtecharmy/soundscape/filters/CalloutHistoryTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/filters/CalloutHistoryTest.kt
@@ -3,9 +3,8 @@ package org.scottishtecharmy.soundscape.filters
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
-import org.scottishtecharmy.soundscape.geoengine.GeoEngine
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.filters.CalloutHistory
 import org.scottishtecharmy.soundscape.geoengine.filters.TrackedCallout
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
@@ -34,7 +33,7 @@ class CalloutHistoryTest {
         )
         history.add(callout)
         Thread.sleep(20)
-        history.trim(GeoEngine.UserGeometry(location))
+        history.trim(UserGeometry(location))
         assertFalse(history.find(callout))
         assertEquals(0, history.size())
     }
@@ -46,7 +45,7 @@ class CalloutHistoryTest {
         val distantLocation = LngLatAlt(10.0, 10.0, 10.0)
         val callout = TrackedCallout("Poi number three", distantLocation, true, false)
         history.add(callout)
-        history.trim(GeoEngine.UserGeometry(location))
+        history.trim(UserGeometry(location))
         assertFalse(history.find(callout))
         assertEquals(0, history.size())
     }
@@ -55,7 +54,7 @@ class CalloutHistoryTest {
     fun testTrimEmptyHistory() {
         val history = CalloutHistory(10)
         val location = LngLatAlt(0.0, 0.0, 0.0) // Example location
-        history.trim(GeoEngine.UserGeometry(location))
+        history.trim(UserGeometry(location))
         assertEquals(0, history.size())
     }
 }


### PR DESCRIPTION
The iOS app has three current headings which I think correspond to:

1. The phone direction
2. The direction of travel
3. The direction from head tracking

This PR adds direction of travel, currently taking it unfiltered from the location provider. The `heading` function is now called to return one of those headings (we don't support head tracking yet), and it's based on the `HeadingMode` of the `UserGeometry` instance. `Auto` mode will pick the travel direction if there is one, otherwise it will use the phone direction. Callers which want the phone direction can specify `HeadingMode.Phone` when creating the `UserGeometry`.