### PR TITLE
Add the start of reverse geocoding to describe locations for LocationDescription

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -33,14 +33,19 @@ import org.scottishtecharmy.soundscape.geoengine.utils.RelativeDirections
 import org.scottishtecharmy.soundscape.geoengine.utils.getDistanceToFeature
 import org.scottishtecharmy.soundscape.geoengine.utils.getRelativeDirectionsPolygons
 import org.scottishtecharmy.soundscape.geoengine.utils.getTriangleForDirection
+import org.scottishtecharmy.soundscape.geoengine.utils.polygonContainsCoordinates
+import org.scottishtecharmy.soundscape.geoengine.utils.removeDuplicateOsmIds
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.Polygon
 import org.scottishtecharmy.soundscape.locationprovider.DirectionProvider
 import org.scottishtecharmy.soundscape.locationprovider.LocationProvider
 import org.scottishtecharmy.soundscape.network.PhotonSearchProvider
+import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.services.SoundscapeService
 import org.scottishtecharmy.soundscape.services.getOttoBus
 import org.scottishtecharmy.soundscape.utils.getCurrentLocale
+import org.scottishtecharmy.soundscape.utils.toLocationDescriptions
 import java.util.Locale
 import kotlin.math.abs
 import kotlin.time.TimeSource
@@ -506,6 +511,94 @@ class GeoEngine {
         return results
     }
 
+    private suspend fun reverseGeocodeResult(location: LngLatAlt) =
+        withContext(Dispatchers.IO) {
+            return@withContext PhotonSearchProvider
+                .getInstance()
+                .reverseGeocodeLocation(
+                    latitude = location.latitude,
+                    longitude = location.longitude
+                ).execute()
+                .body()
+        }
+
+    /**
+     * getLocationDescription returns a LocationDescription object for the current location. This
+     * is basically a reverse geocode. It initially tries to generate it from local tile data, but
+     * falls back to geocoding via the Photon server if network is available.
+     * @param location to reverse geocode
+     * @param preserveLocation ensures that the returned LocationDescription contains the passed in
+     * location rather than overwriting it with the location of a POI that it geocded to.
+     * @return a LocationDescription object containing an address of the location
+     */
+    fun getLocationDescription(location: LngLatAlt,
+                               preserveLocation: Boolean = true) : LocationDescription? {
+
+        var geocode: LocationDescription?
+        val currentLocation = locationProvider.get()
+        // If the location is within our current TileGrid, then we can make our own description of
+        // the location.
+        geocode = runBlocking {
+            withContext(gridState.treeContext) {
+                localReverseGeocode(location, gridState, localizedContext)
+            }
+        }
+        if(geocode != null) {
+            var distance = locationProvider.get().distance(LngLatAlt(geocode.longitude, geocode.latitude))
+            if(distance > 1000) {
+                val km = (distance.toInt() / 100).toFloat() / 10
+                geocode.distance =
+                    localizedContext.getString(R.string.distance_format_km, km.toString())
+            } else {
+                val m = distance.toInt()
+                geocode.distance =
+                    localizedContext.getString(R.string.distance_format_meters, m.toString())
+            }
+            return geocode
+        }
+
+        // If we have network, then we should be able to do a reverse geocode via the photon server
+        // TODO: Check for network first
+        if(true) {
+            geocode = runBlocking {
+                withContext(Dispatchers.IO) {
+                    val result = reverseGeocodeResult(location)
+
+                    // The geocode result includes the location for the POI. In the case of something
+                    // like a park this could be a long way from the point that was passed in.
+                    val ld = result?.features?.toLocationDescriptions(
+                        currentLocationLatitude = currentLocation.latitude,
+                        currentLocationLongitude = currentLocation.longitude
+                    )
+                    if (!ld.isNullOrEmpty()) {
+                        if(preserveLocation) {
+                            val overwritten = ld.first()
+                            overwritten.latitude = location.latitude
+                            overwritten.longitude = location.longitude
+                            if(overwritten.addressName != null) {
+                                overwritten.addressName = localizedContext.getString(R.string.directions_near_name).format(overwritten.addressName)
+                                overwritten
+                            }
+                            else {
+                                null
+                            }
+                        } else {
+                            ld.first()
+                        }
+                    } else
+                        null
+                }
+            }
+            if (geocode != null)
+                return geocode
+        }
+
+        // If we don't have network, and the location is outside of our current TileGrid, then we
+        // could see if the tiles are cached and we can create a temporary TileGrid just for this
+        // but for now just return null.
+        return null
+    }
+
     companion object {
         private const val TAG = "GeoEngine"
     }
@@ -565,4 +658,71 @@ fun formatDistance(distance: Double, localizedContext: Context) : String {
         val metres = distance.toInt()
         return  localizedContext.getString(R.string.distance_format_meters, metres.toString())
     }
