### PR TITLE
Earcon audio positioning fixes

### DIFF
--- a/app/src/androidTest/java/org/scottishtecharmy/soundscape/AudioEngineTest.kt
+++ b/app/src/androidTest/java/org/scottishtecharmy/soundscape/AudioEngineTest.kt
@@ -170,6 +170,18 @@ class AudioEngineTest {
 //        tidyUp(audioEngine)
 //    }
 
+    @Test
+    fun earconPosition() {
+        val audioEngine = initializeAudioEngine()
+
+        audioEngine.updateGeometry(1.0, 1.0, 0.0)
+        audioEngine.createEarcon(NativeAudioEngine.Companion.EARCON_SENSE_POI, 1.0, 2.0)
+        Thread.sleep(3000)
+
+        tidyUp(audioEngine)
+    }
+
+
     companion object {
         const val TAG : String = "AudioTestEngine"
         init {

--- a/app/src/main/cpp/AudioBeacon.cpp
+++ b/app/src/main/cpp/AudioBeacon.cpp
@@ -41,20 +41,22 @@ void PositionedAudio::InitFmodSound() {
                                            5000.0f * FMOD_DISTANCE_FACTOR);
     ERROR_CHECK(result);
 
-    result = m_pSound->setMode(FMOD_LOOP_NORMAL);
-    ERROR_CHECK(result);
-
     {
-        result = m_pSystem->playSound(m_pSound, nullptr, false, &m_pChannel);
+        // Create paused sound channel
+        result = m_pSystem->playSound(m_pSound, nullptr, true, &m_pChannel);
         ERROR_CHECK(result);
 
+        // Adjust position of channel in 3D space
         if(!isnan(m_Latitude) && !isnan(m_Longitude)) {
             // Only set the 3D position if the latitude and longitude are valid
             FMOD_VECTOR pos =m_pEngine->TranslateToFmodVector(m_Longitude, m_Latitude);
             FMOD_VECTOR vel = {0.0f, 0.0f, 0.0f};
             result = m_pChannel->set3DAttributes(&pos, &vel);
         }
+        ERROR_CHECK(result);
 
+        // Start the channel playing
+        result = m_pChannel->setPaused(false);
         ERROR_CHECK(result);
     }
 }

--- a/app/src/main/cpp/AudioBeaconBuffer.cpp
+++ b/app/src/main/cpp/AudioBeaconBuffer.cpp
@@ -173,7 +173,7 @@ void TtsAudioSource::CreateSound(FMOD::System *system, FMOD::Sound **sound)
     extra_info.userdata = this;
 
     auto result = system->createSound(nullptr,
-                                      FMOD_OPENUSER | FMOD_LOOP_OFF | FMOD_3D |
+                                      FMOD_OPENUSER | FMOD_LOOP_NORMAL | FMOD_3D |
                                       FMOD_CREATESTREAM,
                                       &extra_info,
                                       sound);
@@ -256,23 +256,23 @@ EarconSource::EarconSource(PositionedAudio *parent, std::string &asset)
 {
 }
 
-
-EarconSource::~EarconSource()
-{
-    m_pSound->release();
-}
-
-void EarconSource::CreateSound(FMOD::System *system, FMOD::Sound **sound)
-{
-    auto result = system->createSound(m_Asset.c_str(), FMOD_DEFAULT, nullptr, &m_pSound);
+void EarconSource::CreateSound(FMOD::System *system, FMOD::Sound **sound) {
+    auto result = system->createSound(
+            m_Asset.c_str(),
+            FMOD_DEFAULT | FMOD_3D,
+            nullptr,
+            sound);
     ERROR_CHECK(result);
-    system->playSound(m_pSound, nullptr, false, nullptr);
+    // Remember sound for checking for completion
+    m_pSound = *sound;
 }
 
 void EarconSource::UpdateGeometry(double degrees_off_axis)
 {
-    FMOD_OPENSTATE state;
-    m_pSound->getOpenState(&state, nullptr, nullptr, nullptr);
-    if(state == FMOD_OPENSTATE_READY)
-        m_pParent->Eof();
+    if(m_pSound != nullptr) {
+        FMOD_OPENSTATE state;
+        m_pSound->getOpenState(&state, nullptr, nullptr, nullptr);
+        if (state == FMOD_OPENSTATE_READY)
+            m_pParent->Eof();
+    }
 }

--- a/app/src/main/cpp/AudioBeaconBuffer.h
+++ b/app/src/main/cpp/AudioBeaconBuffer.h
@@ -93,8 +93,7 @@ namespace soundscape {
     class EarconSource : public BeaconAudioSource {
     public:
         EarconSource(PositionedAudio *parent, std::string &asset);
-
-        ~EarconSource() override;
+        ~EarconSource() override = default;
 
         void CreateSound(FMOD::System *system, FMOD::Sound **sound) override;
         void UpdateGeometry(double degrees_off_axis) override;


### PR DESCRIPTION
The Earcon code was a bit confused and resulted in audio positioning not working. This change makes EarconSource operate in the same was as BeaconBuffer and TextToSpeechSource. It creates the sound in FMOD and then leaves the rest up to PositionedAudio::InitFmodSound. The only additional work that EarconSource has to do, is that it has to monitor for the playback completing so that it can mark the Earcon as EOF.
The other minor change is to start all audio paused, then set its position, and then take it out of pause to start playing.