### PR TITLE
StreetPreview UI change to allow for TileGrid update

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -164,10 +164,16 @@ class GeoEngine {
                 newLocation?.let { location ->
 
                     // Update the grid state
-                    gridState.locationUpdate(
+                    val updated = gridState.locationUpdate(
                         LngLatAlt(location.longitude, location.latitude),
                         createSuperCategoriesSet()
                     )
+
+                    if(updated) {
+                        // The grid updated, if we're in StreetPreview and were initializing, the
+                        // service needs to update the state to ON.
+                        soundscapeService.tileGridUpdated()
+                    }
 
                     // So long as the AudioEngine is not already busy, run any auto callouts that we
                     // need. Auto Callouts use the direction of travel if there is one, otherwise

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
@@ -73,7 +73,7 @@ open class GridState {
      * The tile grid service is called each time the location changes. It checks if the location
      * has moved away from the center of the current tile grid and if it has calculates a new grid.
      */
-    suspend fun locationUpdate(location: LngLatAlt, enabledCategories: Set<String>) {
+    suspend fun locationUpdate(location: LngLatAlt, enabledCategories: Set<String>) : Boolean {
         val timeSource = TimeSource.Monotonic
         val gridStartTime = timeSource.markNow()
 
@@ -114,12 +114,15 @@ open class GridState {
                 val gridFinishTime = timeSource.markNow()
                 Log.e(TAG, "Time to populate grid: ${gridFinishTime - gridStartTime}")
 
+                return true
             } else {
                 // Updating the tile grid failed, due to a lack of cached tile and then
                 // a lack of network/server issue. There's nothing that we can do, so
                 // simply retry on the next location update.
+                return false
             }
         }
+        return true
     }
 
     private suspend fun updateTileGrid(

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/StreetPreview.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/StreetPreview.kt
@@ -19,8 +19,11 @@ data class StreetPreviewChoice(
     val route: List<LngLatAlt>
 )
 
+enum class StreetPreviewEnabled {
+    OFF, INITIALIZING, ON
+}
 data class StreetPreviewState(
-    val enabled: Boolean = false,
+    val enabled: StreetPreviewEnabled = StreetPreviewEnabled.OFF,
     val choices: List<StreetPreviewChoice> = emptyList()
 )
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
@@ -33,6 +33,7 @@ import org.maplibre.android.geometry.LatLng
 import org.scottishtecharmy.soundscape.MainActivity
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.components.MainSearchBar
+import org.scottishtecharmy.soundscape.geoengine.StreetPreviewEnabled
 import org.scottishtecharmy.soundscape.geoengine.StreetPreviewState
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.DrawerContent
@@ -58,7 +59,7 @@ fun HomePreview() {
         getCurrentLocationDescription = { LocationDescription() },
         shareLocation = {},
         rateSoundscape = {},
-        streetPreviewState = StreetPreviewState(false),
+        streetPreviewState = StreetPreviewState(StreetPreviewEnabled.OFF),
         streetPreviewExit = {},
         streetPreviewGo = {},
         tileGridGeoJson = "",

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
@@ -11,6 +11,7 @@ import org.maplibre.android.annotations.Marker
 import org.maplibre.android.geometry.LatLng
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.components.NavigationButton
+import org.scottishtecharmy.soundscape.geoengine.StreetPreviewEnabled
 import org.scottishtecharmy.soundscape.geoengine.StreetPreviewState
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.HomeRoutes
@@ -37,7 +38,7 @@ fun HomeContent(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        if(streetPreviewState.enabled) {
+        if(streetPreviewState.enabled != StreetPreviewEnabled.OFF) {
             StreetPreview(streetPreviewState, heading, streetPreviewGo, streetPreviewExit)
         } else {
             searchBar()
@@ -107,7 +108,7 @@ fun StreetPreviewHomeContent() {
         onMarkerClick = { true },
         searchBar = {},
         tileGridGeoJson = "",
-        streetPreviewState = StreetPreviewState(true),
+        streetPreviewState = StreetPreviewState(StreetPreviewEnabled.ON),
         streetPreviewGo = {},
         streetPreviewExit = {},
         getCurrentLocationDescription = { LocationDescription() }
@@ -126,7 +127,7 @@ fun PreviewHomeContent() {
         onMarkerClick = { true },
         searchBar = {},
         tileGridGeoJson = "",
-        streetPreviewState = StreetPreviewState(false),
+        streetPreviewState = StreetPreviewState(StreetPreviewEnabled.OFF),
         streetPreviewGo = {},
         streetPreviewExit = {},
         getCurrentLocationDescription = { LocationDescription() }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/StreetPreviewUi.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/StreetPreviewUi.kt
@@ -1,8 +1,14 @@
 package org.scottishtecharmy.soundscape.screens.home.home
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.components.NavigationButton
+import org.scottishtecharmy.soundscape.geoengine.StreetPreviewEnabled
 import org.scottishtecharmy.soundscape.geoengine.StreetPreviewState
 import org.scottishtecharmy.soundscape.geoengine.utils.calculateHeadingOffset
 
@@ -13,57 +19,62 @@ fun StreetPreview(
     go: () -> Unit,
     exit: () -> Unit
 ) {
-    // Find best match
-    var bestChoice = -1
-    var bestHeading = Double.POSITIVE_INFINITY
-    val roads = emptySet<String>().toMutableSet()
-    for((index, choice) in state.choices.withIndex()) {
-        val headingDelta = calculateHeadingOffset(choice.heading, heading.toDouble())
-        if(headingDelta < bestHeading){
-            bestHeading = headingDelta
-            bestChoice = index
+    if(state.enabled == StreetPreviewEnabled.INITIALIZING) {
+        Text(text = stringResource(R.string.general_loading_start),
+            Modifier.padding(20.dp))
+    } else {
+        // Find best match
+        var bestChoice = -1
+        var bestHeading = Double.POSITIVE_INFINITY
+        val roads = emptySet<String>().toMutableSet()
+        for ((index, choice) in state.choices.withIndex()) {
+            val headingDelta = calculateHeadingOffset(choice.heading, heading.toDouble())
+            if (headingDelta < bestHeading) {
+                bestHeading = headingDelta
+                bestChoice = index
+            }
+            roads.add(choice.name)
         }
-        roads.add(choice.name)
-    }
 
-    // Create intersection description
-    var intersectionText = ""
-    var lastName: String? = null
-    for(road in roads) {
-        if(lastName != null) {
-            if(intersectionText.isNotEmpty()) intersectionText += ", "
-            intersectionText += "$lastName"
+        // Create intersection description
+        var intersectionText = ""
+        var lastName: String? = null
+        for (road in roads) {
+            if (lastName != null) {
+                if (intersectionText.isNotEmpty()) intersectionText += ", "
+                intersectionText += "$lastName"
+            }
+            lastName = road
         }
-        lastName = road
-    }
-    if(lastName != null) {
-        if (intersectionText.isEmpty()) {
-            intersectionText = lastName
+        if (lastName != null) {
+            if (intersectionText.isEmpty()) {
+                intersectionText = lastName
+            } else {
+                intersectionText += " and $lastName"
+            }
         }
-        else {
-            intersectionText += " and $lastName"
-        }
-    }
-    // TODO: Internationalization
-    var text = "Go"
-    if(bestChoice != -1) {
-        text += " - " + state.choices[bestChoice].name
-    }
 
-    // TODO: Internationalization
-    Text(text = "At $intersectionText")
-
-    NavigationButton(
-        onClick = {
-            go()
-        },
-        text = text
-    )
-    NavigationButton(
-        onClick = {
-            exit()
-        },
+        var text = stringResource(R.string.preview_go_title)
         // TODO: Internationalization
-        text = "Exit street preview"
-    )
+        text += if (bestChoice != -1) " - " + state.choices[bestChoice].name
+        else " to nearest intersection"
+
+        // TODO: Internationalization
+        if (intersectionText.isNotEmpty()) {
+            Text(text = "At $intersectionText")
+        }
+        NavigationButton(
+            onClick = {
+                go()
+            },
+            text = text
+        )
+        NavigationButton(
+            onClick = {
+                exit()
+            },
+            // TODO: Internationalization
+            text = "Exit street preview"
+        )
+    }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeState.kt
@@ -1,6 +1,7 @@
 package org.scottishtecharmy.soundscape.viewmodels.home
 
 import org.maplibre.android.geometry.LatLng
+import org.scottishtecharmy.soundscape.geoengine.StreetPreviewEnabled
 import org.scottishtecharmy.soundscape.geoengine.StreetPreviewState
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
@@ -9,7 +10,7 @@ data class HomeState(
     var heading: Float = 0.0f,
     var location: LngLatAlt? = null,
     var beaconLocation: LngLatAlt? = null,
-    var streetPreviewState: StreetPreviewState = StreetPreviewState(false),
+    var streetPreviewState: StreetPreviewState = StreetPreviewState(StreetPreviewEnabled.OFF),
     var tileGridGeoJson: String = "",
     var isSearching: Boolean = false,
     var searchItems: List<LocationDescription>? = null,


### PR DESCRIPTION
Prior to this change, trying to use StreetPreview to a far away location
was broken and would jump to the edge of the current TileGrid instead. This
change causes the UI to wait for the new TileGrid to be uploaded before
jumping to the nearest road and providing a choice for the user.