+}
+
+fun localReverseGeocode(location: LngLatAlt,
+                        gridState: GridState,
+                        localizedContext: Context): LocationDescription? {
+
+    if(!gridState.isLocationWithinGrid(location)) return null
+
+    // Check if we're inside a POI
+    val gridPoiCollection = gridState.getFeatureCollection(TreeId.POIS, location, 200.0)
+    val gridPoiFeatureCollection = removeDuplicateOsmIds(gridPoiCollection)
+    for(poi in gridPoiFeatureCollection) {
+        // We can only be inside polygons
+        if(poi.geometry.type == "Polygon") {
+            val polygon = poi.geometry as Polygon
+
+            if(polygonContainsCoordinates(location, polygon)) {
+                // We've found a POI that contains the location. We could return the c
+                val name = poi.properties?.get("name")
+                if(name != null) {
+                    return LocationDescription(
+                        addressName = localizedContext.getString(R.string.directions_at_poi).format(name as String),
+                        longitude = location.longitude,
+                        latitude = location.latitude,
+                    )
+                }
+            }
+        }
+    }
+
+    // Check if the location is alongside a road/path.
+    val nearestRoad = gridState.getNearestFeature(TreeId.ROADS_AND_PATHS, location, 100.0)
+    if(nearestRoad != null) {
+        val properties = nearestRoad.properties
+        if (properties != null) {
+            var roadName = properties["name"]
+            if (roadName == null) {
+                roadName = properties["highway"]
+            }
+            return LocationDescription(
+                addressName = localizedContext.getString(R.string.directions_near_name).format(roadName as String),
+                longitude = location.longitude,
+                latitude = location.latitude
+            )
+        }
+    }
+
+    return null
+}
+
+/** Reverse geocodes a location into 1 of 4 possible states
+ * - within a POI
+ * - alongside a road
+ * - general location
+ * - unknown location).
+ */
+fun reverseGeocode(userGeometry: UserGeometry,
+                   gridState: GridState,
+                   localizedContext: Context): PositionedString {
+
+    val location = localReverseGeocode(userGeometry.location, gridState, localizedContext)
+    location?.let { l ->
+        l.addressName?.let { name ->
+            return PositionedString(name, userGeometry.location)
+        }
+    }
+    return PositionedString(localizedContext.getString(R.string.poi_unknown_place))
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
@@ -55,6 +55,7 @@ open class GridState {
     internal lateinit var tileClient: TileClient
 
     private var centralBoundingBox = BoundingBox()
+    private var totalBoundingBox = BoundingBox()
     internal var featureTrees = Array(TreeId.MAX_COLLECTION_ID.id) { FeatureTree(null) }
     @OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
     val treeContext = newSingleThreadContext("TreeContext")
@@ -63,6 +64,10 @@ open class GridState {
     open fun start(application: Application, soundscapeService: SoundscapeService) {}
     fun stop() {}
     open fun fixupCollections(featureCollections: Array<FeatureCollection>) {}
+
+    fun isLocationWithinGrid(location: LngLatAlt): Boolean {
+        return pointIsWithinBoundingBox(location, totalBoundingBox)
+    }
 
     /**
      * The tile grid service is called each time the location changes. It checks if the location
@@ -84,6 +89,7 @@ open class GridState {
             if (updateTileGrid(tileGrid, featureCollections)) {
                 // We have got a new grid, so create our new central region
                 centralBoundingBox = tileGrid.centralBoundingBox
+                totalBoundingBox = tileGrid.totalBoundingBox
 
                 fixupCollections(featureCollections)
                 classifyPois(featureCollections, enabledCategories)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/AutoCallout.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/AutoCallout.kt
@@ -6,7 +6,6 @@ import android.util.Log
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.scottishtecharmy.soundscape.MainActivity.Companion.ALLOW_CALLOUTS_KEY
-import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
 import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.GridState
@@ -16,84 +15,19 @@ import org.scottishtecharmy.soundscape.geoengine.filters.CalloutHistory
 import org.scottishtecharmy.soundscape.geoengine.filters.LocationUpdateFilter
 import org.scottishtecharmy.soundscape.geoengine.filters.TrackedCallout
 import org.scottishtecharmy.soundscape.geoengine.getTextForFeature
-import org.scottishtecharmy.soundscape.geoengine.utils.getCompassLabelFacingDirectionAlong
+import org.scottishtecharmy.soundscape.geoengine.reverseGeocode
 import org.scottishtecharmy.soundscape.geoengine.utils.getDistanceToFeature
-import org.scottishtecharmy.soundscape.geoengine.utils.polygonContainsCoordinates
-import org.scottishtecharmy.soundscape.geoengine.utils.removeDuplicateOsmIds
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
-import org.scottishtecharmy.soundscape.geojsonparser.geojson.Polygon
 
 class AutoCallout(
     private val localizedContext: Context,
     private val sharedPreferences: SharedPreferences
 ) {
-
-
     private val locationFilter = LocationUpdateFilter(10000, 50.0)
     private val poiFilter = LocationUpdateFilter(5000, 5.0)
     private val intersectionFilter = LocationUpdateFilter(5000, 5.0)
     private val intersectionCalloutHistory = CalloutHistory(30000)
     private val poiCalloutHistory = CalloutHistory()
-
-
-    /** Reverse geocodes a location into 1 of 4 possible states
-     * - within a POI
-     * - alongside a road
-     * - general location
-     * - unknown location).
-     */
-    private fun reverseGeocode(userGeometry: UserGeometry,
-                               gridState: GridState): List<PositionedString> {
-        val results : MutableList<PositionedString> = mutableListOf()
-
-        // Check if we're inside a POI
-        val gridPoiCollection = gridState.getFeatureCollection(TreeId.POIS, userGeometry.location, 200.0)
-        val gridPoiFeatureCollection = removeDuplicateOsmIds(gridPoiCollection)
-        for(poi in gridPoiFeatureCollection) {
-            // We can only be inside polygons
-            if(poi.geometry.type == "Polygon") {
-                val polygon = poi.geometry as Polygon
-
-                if(polygonContainsCoordinates(userGeometry.location, polygon)) {
-                    // We've found a POI that contains our location
-                    val name = poi.properties?.get("name")
-                    if(name != null) {
-                        results.add(
-                            PositionedString(
-                                localizedContext.getString(R.string.directions_at_poi).format(name as String)
-                            ),
-                        )
-                        return results
-                    }
-                }
-            }
-        }
-
-        // Check if we're alongside a road/path
-        val nearestRoad = gridState.getNearestFeature(TreeId.ROADS_AND_PATHS, userGeometry.location, 100.0)
-        if(nearestRoad != null) {
-            val properties = nearestRoad.properties
-            if (properties != null) {
-                val orientation = userGeometry.heading()
-                var roadName = properties["name"]
-                if (roadName == null) {
-                    roadName = properties["highway"]
-                }
-                val facingDirectionAlongRoad =
-                    getCompassLabelFacingDirectionAlong(
-                        localizedContext,
-                        orientation.toInt(),
-                        roadName.toString(),
-                        userGeometry.inMotion,
-                        userGeometry.inVehicle
-                    )
-                results.add(PositionedString(facingDirectionAlongRoad))
-                return results
-            }
-        }
-
-        return results
-    }
 
     private fun buildCalloutForRoadSense(userGeometry: UserGeometry,
                                          gridState: GridState): List<PositionedString> {
@@ -112,11 +46,11 @@ class AutoCallout(
         locationFilter.update(userGeometry)
 
         // Reverse geocode the current location (this is the iOS name for the function)
-        val results = reverseGeocode(userGeometry, gridState)
+        val geocode = reverseGeocode(userGeometry, gridState, localizedContext)
 
         // Check that the geocode has changed before returning a callout describing it
 
-        return results
+        return listOf(geocode)
     }
 
     private fun buildCalloutForIntersections(userGeometry: UserGeometry,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileGridUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileGridUtils.kt
@@ -10,10 +10,11 @@ import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Polygon
 import org.scottishtecharmy.soundscape.geojsonparser.moshi.GeoJsonObjectMoshiAdapter
 
-class TileGrid(newTiles : MutableList<Tile>, newCentralBoundingBox : BoundingBox) {
+class TileGrid(newTiles : MutableList<Tile>,
+               var centralBoundingBox : BoundingBox,
+               var totalBoundingBox : BoundingBox) {
 
     val tiles : MutableList<Tile> = newTiles
-    var centralBoundingBox : BoundingBox = newCentralBoundingBox
 
     /**
      * Return GeoJSON that describes the tile grid and the central bounding box so that it can be
@@ -98,7 +99,15 @@ class TileGrid(newTiles : MutableList<Tile>, newCentralBoundingBox : BoundingBox
                     tiles.add(surroundingTile)
                 }
             }
-            return TileGrid(tiles, centralBoundingBox)
+
+            val totalBoundingBox = BoundingBox(
+                southWest.second,
+                southWest.first,
+                northEast.second,
+                northEast.first
+            )
+
+            return TileGrid(tiles, centralBoundingBox, totalBoundingBox)
         }
 
         /**
@@ -155,6 +164,23 @@ class TileGrid(newTiles : MutableList<Tile>, newCentralBoundingBox : BoundingBox
                 }
             }
 
+            val gridNorthWest = pixelXYToLatLon(
+                (xValues[0] * 256).toDouble(),
+                (yValues[0] * 256).toDouble(),
+                ZOOM_LEVEL
+            )
+            val gridSouthEast = pixelXYToLatLon(
+                ((xValues[1] + 1).mod(maxCoordinate) * 256).toDouble(),
+                ((yValues[1] + 1).mod(maxCoordinate) * 256).toDouble(),
+                ZOOM_LEVEL
+            )
+            val totalBoundingBox = BoundingBox(
+                gridNorthWest.second,
+                gridSouthEast.first,
+                gridSouthEast.second,
+                gridNorthWest.first
+            )
+
             // Center of grid is the top left corner of the bottom right tile
             val centerX = (xValues[1] * 256)
             val centerY = (yValues[1] * 256)
@@ -173,7 +199,7 @@ class TileGrid(newTiles : MutableList<Tile>, newCentralBoundingBox : BoundingBox
                     tiles.add(surroundingTile)
                 }
             }
-            return TileGrid(tiles, centralBoundingBox)
+            return TileGrid(tiles, centralBoundingBox, totalBoundingBox)
         }
 
         /**
@@ -194,7 +220,7 @@ class TileGrid(newTiles : MutableList<Tile>, newCentralBoundingBox : BoundingBox
                 3 -> return get3x3TileGrid(currentLocation)
             }
             assert(false)
-            return TileGrid(mutableListOf(), BoundingBox())
+            return TileGrid(mutableListOf(), BoundingBox(), BoundingBox())
         }
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/network/SearchProvider.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/network/SearchProvider.kt
@@ -14,7 +14,6 @@ import retrofit2.http.Headers
 import retrofit2.http.Query
 import java.util.Locale
 import java.util.concurrent.TimeUnit
-import kotlin.time.Duration
 
 const val BASE_URL = "https://photon.komoot.io/"
 
@@ -41,6 +40,17 @@ interface PhotonSearchProvider {
         @Query("lang") language: String = Locale.getDefault().language,
         @Query("limit") limit: UInt = 5U,
         @Query("location_bias_scale") bias: Float = 0.2f
+    ): Call<FeatureCollection>
+
+    @Headers(
+        "Cache-control: max-age=0",
+        "Connection: keep-alive"
+    )
+    @GET("reverse/")
+    fun reverseGeocodeLocation(
+        @Query("lat") latitude: Double? = null,
+        @Query("lon") longitude: Double? = null,
+        @Query("lang") language: String = Locale.getDefault().language,
     ): Call<FeatureCollection>
 
     companion object {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
@@ -16,6 +16,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.google.gson.GsonBuilder
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.home.home.HelpScreen
 import org.scottishtecharmy.soundscape.screens.home.home.Home
@@ -63,12 +64,8 @@ fun HomeScreen(
                 heading = state.value.heading,
                 onNavigate = { dest -> navController.navigate(dest) },
                 onMapLongClick = { latLong ->
-                    val ld =
-                        LocationDescription(
-                            addressName = "Current location",
-                            latitude =latLong.latitude,
-                            longitude = latLong.longitude,
-                        )
+                    val location = LngLatAlt(latLong.longitude, latLong.latitude)
+                    val ld = viewModel.getLocationDescription(location) ?: LocationDescription()
                     navController.navigate(generateLocationDetailsRoute(ld))
                     true
                 },
@@ -78,6 +75,17 @@ fun HomeScreen(
                 getMyLocation = { viewModel.myLocation() },
                 getWhatsAheadOfMe = { viewModel.aheadOfMe() },
                 getWhatsAroundMe = { viewModel.whatsAroundMe() },
+                getCurrentLocationDescription = {
+                    if(state.value.location != null) {
+                        val location = LngLatAlt(
+                            state.value.location!!.longitude,
+                            state.value.location!!.latitude
+                        )
+                        viewModel.getLocationDescription(location) ?: LocationDescription()
+                    } else {
+                        LocationDescription()
+                    }
+                },
                 searchText = searchText.value,
                 isSearching = state.value.isSearching,
                 onToggleSearch = viewModel::onToggleSearch,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/data/LocationDescription.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/data/LocationDescription.kt
@@ -1,10 +1,11 @@
 package org.scottishtecharmy.soundscape.screens.home.data
 
 data class LocationDescription(
-    val addressName: String? = null,
+    var addressName: String? = null,
     val fullAddress: String? = null,
-    val distance: String? = null,
-    val latitude: Double = Double.NaN,
-    val longitude: Double = Double.NaN,
-    val marker: Boolean = false,
+    val country: String? = null,
+    var distance: String? = null,
+    var latitude: Double = Double.NaN,
+    var longitude: Double = Double.NaN,
+    val marker: Boolean = false
 )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
@@ -55,6 +55,7 @@ fun HomePreview() {
         getMyLocation = {},
         getWhatsAroundMe = {},
         getWhatsAheadOfMe = {},
+        getCurrentLocationDescription = { LocationDescription() },
         shareLocation = {},
         rateSoundscape = {},
         streetPreviewState = StreetPreviewState(false),
@@ -81,6 +82,7 @@ fun Home(
     getMyLocation: () -> Unit,
     getWhatsAroundMe: () -> Unit,
     getWhatsAheadOfMe: () -> Unit,
+    getCurrentLocationDescription: () -> LocationDescription,
     shareLocation: () -> Unit,
     rateSoundscape: () -> Unit,
     streetPreviewState: StreetPreviewState,
@@ -135,6 +137,7 @@ fun Home(
                 heading = heading,
                 modifier = Modifier.padding(innerPadding),
                 onNavigate = onNavigate,
+                getCurrentLocationDescription = getCurrentLocationDescription,
                 searchBar = {
                     MainSearchBar(
                         searchText = searchText,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
@@ -25,6 +25,7 @@ fun HomeContent(
     onNavigate: (String) -> Unit,
     onMapLongClick: (LatLng) -> Boolean,
     onMarkerClick: (Marker) -> Boolean,
+    getCurrentLocationDescription: () -> LocationDescription,
     searchBar: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     tileGridGeoJson: String,
@@ -72,14 +73,8 @@ fun HomeContent(
                 NavigationButton(
                     onClick = {
                         if (latitude != null && longitude != null) {
-                            val ld =
-                                LocationDescription(
-                                    // TODO handle LocationDescription instantiation in viewmodel ?
-                                    addressName = "Current location",
-                                    latitude = latitude,
-                                    longitude = longitude,
-                                )
-                            onNavigate(generateLocationDetailsRoute(ld)) // TODO handle at top level the generateLocationDetailsRoute ?
+                            val ld = getCurrentLocationDescription()
+                            onNavigate(generateLocationDetailsRoute(ld))
                         }
                     },
                     text = stringResource(R.string.search_use_current_location),
@@ -117,7 +112,8 @@ fun StreetPreviewHomeContent() {
         tileGridGeoJson = "",
         streetPreviewState = StreetPreviewState(true),
         streetPreviewGo = {},
-        streetPreviewExit = {}
+        streetPreviewExit = {},
+        getCurrentLocationDescription = { LocationDescription() }
     )
 }
 
@@ -136,6 +132,7 @@ fun PreviewHomeContent() {
         tileGridGeoJson = "",
         streetPreviewState = StreetPreviewState(false),
         streetPreviewGo = {},
-        streetPreviewExit = {}
+        streetPreviewExit = {},
+        getCurrentLocationDescription = { LocationDescription() }
     )
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -45,6 +45,7 @@ import org.scottishtecharmy.soundscape.locationprovider.AndroidLocationProvider
 import org.scottishtecharmy.soundscape.locationprovider.DirectionProvider
 import org.scottishtecharmy.soundscape.locationprovider.LocationProvider
 import org.scottishtecharmy.soundscape.locationprovider.StaticLocationProvider
+import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -360,6 +361,10 @@ class SoundscapeService : MediaSessionService() {
             val results = geoEngine.aheadOfMe()
             speakCallout(results)
         }
+    }
+
+    fun getLocationDescription(location: LngLatAlt) : LocationDescription? {
+        return geoEngine.getLocationDescription(location)
     }
 
     private lateinit var routePlayer : RoutePlayer

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
@@ -8,69 +8,65 @@ import kotlinx.coroutines.launch
 import org.scottishtecharmy.soundscape.SoundscapeServiceConnection
 import org.scottishtecharmy.soundscape.database.local.model.Location
 import org.scottishtecharmy.soundscape.database.local.model.MarkerData
-import org.scottishtecharmy.soundscape.database.repository.MarkersRepository
 import org.scottishtecharmy.soundscape.database.repository.RoutesRepository
-import org.scottishtecharmy.soundscape.screens.home.Navigator
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import javax.inject.Inject
 
 @HiltViewModel
-class LocationDetailsViewModel
-    @Inject
-    constructor(
-        private val soundscapeServiceConnection: SoundscapeServiceConnection,
-        private val navigator: Navigator,
-        private val routesRepository: RoutesRepository,
-        private val markersRepository: MarkersRepository,
-    ) : ViewModel() {
-        private var serviceConnection: SoundscapeServiceConnection? = null
+class LocationDetailsViewModel @Inject constructor(
+    private val soundscapeServiceConnection : SoundscapeServiceConnection,
+    private val routesRepository: RoutesRepository
+): ViewModel() {
 
-        fun createBeacon(
-            latitude: Double,
-            longitude: Double,
-        ) {
-            soundscapeServiceConnection.soundscapeService?.createBeacon(latitude, longitude)
-        }
+    fun createBeacon(
+        latitude: Double,
+        longitude: Double,
+    ) {
+        soundscapeServiceConnection.soundscapeService?.createBeacon(latitude, longitude)
+    }
 
-        fun enableStreetPreview(
-            latitude: Double,
-            longitude: Double,
-        ) {
-            soundscapeServiceConnection.setStreetPreviewMode(true, latitude, longitude)
-        }
+    fun enableStreetPreview(
+        latitude: Double,
+        longitude: Double,
+    ) {
+        soundscapeServiceConnection.setStreetPreviewMode(true, latitude, longitude)
+    }
 
-        fun createMarker(locationDescription: LocationDescription) {
-            viewModelScope.launch {
-                var name = locationDescription.addressName
-                if (name == null) name = locationDescription.fullAddress
-                name = name ?: "Unknown"
-                val marker =
-                    MarkerData(
-                        addressName = name,
-                        fullAddress = locationDescription.fullAddress ?: "", // TODO Fanny is it possible to get no full address ?
-                        location = Location(latitude = locationDescription.latitude, longitude = locationDescription.longitude),
-                    )
-                try {
-                    markersRepository.insertMarker(marker)
+    fun createMarker(locationDescription: LocationDescription) {
+        viewModelScope.launch {
+            var name = locationDescription.addressName
+            if (name == null) name = locationDescription.fullAddress
+            name = name ?: "Unknown"
+            val marker =
+                MarkerData(
+                    addressName = name,
+                    fullAddress = locationDescription.fullAddress ?: "", // TODO Fanny is it possible to get no full address ?
+                    location = Location(latitude = locationDescription.latitude, longitude = locationDescription.longitude),
+                )
+            try {
+                routesRepository.insertWaypoint(marker)
 
-                    Log.d("LocationDetailsViewModel", "Marker saved successfully: ${marker.addressName}")
-                } catch (e: Exception) {
-                    Log.e("LocationDetailsViewModel", "Error saving route: ${e.message}")
-                }
+                Log.d("LocationDetailsViewModel", "Marker saved successfully: ${marker.addressName}")
+            } catch (e: Exception) {
+                Log.e("LocationDetailsViewModel", "Error saving route: ${e.message}")
             }
-        }
-
-        init {
-            navigator.navigate("")
-            serviceConnection = soundscapeServiceConnection
-            viewModelScope.launch {
-                soundscapeServiceConnection.serviceBoundState.collect {
-                    Log.d(TAG, "serviceBoundState $it")
-                }
-            }
-        }
-
-        companion object {
-            private const val TAG = "LocationDetailsViewModel"
         }
     }
+
+    init {
+        viewModelScope.launch {
+            soundscapeServiceConnection.serviceBoundState.collect {
+                Log.d(TAG, "serviceBoundState $it")
+            }
+        }
+    }
+
+    fun getLocationDescription(location: LngLatAlt) : LocationDescription? {
+        return soundscapeServiceConnection.soundscapeService?.getLocationDescription(location)
+    }
+
+    companion object {
+        private const val TAG = "LocationDetailsViewModel"
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeState.kt
@@ -1,13 +1,12 @@
 package org.scottishtecharmy.soundscape.viewmodels.home
 
-import android.location.Location
 import org.maplibre.android.geometry.LatLng
 import org.scottishtecharmy.soundscape.geoengine.StreetPreviewState
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 
 data class HomeState(
     var heading: Float = 0.0f,
-    var location: Location? = null,
+    var location: LatLng? = null,
     var beaconLocation: LatLng? = null,
     var streetPreviewState: StreetPreviewState = StreetPreviewState(false),
     var tileGridGeoJson: String = "",

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeViewModel.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.launch
 import org.maplibre.android.annotations.Marker
 import org.maplibre.android.geometry.LatLng
 import org.scottishtecharmy.soundscape.SoundscapeServiceConnection
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.utils.blankOrEmpty
 import org.scottishtecharmy.soundscape.utils.toLocationDescriptions
 import java.net.URLEncoder
@@ -36,240 +38,244 @@ class HomeViewModel
     @Inject
     constructor(
         private val soundscapeServiceConnection: SoundscapeServiceConnection,
-    ) : ViewModel() {
-        private val _state: MutableStateFlow<HomeState> = MutableStateFlow(HomeState())
-        val state: StateFlow<HomeState> = _state.asStateFlow()
-        private val _searchText: MutableStateFlow<String> = MutableStateFlow("")
-        val searchText: StateFlow<String> = _searchText.asStateFlow()
+) : ViewModel() {
+    private val _state: MutableStateFlow<HomeState> = MutableStateFlow(HomeState())
+    val state: StateFlow<HomeState> = _state.asStateFlow()
+    private val _searchText: MutableStateFlow<String> = MutableStateFlow("")
+    val searchText: StateFlow<String> = _searchText.asStateFlow()
 
-        private var job = Job()
-        private var spJob = Job()
+    private var job = Job()
+    private var spJob = Job()
 
-        init {
-            handleMonitoring()
-            fetchSearchResult()
+    init {
+        handleMonitoring()
+        fetchSearchResult()
+    }
+
+    private fun handleMonitoring() {
+        viewModelScope.launch {
+            soundscapeServiceConnection.serviceBoundState.collect { serviceBoundState ->
+                Log.d(TAG, "serviceBoundState $serviceBoundState")
+                if (serviceBoundState) {
+                    // The service has started, so start monitoring the location and heading
+                    startMonitoringLocation()
+                    // And start monitoring the street preview mode
+                    startMonitoringStreetPreviewState()
+                } else {
+                    // The service has gone away so remove the current location marker
+                    _state.update { it.copy(location = null) }
+                    stopMonitoringStreetPreviewState()
+                    stopMonitoringLocation()
+                }
+            }
         }
+    }
 
-        private fun handleMonitoring() {
-            viewModelScope.launch {
-                soundscapeServiceConnection.serviceBoundState.collect { serviceBoundState ->
-                    Log.d(TAG, "serviceBoundState $serviceBoundState")
-                    if (serviceBoundState) {
-                        // The service has started, so start monitoring the location and heading
-                        startMonitoringLocation()
-                        // And start monitoring the street preview mode
-                        startMonitoringStreetPreviewState()
+    override fun onCleared() {
+        super.onCleared()
+        stopMonitoringStreetPreviewState()
+        stopMonitoringLocation()
+    }
+
+    /**
+     * startMonitoringLocation launches monitoring of the location and orientation providers. These
+     * can change e.g. when switching to and from StreetPreview mode, so they are launched in a job.
+     * That job is cancelled when the StreetPreview mode changes and the monitoring restarted.
+     */
+    private fun startMonitoringLocation() {
+        Log.d(TAG, "ViewModel startMonitoringLocation")
+        job = Job()
+        viewModelScope.launch(job) {
+            // Observe location updates from the service
+            soundscapeServiceConnection.getLocationFlow()?.collectLatest { value ->
+                if (value != null) {
+                    Log.d(TAG, "Location $value")
+                    _state.update { it.copy(location = LatLng(value.latitude, value.longitude)) }
+                }
+            }
+        }
+        viewModelScope.launch(job) {
+            // Observe orientation updates from the service
+            soundscapeServiceConnection.getOrientationFlow()?.collectLatest { value ->
+                if (value != null) {
+                    _state.update { it.copy(heading = value.headingDegrees) }
+                }
+            }
+        }
+        viewModelScope.launch(job) {
+            // Observe beacon location update from the service so we can show it on the map
+            soundscapeServiceConnection.getBeaconFlow()?.collectLatest { value ->
+                Log.d(TAG, "beacon collected $value")
+                if (value != null) {
+                    _state.update {
+                        it.copy(
+                            beaconLocation =
+                                LatLng(
+                                    value.latitude,
+                                    value.longitude,
+                                ),
+                        )
+                    }
+                } else {
+                    _state.update { it.copy(beaconLocation = null) }
+                }
+            }
+        }
+    }
+
+    private fun stopMonitoringLocation() {
+        Log.d(TAG, "stopMonitoringLocation")
+        job.cancel()
+    }
+
+    /**
+     * startMonitoringStreetPreviewState launches a job to monitor the state of street preview mode.
+     * When the mode from the service changes then the local flow for the UI is updated and the
+     * location and orientation monitoring is turned off and on again so as to use the new providers.
+     */
+    private fun startMonitoringStreetPreviewState() {
+        Log.d(TAG, "startMonitoringStreetPreviewState")
+        spJob = Job()
+        viewModelScope.launch(spJob) {
+            // Observe street preview mode from the service so we can update state
+            soundscapeServiceConnection.getStreetPreviewModeFlow()?.collect { value ->
+                Log.d(TAG, "Street Preview Mode: $value")
+                _state.update { it.copy(streetPreviewState = value) }
+
+                // Restart location monitoring for new provider
+                stopMonitoringLocation()
+                startMonitoringLocation()
+            }
+        }
+    }
+
+    private fun stopMonitoringStreetPreviewState() {
+        Log.d(TAG, "stopMonitoringStreetPreviewState")
+        spJob.cancel()
+    }
+
+    fun onMarkerClick(marker: Marker): Boolean {
+        Log.d(TAG, "marker click")
+
+        if (marker.position == _state.value.beaconLocation) {
+            soundscapeServiceConnection.soundscapeService?.destroyBeacon()
+            _state.update { it.copy(beaconLocation = null) }
+
+            return true
+        }
+        return false
+    }
+
+    fun myLocation() {
+        // Log.d(TAG, "myLocation() triggered")
+        viewModelScope.launch {
+            soundscapeServiceConnection.soundscapeService?.myLocation()
+        }
+    }
+
+    fun aheadOfMe() {
+        // Log.d(TAG, "myLocation() triggered")
+        viewModelScope.launch {
+            soundscapeServiceConnection.soundscapeService?.aheadOfMe()
+        }
+    }
+
+    fun whatsAroundMe() {
+        // Log.d(TAG, "myLocation() triggered")
+        viewModelScope.launch {
+            soundscapeServiceConnection.soundscapeService?.whatsAroundMe()
+        }
+    }
+
+    fun streetPreviewGo() {
+        // Log.d(TAG, "myLocation() triggered")
+        viewModelScope.launch {
+            soundscapeServiceConnection.streetPreviewGo()
+        }
+    }
+
+    fun streetPreviewExit() {
+        // Log.d(TAG, "myLocation() triggered")
+        viewModelScope.launch {
+            soundscapeServiceConnection.setStreetPreviewMode(false)
+        }
+    }
+
+    fun getLocationDescription(location: LngLatAlt) : LocationDescription? {
+        return soundscapeServiceConnection.soundscapeService?.getLocationDescription(location)
+    }
+
+    fun shareLocation(context: Context) {
+        // Share the current location using standard Android sharing mechanism. It's shared as a
+        //
+        //  soundscape://latitude,longitude
+        //
+        // URI, with the , encoded. This shows up in Slack as a clickable link which is the main
+        // usefulness for now
+        val location = soundscapeServiceConnection.getLocationFlow()?.value
+        if (location != null) {
+            val sendIntent: Intent =
+                Intent().apply {
+                    action = Intent.ACTION_SEND
+                    putExtra(Intent.EXTRA_TITLE, "Problem location")
+                    val latitude = location.latitude
+                    val longitude = location.longitude
+                    val uriData: String =
+                        URLEncoder.encode("$latitude,$longitude", Charsets.UTF_8.name())
+                    putExtra(Intent.EXTRA_TEXT, "soundscape://$uriData")
+                    type = "text/plain"
+                }
+
+            val shareIntent = Intent.createChooser(sendIntent, null)
+            context.startActivity(shareIntent)
+        }
+    }
+
+    fun onSearchTextChange(text: String) {
+        _searchText.value = text
+    }
+
+    private fun fetchSearchResult() {
+        viewModelScope.launch {
+            _searchText
+                .debounce(500)
+                .distinctUntilChanged()
+                .collectLatest { searchText ->
+                    if (searchText.blankOrEmpty()) {
+                        _state.update { it.copy(searchItems = emptyList()) }
                     } else {
-                        // The service has gone away so remove the current location marker
-                        _state.update { it.copy(location = null) }
-                        stopMonitoringStreetPreviewState()
-                        stopMonitoringLocation()
-                    }
-                }
-            }
-        }
+                        val result =
+                            soundscapeServiceConnection.soundscapeService?.searchResult(searchText)
 
-        override fun onCleared() {
-            super.onCleared()
-            stopMonitoringStreetPreviewState()
-            stopMonitoringLocation()
-        }
-
-        /**
-         * startMonitoringLocation launches monitoring of the location and orientation providers. These
-         * can change e.g. when switching to and from StreetPreview mode, so they are launched in a job.
-         * That job is cancelled when the StreetPreview mode changes and the monitoring restarted.
-         */
-        private fun startMonitoringLocation() {
-            Log.d(TAG, "ViewModel startMonitoringLocation")
-            job = Job()
-            viewModelScope.launch(job) {
-                // Observe location updates from the service
-                soundscapeServiceConnection.getLocationFlow()?.collectLatest { value ->
-                    if (value != null) {
-                        Log.d(TAG, "Location $value")
-                        _state.update { it.copy(location = value) }
-                    }
-                }
-            }
-            viewModelScope.launch(job) {
-                // Observe orientation updates from the service
-                soundscapeServiceConnection.getOrientationFlow()?.collectLatest { value ->
-                    if (value != null) {
-                        _state.update { it.copy(heading = value.headingDegrees) }
-                    }
-                }
-            }
-            viewModelScope.launch(job) {
-                // Observe beacon location update from the service so we can show it on the map
-                soundscapeServiceConnection.getBeaconFlow()?.collectLatest { value ->
-                    Log.d(TAG, "beacon collected $value")
-                    if (value != null) {
                         _state.update {
                             it.copy(
-                                beaconLocation =
-                                    LatLng(
-                                        value.latitude,
-                                        value.longitude,
+                                searchItems =
+                                    result?.toLocationDescriptions(
+                                        currentLocationLatitude = state.value.location?.latitude ?: 0.0,
+                                        currentLocationLongitude =
+                                            state.value.location?.longitude
+                                                ?: 0.0,
                                     ),
                             )
                         }
-                    } else {
-                        _state.update { it.copy(beaconLocation = null) }
                     }
                 }
-            }
-        }
-
-        private fun stopMonitoringLocation() {
-            Log.d(TAG, "stopMonitoringLocation")
-            job.cancel()
-        }
-
-        /**
-         * startMonitoringStreetPreviewState launches a job to monitor the state of street preview mode.
-         * When the mode from the service changes then the local flow for the UI is updated and the
-         * location and orientation monitoring is turned off and on again so as to use the new providers.
-         */
-        private fun startMonitoringStreetPreviewState() {
-            Log.d(TAG, "startMonitoringStreetPreviewState")
-            spJob = Job()
-            viewModelScope.launch(spJob) {
-                // Observe street preview mode from the service so we can update state
-                soundscapeServiceConnection.getStreetPreviewModeFlow()?.collect { value ->
-                    Log.d(TAG, "Street Preview Mode: $value")
-                    _state.update { it.copy(streetPreviewState = value) }
-
-                    // Restart location monitoring for new provider
-                    stopMonitoringLocation()
-                    startMonitoringLocation()
-                }
-            }
-        }
-
-        private fun stopMonitoringStreetPreviewState() {
-            Log.d(TAG, "stopMonitoringStreetPreviewState")
-            spJob.cancel()
-        }
-
-        fun onMarkerClick(marker: Marker): Boolean {
-            Log.d(TAG, "marker click")
-
-            if (marker.position == _state.value.beaconLocation) {
-                soundscapeServiceConnection.soundscapeService?.destroyBeacon()
-                _state.update { it.copy(beaconLocation = null) }
-
-                return true
-            }
-            return false
-        }
-
-        fun myLocation() {
-            // Log.d(TAG, "myLocation() triggered")
-            viewModelScope.launch {
-                soundscapeServiceConnection.soundscapeService?.myLocation()
-            }
-        }
-
-        fun aheadOfMe() {
-            // Log.d(TAG, "myLocation() triggered")
-            viewModelScope.launch {
-                soundscapeServiceConnection.soundscapeService?.aheadOfMe()
-            }
-        }
-
-        fun whatsAroundMe() {
-            // Log.d(TAG, "myLocation() triggered")
-            viewModelScope.launch {
-                soundscapeServiceConnection.soundscapeService?.whatsAroundMe()
-            }
-        }
-
-        fun streetPreviewGo() {
-            // Log.d(TAG, "myLocation() triggered")
-            viewModelScope.launch {
-                soundscapeServiceConnection.streetPreviewGo()
-            }
-        }
-
-        fun streetPreviewExit() {
-            // Log.d(TAG, "myLocation() triggered")
-            viewModelScope.launch {
-                soundscapeServiceConnection.setStreetPreviewMode(false)
-            }
-        }
-
-        fun shareLocation(context: Context) {
-            // Share the current location using standard Android sharing mechanism. It's shared as a
-            //
-            //  soundscape://latitude,longitude
-            //
-            // URI, with the , encoded. This shows up in Slack as a clickable link which is the main
-            // usefulness for now
-            val location = soundscapeServiceConnection.getLocationFlow()?.value
-            if (location != null) {
-                val sendIntent: Intent =
-                    Intent().apply {
-                        action = Intent.ACTION_SEND
-                        putExtra(Intent.EXTRA_TITLE, "Problem location")
-                        val latitude = location.latitude
-                        val longitude = location.longitude
-                        val uriData: String =
-                            URLEncoder.encode("$latitude,$longitude", Charsets.UTF_8.name())
-                        putExtra(Intent.EXTRA_TEXT, "soundscape://$uriData")
-                        type = "text/plain"
-                    }
-
-                val shareIntent = Intent.createChooser(sendIntent, null)
-                context.startActivity(shareIntent)
-            }
-        }
-
-        fun onSearchTextChange(text: String) {
-            _searchText.value = text
-        }
-
-        private fun fetchSearchResult() {
-            viewModelScope.launch {
-                _searchText
-                    .debounce(500)
-                    .distinctUntilChanged()
-                    .collectLatest { searchText ->
-                        if (searchText.blankOrEmpty()) {
-                            _state.update { it.copy(searchItems = emptyList()) }
-                        } else {
-                            val result =
-                                soundscapeServiceConnection.soundscapeService?.searchResult(searchText)
-
-                            _state.update {
-                                it.copy(
-                                    searchItems =
-                                        result?.toLocationDescriptions(
-                                            currentLocationLatitude = state.value.location?.latitude ?: 0.0,
-                                            currentLocationLongitude =
-                                                state.value.location?.longitude
-                                                    ?: 0.0,
-                                        ),
-                                )
-                            }
-                        }
-                    }
-            }
-        }
-
-        fun onToggleSearch() {
-            _state.update { it.copy(isSearching = !it.isSearching) }
-
-            if (!state.value.isSearching) {
-                onSearchTextChange("")
-            }
-        }
-
-        fun setRoutesAndMarkersTab(pickRoutes: Boolean) {
-            _state.update { it.copy(routesTabSelected = pickRoutes) }
-        }
-
-    companion object {
-            private const val TAG = "HomeViewModel"
         }
     }
+
+    fun onToggleSearch() {
+        _state.update { it.copy(isSearching = !it.isSearching) }
+
+        if (!state.value.isSearching) {
+            onSearchTextChange("")
+        }
+    }
+
+    fun setRoutesAndMarkersTab(pickRoutes: Boolean) {
+        _state.update { it.copy(routesTabSelected = pickRoutes) }
+    }
+
+companion object {
+        private const val TAG = "HomeViewModel"
+    }
+}


### PR DESCRIPTION
When creating markers we want to be able to describe the location so that the marker name makes sense. The approach here is to:

1. Generate a description based on the local tile data if we have it
2. Request the photon server reverse geocodes the location

The latter generally gives a better response, but is slower as it involves a roundtrip to the server.