### PR TITLE
Move APIs with doubles for lng/lat to use LngLatAlt instead.

### DIFF
--- a/app/src/androidTest/java/org/scottishtecharmy/soundscape/AudioEngineTest.kt
+++ b/app/src/androidTest/java/org/scottishtecharmy/soundscape/AudioEngineTest.kt
@@ -6,6 +6,7 @@ import org.scottishtecharmy.soundscape.audio.AudioEngine
 import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
 import org.junit.Assert
 import org.junit.Test
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 
 class AudioEngineTest {
 
@@ -60,14 +61,14 @@ class AudioEngineTest {
     fun soundBeacon() {
         val audioEngine = initializeAudioEngine()
 
-        val beacon = audioEngine.createBeacon(1.0, 0.0)
+        val beacon = audioEngine.createBeacon(LngLatAlt(1.0, 0.0))
         moveListener(audioEngine, 4000)
         audioEngine.destroyBeacon(beacon)
 
         audioEngine.createTextToSpeech("Beacon here!")
         moveListener(audioEngine, 4000)
 
-        val beacon3 = audioEngine.createBeacon(1.0, 0.0)
+        val beacon3 = audioEngine.createBeacon(LngLatAlt(1.0, 0.0))
         moveListener(audioEngine, 4000)
         audioEngine.destroyBeacon(beacon3)
 
@@ -85,7 +86,7 @@ class AudioEngineTest {
             Log.d(TAG, "Test beacon type $beaconType")
             audioEngine.setBeaconType(beaconType)
 
-            val beacon = audioEngine.createBeacon(1.0, 0.0)
+            val beacon = audioEngine.createBeacon(LngLatAlt(1.0, 0.0))
             moveListener(audioEngine, 6000)
             audioEngine.destroyBeacon(beacon)
         }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeIntents.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeIntents.kt
@@ -16,6 +16,7 @@ import org.scottishtecharmy.soundscape.database.local.model.Location
 import org.scottishtecharmy.soundscape.database.local.model.RouteData
 import org.scottishtecharmy.soundscape.database.local.model.MarkerData
 import org.scottishtecharmy.soundscape.database.repository.RoutesRepository
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.Navigator
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.home.locationDetails.generateLocationDetailsRoute
@@ -54,8 +55,7 @@ class SoundscapeIntents
                             val ld =
                                 LocationDescription(
                                     addressName = address.getAddressLine(0),
-                                    latitude = address.latitude,
-                                    longitude = address.longitude,
+                                    location = LngLatAlt(address.longitude, address.latitude)
                                 )
                             navigator.navigate(generateLocationDetailsRoute(ld))
                         }
@@ -72,8 +72,7 @@ class SoundscapeIntents
                     val ld =
                         LocationDescription(
                             addressName = address.getAddressLine(0),
-                            latitude = address.latitude,
-                            longitude = address.longitude,
+                            location = LngLatAlt(address.longitude, address.latitude)
                         )
                     navigator.navigate(generateLocationDetailsRoute(ld))
                 }
@@ -193,8 +192,7 @@ class SoundscapeIntents
                             // Switch to Street Preview mode
                             mainActivity.soundscapeServiceConnection.setStreetPreviewMode(
                                 true,
-                                latitude.toDouble(),
-                                longitude.toDouble(),
+                                LngLatAlt(longitude.toDouble(), latitude.toDouble())
                             )
                         } else {
                             try {
@@ -205,8 +203,7 @@ class SoundscapeIntents
                                 val ld =
                                     LocationDescription(
                                         addressName = URLEncoder.encode(uriData, "utf-8"),
-                                        latitude = latitude.toDouble(),
-                                        longitude = longitude.toDouble(),
+                                        location = LngLatAlt(longitude.toDouble(), latitude.toDouble())
                                     )
                                 mainActivity.navigator.navigate(generateLocationDetailsRoute(ld))
                             }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
@@ -38,9 +38,9 @@ class SoundscapeServiceConnection @Inject constructor() {
         return soundscapeService?.streetPreviewFlow
     }
 
-    fun setStreetPreviewMode(on : Boolean, latitude: Double = 0.0, longitude: Double = 0.0) {
+    fun setStreetPreviewMode(on : Boolean, location: LngLatAlt? = null) {
         Log.d(TAG, "setStreetPreviewMode $on")
-        soundscapeService?.setStreetPreviewMode(on, latitude, longitude)
+        soundscapeService?.setStreetPreviewMode(on, location)
     }
 
     fun startRoute(routeName: String) {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/audio/AudioEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/audio/AudioEngine.kt
@@ -2,10 +2,11 @@ package org.scottishtecharmy.soundscape.audio
 
 import android.content.SharedPreferences
 import android.speech.tts.Voice
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import java.util.Locale
 
 interface AudioEngine {
-    fun createBeacon(latitude: Double, longitude: Double) : Long
+    fun createBeacon(location: LngLatAlt) : Long
     fun destroyBeacon(beaconHandle : Long)
     fun createTextToSpeech(text: String, latitude: Double = Double.NaN, longitude: Double = Double.NaN) : Long
     fun createEarcon(asset: String, latitude: Double = Double.NaN, longitude: Double = Double.NaN) : Long

--- a/app/src/main/java/org/scottishtecharmy/soundscape/audio/NativeAudioEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/audio/NativeAudioEngine.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.scottishtecharmy.soundscape.MainActivity
 import org.scottishtecharmy.soundscape.R
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.utils.getCurrentLocale
 import java.util.Locale
 import javax.inject.Inject
@@ -184,12 +185,12 @@ class NativeAudioEngine @Inject constructor(): AudioEngine, TextToSpeech.OnInitL
         }
     }
 
-    override fun createBeacon(latitude: Double, longitude: Double) : Long
+    override fun createBeacon(location: LngLatAlt) : Long
     {
         synchronized(engineMutex) {
             if(engineHandle != 0L) {
                 Log.d(TAG, "Call createNativeBeacon")
-                return createNativeBeacon(engineHandle, latitude, longitude)
+                return createNativeBeacon(engineHandle, location.latitude, location.longitude)
             }
 
             return 0

--- a/app/src/main/java/org/scottishtecharmy/soundscape/components/LocationItem.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/components/LocationItem.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.ui.theme.Foreground2
 import org.scottishtecharmy.soundscape.ui.theme.IntroductionTheme
@@ -100,8 +101,7 @@ fun PreviewSearchItemButton() {
                     addressName = "Bristol",
                     fullAddress = "18 Street \n59000 Lille\nFrance",
                     distance = "17 Km",
-                    latitude = 9.55,
-                    longitude = 8.00,
+                    location = LngLatAlt(8.00, 9.55)
                 )
             LocationItem(
                 item = test,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/database/local/model/RouteData.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/database/local/model/RouteData.kt
@@ -8,6 +8,7 @@ import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.annotations.Ignore
 import io.realm.kotlin.types.annotations.PrimaryKey
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import kotlin.Double.Companion.NaN
 
 class Location : EmbeddedRealmObject {
@@ -40,6 +41,8 @@ class Location : EmbeddedRealmObject {
         set(value) {
             coordinates[0] = value
         }
+
+    fun location(): LngLatAlt { return LngLatAlt(longitude, latitude) }
 }
 
 class RouteData(

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -544,16 +544,8 @@ class GeoEngine {
             }
         }
         if(geocode != null) {
-            var distance = locationProvider.get().distance(LngLatAlt(geocode.longitude, geocode.latitude))
-            if(distance > 1000) {
-                val km = (distance.toInt() / 100).toFloat() / 10
-                geocode.distance =
-                    localizedContext.getString(R.string.distance_format_km, km.toString())
-            } else {
-                val m = distance.toInt()
-                geocode.distance =
-                    localizedContext.getString(R.string.distance_format_meters, m.toString())
-            }
+            val distance = locationProvider.get().distance(geocode.location)
+            geocode.distance = formatDistance(distance, localizedContext)
             return geocode
         }
 
@@ -566,15 +558,11 @@ class GeoEngine {
 
                     // The geocode result includes the location for the POI. In the case of something
                     // like a park this could be a long way from the point that was passed in.
-                    val ld = result?.features?.toLocationDescriptions(
-                        currentLocationLatitude = currentLocation.latitude,
-                        currentLocationLongitude = currentLocation.longitude
-                    )
+                    val ld = result?.features?.toLocationDescriptions(currentLocation, localizedContext)
                     if (!ld.isNullOrEmpty()) {
                         if(preserveLocation) {
                             val overwritten = ld.first()
-                            overwritten.latitude = location.latitude
-                            overwritten.longitude = location.longitude
+                            overwritten.location = location
                             if(overwritten.addressName != null) {
                                 overwritten.addressName = localizedContext.getString(R.string.directions_near_name).format(overwritten.addressName)
                                 overwritten
@@ -680,8 +668,7 @@ fun localReverseGeocode(location: LngLatAlt,
                 if(name != null) {
                     return LocationDescription(
                         addressName = localizedContext.getString(R.string.directions_at_poi).format(name as String),
-                        longitude = location.longitude,
-                        latitude = location.latitude,
+                        location = location,
                     )
                 }
             }
@@ -699,8 +686,7 @@ fun localReverseGeocode(location: LngLatAlt,
             }
             return LocationDescription(
                 addressName = localizedContext.getString(R.string.directions_near_name).format(roadName as String),
-                longitude = location.longitude,
-                latitude = location.latitude
+                location = location,
             )
         }
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geojsonparser/geojson/LngLatAlt.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geojsonparser/geojson/LngLatAlt.kt
@@ -1,6 +1,7 @@
 package org.scottishtecharmy.soundscape.geojsonparser.geojson
 
 import com.squareup.moshi.JsonClass
+import org.maplibre.android.geometry.LatLng
 import org.scottishtecharmy.soundscape.geoengine.utils.distance
 import java.io.Serializable
 
@@ -35,6 +36,10 @@ open class LngLatAlt(
         return "$longitude,$latitude"
     }
 
+    fun toLatLng(): LatLng {
+        return LatLng(latitude, longitude)
+    }
+
     fun distance(other: LngLatAlt): Double {
         return distance(latitude, longitude, other.latitude, other.longitude)
     }
@@ -52,6 +57,8 @@ open class LngLatAlt(
      * Distance to a LineString from current location.
      * @param lineStringCoordinates
      * LineString that we are working out the distance from
+     * @param nearestPoint
+     * Point in the line nearest that had the shortest distance
      * @return The distance of the point to the LineString
      */
     fun distanceToLineString(
@@ -79,4 +86,8 @@ open class LngLatAlt(
         }
         return shortestDistance
     }
+}
+
+fun fromLatLng(loc:LatLng): LngLatAlt {
+    return LngLatAlt(loc.longitude, loc.latitude)
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/GpxDrivenProvider.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/GpxDrivenProvider.kt
@@ -17,7 +17,7 @@ import java.io.InputStream
 
 class GpxDrivenProvider  {
 
-    var locationProvider = StaticLocationProvider(0.0,0.0)
+    var locationProvider = StaticLocationProvider(LngLatAlt())
     var directionProvider = DirectionProvider()
 
     private var parsedGpx: Gpx? = null

--- a/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/StaticLocationProvider.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/StaticLocationProvider.kt
@@ -5,7 +5,7 @@ import android.location.Location
 import android.location.LocationManager
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 
-class StaticLocationProvider(private var latitude: Double, private var longitude: Double) :
+class StaticLocationProvider(private var location: LngLatAlt) :
     LocationProvider() {
 
     override fun destroy() {
@@ -13,20 +13,20 @@ class StaticLocationProvider(private var latitude: Double, private var longitude
 
     override fun start(context : Context){
         // Simply set our flow source as the passed in location with 10m accuracy so that it's not ignored
-        val location = Location(LocationManager.PASSIVE_PROVIDER)
-        location.latitude = latitude
-        location.longitude = longitude
-        location.accuracy = 10.0F
-        mutableLocationFlow.value = location
+        val passiveLocation = Location(LocationManager.PASSIVE_PROVIDER)
+        passiveLocation.latitude = location.latitude
+        passiveLocation.longitude = location.longitude
+        passiveLocation.accuracy = 10.0F
+        mutableLocationFlow.value = passiveLocation
     }
 
     override fun updateLocation(newLocation: LngLatAlt, speed: Float) {
-        val location = Location(LocationManager.PASSIVE_PROVIDER)
-        location.latitude = newLocation.latitude
-        location.longitude = newLocation.longitude
-        location.speed = speed
-        location.accuracy = 10.0F
-        mutableLocationFlow.value = location
+        val passiveLocation = Location(LocationManager.PASSIVE_PROVIDER)
+        passiveLocation.latitude = newLocation.latitude
+        passiveLocation.longitude = newLocation.longitude
+        passiveLocation.speed = speed
+        passiveLocation.accuracy = 10.0F
+        mutableLocationFlow.value = passiveLocation
     }
 
     companion object {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
@@ -58,8 +58,7 @@ fun HomeScreen(
         composable(HomeRoutes.Home.route) {
             val context = LocalContext.current
             Home(
-                latitude = state.value.location?.latitude,
-                longitude = state.value.location?.longitude,
+                location = state.value.location,
                 beaconLocation = state.value.beaconLocation,
                 heading = state.value.heading,
                 onNavigate = { dest -> navController.navigate(dest) },
@@ -137,8 +136,7 @@ fun HomeScreen(
                         }
                     }
                 },
-                latitude = state.value.location?.latitude,
-                longitude = state.value.location?.longitude,
+                location = state.value.location,
                 navController = navController,
                 heading = state.value.heading,
                 modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing),

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/data/LocationDescription.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/data/LocationDescription.kt
@@ -1,11 +1,12 @@
 package org.scottishtecharmy.soundscape.screens.home.data
 
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+
 data class LocationDescription(
     var addressName: String? = null,
     val fullAddress: String? = null,
     val country: String? = null,
     var distance: String? = null,
-    var latitude: Double = Double.NaN,
-    var longitude: Double = Double.NaN,
+    var location: LngLatAlt = LngLatAlt(),
     val marker: Boolean = false
 )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
@@ -34,6 +34,7 @@ import org.scottishtecharmy.soundscape.MainActivity
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.components.MainSearchBar
 import org.scottishtecharmy.soundscape.geoengine.StreetPreviewState
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.DrawerContent
 import org.scottishtecharmy.soundscape.screens.home.HomeRoutes
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
@@ -45,8 +46,7 @@ import org.scottishtecharmy.soundscape.ui.theme.OnPrimary
 @Composable
 fun HomePreview() {
     Home(
-        latitude = null,
-        longitude = null,
+        location = null,
         beaconLocation = null,
         heading = 0.0f,
         onNavigate = {},
@@ -72,9 +72,8 @@ fun HomePreview() {
 
 @Composable
 fun Home(
-    latitude: Double?,
-    longitude: Double?,
-    beaconLocation: LatLng?,
+    location: LngLatAlt?,
+    beaconLocation: LngLatAlt?,
     heading: Float,
     onNavigate: (String) -> Unit,
     onMapLongClick: (LatLng) -> Boolean,
@@ -131,8 +130,7 @@ fun Home(
             contentWindowInsets = WindowInsets(0, 0, 0, 0),
         ) { innerPadding ->
             HomeContent(
-                latitude = latitude,
-                longitude = longitude,
+                location = location,
                 beaconLocation = beaconLocation,
                 heading = heading,
                 modifier = Modifier.padding(innerPadding),

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
@@ -12,15 +12,15 @@ import org.maplibre.android.geometry.LatLng
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.components.NavigationButton
 import org.scottishtecharmy.soundscape.geoengine.StreetPreviewState
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.HomeRoutes
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.home.locationDetails.generateLocationDetailsRoute
 
 @Composable
 fun HomeContent(
-    latitude: Double?,
-    longitude: Double?,
-    beaconLocation: LatLng?,
+    location: LngLatAlt?,
+    beaconLocation: LngLatAlt?,
     heading: Float,
     onNavigate: (String) -> Unit,
     onMapLongClick: (LatLng) -> Boolean,
@@ -38,8 +38,7 @@ fun HomeContent(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         if(streetPreviewState.enabled) {
-            if(latitude != null && longitude != null)
-                StreetPreview(streetPreviewState, heading, streetPreviewGo, streetPreviewExit)
+            StreetPreview(streetPreviewState, heading, streetPreviewGo, streetPreviewExit)
         } else {
             searchBar()
 
@@ -55,8 +54,7 @@ fun HomeContent(
                         val ld =
                             LocationDescription(
                                 addressName = "Barrowland Ballroom",
-                                latitude = 55.8552688,
-                                longitude = -4.2366753,
+                                location = LngLatAlt(-4.2366753, 55.8552688)
                             )
                         onNavigate(generateLocationDetailsRoute(ld))
                     },
@@ -72,7 +70,7 @@ fun HomeContent(
                 // Current location
                 NavigationButton(
                     onClick = {
-                        if (latitude != null && longitude != null) {
+                        if (location != null) {
                             val ld = getCurrentLocationDescription()
                             onNavigate(generateLocationDetailsRoute(ld))
                         }
@@ -81,13 +79,13 @@ fun HomeContent(
                 )
             }
         }
-        if (latitude != null && longitude != null) {
+        if (location != null) {
             MapContainerLibre(
                 beaconLocation = beaconLocation,
-                mapCenter = LatLng(latitude, longitude),
+                mapCenter = location,
                 allowScrolling = false,
                 mapViewRotation = 0.0F,
-                userLocation = LatLng(latitude, longitude),
+                userLocation = location,
                 userSymbolRotation = heading,
                 onMapLongClick = onMapLongClick,
                 onMarkerClick = onMarkerClick,
@@ -101,8 +99,7 @@ fun HomeContent(
 @Composable
 fun StreetPreviewHomeContent() {
     HomeContent(
-        latitude = null,
-        longitude = null,
+        location = null,
         beaconLocation = null,
         heading = 0.0f,
         onNavigate = {},
@@ -121,8 +118,7 @@ fun StreetPreviewHomeContent() {
 @Composable
 fun PreviewHomeContent() {
     HomeContent(
-        latitude = null,
-        longitude = null,
+        location = null,
         beaconLocation = null,
         heading = 0.0f,
         onNavigate = {},

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
@@ -30,6 +30,7 @@ import org.maplibre.android.style.sources.GeoJsonSource
 import org.maplibre.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.BuildConfig
 import org.scottishtecharmy.soundscape.R
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import java.io.File
 
 const val USER_POSITION_MARKER_NAME = "USER_POSITION_MARKER_NAME"
@@ -47,12 +48,12 @@ const val USER_POSITION_MARKER_NAME = "USER_POSITION_MARKER_NAME"
  */
 @Composable
 fun MapContainerLibre(
-    mapCenter: LatLng,
+    mapCenter: LngLatAlt,
     allowScrolling: Boolean,
     mapViewRotation: Float,
-    userLocation: LatLng,
+    userLocation: LngLatAlt,
     userSymbolRotation: Float,
-    beaconLocation: LatLng?,
+    beaconLocation: LngLatAlt?,
     modifier: Modifier = Modifier,
     onMapLongClick: (LatLng) -> Boolean,
     onMarkerClick: (Marker) -> Boolean,
@@ -64,13 +65,13 @@ fun MapContainerLibre(
         // been disallowed
         val cp = CameraPosition.Builder().bearing(mapViewRotation.toDouble())
         if(!allowScrolling)
-            cp.target(mapCenter)
+            cp.target(mapCenter.toLatLng())
         cp.build()
     }
 
     val symbolOptions = remember(userLocation, userSymbolRotation) {
         SymbolOptions()
-            .withLatLng(userLocation)
+            .withLatLng(userLocation.toLatLng())
             .withIconImage(USER_POSITION_MARKER_NAME)
             .withIconAnchor("center")
             .withIconRotate(userSymbolRotation)
@@ -157,7 +158,7 @@ fun MapContainerLibre(
             }
 
             mapLibre.cameraPosition = CameraPosition.Builder()
-                .target(mapCenter)
+                .target(mapCenter.toLatLng())
                 .zoom(15.0) // we set the zoom only at init
                 .bearing(mapViewRotation.toDouble())
                 .build()
@@ -169,7 +170,7 @@ fun MapContainerLibre(
             if (beaconLocation != null && beaconLocationMarker.value == null) {
                 // first time beacon is created
                 val markerOptions = MarkerOptions()
-                    .position(beaconLocation)
+                    .position(beaconLocation.toLatLng())
                 beaconLocationMarker.value = mapLibre.addMarker(markerOptions)
             }
         }
@@ -185,7 +186,7 @@ fun MapContainerLibre(
                     mapLibre.cameraPosition = cameraPosition
                     symbol.value?.let { sym ->
                         // We have a symbol, so update it
-                        sym.latLng = userLocation
+                        sym.latLng = userLocation.toLatLng()
                         sym.iconRotate = userSymbolRotation
                         symbolManager.value?.update(sym)
                     }
@@ -194,13 +195,13 @@ fun MapContainerLibre(
                         // beacon to display
                         beaconLocationMarker.value?.let { currentBeaconMarker ->
                             // update beacon position
-                            currentBeaconMarker.position = beaconLocation
+                            currentBeaconMarker.position = beaconLocation.toLatLng()
                             mapLibre.updateMarker(currentBeaconMarker)
                         } ?: {
                             // new beacon to display
                             val markerOptions =
                                 MarkerOptions()
-                                    .position(beaconLocation)
+                                    .position(beaconLocation.toLatLng())
                             beaconLocationMarker.value = mapLibre.addMarker(markerOptions)
                         }
                     } else {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/markersscreen/MarkersScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/markersscreen/MarkersScreen.kt
@@ -32,6 +32,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import org.scottishtecharmy.soundscape.R
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.markers_routes.components.MarkersAndRoutesListSort
 import org.scottishtecharmy.soundscape.ui.theme.SoundscapeTheme
@@ -167,8 +168,7 @@ fun MarkersScreenPopulatedPreview() {
                             LocationDescription(
                                 "Waypoint 1",
                                 "Street Blabla, Blabla City",
-                                latitude = Double.NaN,
-                                longitude = Double.NaN,
+                                location = LngLatAlt(),
                                 distance = "2 km",
                             ),
                         ),

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/markersscreen/MarkersScreenList.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/markersscreen/MarkersScreenList.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import org.scottishtecharmy.soundscape.components.LocationItem
-import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.home.locationDetails.generateLocationDetailsRoute
 import org.scottishtecharmy.soundscape.screens.markers_routes.navigation.ScreensForMarkersAndRoutes
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/audiobeacons/AudioBeaconsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/audiobeacons/AudioBeaconsViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.scottishtecharmy.soundscape.MainActivity
 import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import javax.inject.Inject
 
 @HiltViewModel
@@ -36,7 +37,7 @@ class AudioBeaconsViewModel @Inject constructor(@ApplicationContext val context:
         audioEngine.setBeaconType(type)
         if(beacon != 0L)
             audioEngine.destroyBeacon(beacon)
-        beacon = audioEngine.createBeacon(1.0, 0.0)
+        beacon = audioEngine.createBeacon(LngLatAlt(1.0, 0.0))
         _state.value = state.value.copy(selectedBeacon = type)
         // Store the preference for future use
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/RoutePlayer.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/RoutePlayer.kt
@@ -11,6 +11,7 @@ import org.scottishtecharmy.soundscape.database.local.dao.RoutesDao
 import org.scottishtecharmy.soundscape.database.local.model.RouteData
 import org.scottishtecharmy.soundscape.database.repository.RoutesRepository
 import org.scottishtecharmy.soundscape.geoengine.utils.distance
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 
 class RoutePlayer(val service: SoundscapeService) {
     private var currentRouteData: RouteData? = null
@@ -59,7 +60,7 @@ class RoutePlayer(val service: SoundscapeService) {
             service.audioEngine.clearTextToSpeechQueue()
             service.audioEngine.createTextToSpeech("Move to marker ${index+1}, ${route.waypoints[index].addressName}", location.latitude, location.longitude)
 
-            service.createBeacon(location.latitude, location.longitude)
+            service.createBeacon(LngLatAlt(location.latitude, location.longitude))
 }
     }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -112,14 +112,16 @@ class SoundscapeService : MediaSessionService() {
         return binder!!
     }
 
-    fun setStreetPreviewMode(on: Boolean, latitude: Double, longitude: Double) {
+    fun setStreetPreviewMode(on: Boolean, location: LngLatAlt?) {
         directionProvider.destroy()
         locationProvider.destroy()
         geoEngine.stop()
         if (on) {
             // Use static location, but phone's direction
-            locationProvider = StaticLocationProvider(latitude, longitude)
-            directionProvider = AndroidDirectionProvider(this)
+            if(location != null) {
+                locationProvider = StaticLocationProvider(location)
+                directionProvider = AndroidDirectionProvider(this)
+            }
         } else {
             // Switch back to phone's location and direction
             locationProvider = AndroidLocationProvider(this)
@@ -317,13 +319,15 @@ class SoundscapeService : MediaSessionService() {
             Realm.deleteRealm(config)
         }*/
 
-    fun createBeacon(latitude: Double, longitude: Double) {
+    fun createBeacon(location: LngLatAlt?) {
+        if(location == null) return
+
         if (audioBeacon != 0L) {
             audioEngine.destroyBeacon(audioBeacon)
         }
-        audioBeacon = audioEngine.createBeacon(latitude, longitude)
+        audioBeacon = audioEngine.createBeacon(location)
         // Report any change in beacon back to application
-        _beaconFlow.value = LngLatAlt(longitude, latitude)
+        _beaconFlow.value = location
     }
 
     fun destroyBeacon() {
@@ -410,7 +414,7 @@ class SoundscapeService : MediaSessionService() {
 
     /**
      * streetPreviewGo is called when the 'GO' button is pressed when in StreetPreview mode.
-     * It indicates that the user has selected the direction of travel in which they wich to move.
+     * It indicates that the user has selected the direction of travel in which they which to move.
      */
     fun streetPreviewGo() {
         _streetPreviewFlow.value = StreetPreviewState(true, geoEngine.streetPreviewGo())

--- a/app/src/main/java/org/scottishtecharmy/soundscape/utils/LocationExt.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/utils/LocationExt.kt
@@ -1,14 +1,15 @@
 package org.scottishtecharmy.soundscape.utils
 
-import android.location.Location
+import android.content.Context
+import org.scottishtecharmy.soundscape.geoengine.formatDistance
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
-import java.util.Locale
 
 fun ArrayList<Feature>.toLocationDescriptions(
-    currentLocationLatitude: Double,
-    currentLocationLongitude: Double,
+    currentLocation: LngLatAlt,
+    localizedContext: Context
 ): List<LocationDescription> =
     mapNotNull { feature ->
         feature.properties?.let { properties ->
@@ -30,15 +31,10 @@ fun ArrayList<Feature>.toLocationDescriptions(
                 fullAddress = fullAddress,
                 distance =
                     formatDistance(
-                        calculateDistance(
-                            lat1 = currentLocationLatitude,
-                            lon1 = currentLocationLongitude,
-                            lat2 = (feature.geometry as Point).coordinates.latitude,
-                            lon2 = (feature.geometry as Point).coordinates.longitude,
-                        ),
+                        currentLocation.distance((feature.geometry as Point).coordinates),
+                        localizedContext
                     ),
-                latitude = (feature.geometry as Point).coordinates.latitude,
-                longitude = (feature.geometry as Point).coordinates.longitude,
+                location = (feature.geometry as Point).coordinates,
             )
         }
     }
@@ -58,37 +54,4 @@ fun buildAddressFormat(
         addressFormat.isEmpty() -> null
         else -> addressFormat.joinToString("\n")
     }
-}
-
-private fun calculateDistance(
-    lat1: Double,
-    lon1: Double,
-    lat2: Double,
-    lon2: Double,
-): Float {
-    val results = FloatArray(1)
-    Location.distanceBetween(lat1, lon1, lat2, lon2, results)
-    return results[0]
-}
-
-private fun formatDistance(distanceInMeters: Float): String {
-    val distanceInKm = distanceInMeters / 1000
-    return String.format(Locale.getDefault(), "%.1f km", distanceInKm)
-}
-
-fun Location.calculateDistanceTo(
-    lat: Double,
-    lon: Double,
-): String {
-    val results = FloatArray(1)
-    Location.distanceBetween(
-        this.latitude,
-        this.longitude,
-        lat,
-        lon,
-        results,
-    )
-    val distanceInMeters = results[0]
-    val distanceInKm = distanceInMeters / 1000
-    return String.format(Locale.getDefault(), "%.1f km", distanceInKm)
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
@@ -19,18 +19,13 @@ class LocationDetailsViewModel @Inject constructor(
     private val routesRepository: RoutesRepository
 ): ViewModel() {
 
-    fun createBeacon(
-        latitude: Double,
-        longitude: Double,
-    ) {
-        soundscapeServiceConnection.soundscapeService?.createBeacon(latitude, longitude)
+    fun createBeacon(location: LngLatAlt) {
+        soundscapeServiceConnection.soundscapeService?.createBeacon(location)
     }
 
-    fun enableStreetPreview(
-        latitude: Double,
-        longitude: Double,
-    ) {
-        soundscapeServiceConnection.setStreetPreviewMode(true, latitude, longitude)
+    fun enableStreetPreview(location: LngLatAlt) {
+        soundscapeServiceConnection.setStreetPreviewMode(true, location)
+
     }
 
     fun createMarker(locationDescription: LocationDescription) {
@@ -42,7 +37,7 @@ class LocationDetailsViewModel @Inject constructor(
                 MarkerData(
                     addressName = name,
                     fullAddress = locationDescription.fullAddress ?: "", // TODO Fanny is it possible to get no full address ?
-                    location = Location(latitude = locationDescription.latitude, longitude = locationDescription.longitude),
+                    location = Location(latitude = locationDescription.location.latitude, longitude = locationDescription.location.longitude),
                 )
             try {
                 routesRepository.insertWaypoint(marker)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeState.kt
@@ -2,12 +2,13 @@ package org.scottishtecharmy.soundscape.viewmodels.home
 
 import org.maplibre.android.geometry.LatLng
 import org.scottishtecharmy.soundscape.geoengine.StreetPreviewState
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 
 data class HomeState(
     var heading: Float = 0.0f,
-    var location: LatLng? = null,
-    var beaconLocation: LatLng? = null,
+    var location: LngLatAlt? = null,
+    var beaconLocation: LngLatAlt? = null,
     var streetPreviewState: StreetPreviewState = StreetPreviewState(false),
     var tileGridGeoJson: String = "",
     var isSearching: Boolean = false,


### PR DESCRIPTION
There were too many pairs of longitude and latitude doubles being passed around in the UI instead of using the data class LngLatAlt. This commit sorts this out.