### PR TITLE
Fix Preview to skip MapContainerLibre

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
@@ -41,35 +41,7 @@ import org.scottishtecharmy.soundscape.screens.home.HomeRoutes
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.home.locationDetails.generateLocationDetailsRoute
 import org.scottishtecharmy.soundscape.ui.theme.OnPrimary
-
-@Preview(device = "spec:parent=pixel_5,orientation=landscape", showBackground = true)
-@Preview(showBackground = true)
-@Composable
-fun HomePreview() {
-    Home(
-        location = null,
-        beaconLocation = null,
-        heading = 0.0f,
-        onNavigate = {},
-        onMapLongClick = { false },
-        onMarkerClick = { true },
-        getMyLocation = {},
-        getWhatsAroundMe = {},
-        getWhatsAheadOfMe = {},
-        getCurrentLocationDescription = { LocationDescription() },
-        shareLocation = {},
-        rateSoundscape = {},
-        streetPreviewState = StreetPreviewState(StreetPreviewEnabled.OFF),
-        streetPreviewExit = {},
-        streetPreviewGo = {},
-        tileGridGeoJson = "",
-        searchText = "Lille",
-        isSearching = true,
-        onSearchTextChange = {},
-        onToggleSearch = {},
-        searchItems = emptyList(),
-    )
-}
+import org.scottishtecharmy.soundscape.ui.theme.SoundscapeTheme
 
 @Composable
 fun Home(
@@ -209,4 +181,86 @@ fun HomeTopAppBar(
             }
         },
     )
+}
+
+
+@Preview(device = "spec:parent=pixel_5,orientation=landscape", showBackground = true)
+@Preview(showBackground = true)
+@Composable
+fun HomePreview() {
+    SoundscapeTheme {
+        Home(
+            location = null,
+            beaconLocation = null,
+            heading = 0.0f,
+            onNavigate = {},
+            onMapLongClick = { false },
+            onMarkerClick = { true },
+            getMyLocation = {},
+            getWhatsAroundMe = {},
+            getWhatsAheadOfMe = {},
+            getCurrentLocationDescription = { LocationDescription() },
+            shareLocation = {},
+            rateSoundscape = {},
+            streetPreviewState = StreetPreviewState(StreetPreviewEnabled.OFF),
+            streetPreviewExit = {},
+            streetPreviewGo = {},
+            tileGridGeoJson = "",
+            searchText = "Lille",
+            isSearching = false,
+            onSearchTextChange = {},
+            onToggleSearch = {},
+            searchItems = emptyList(),
+        )
+    }
+}
+
+@Preview(device = "spec:parent=pixel_5,orientation=landscape", showBackground = true)
+@Preview(showBackground = true)
+@Composable
+fun HomeSearchPreview() {
+    SoundscapeTheme {
+        Home(
+            location = null,
+            beaconLocation = null,
+            heading = 0.0f,
+            onNavigate = {},
+            onMapLongClick = { false },
+            onMarkerClick = { true },
+            getMyLocation = {},
+            getWhatsAroundMe = {},
+            getWhatsAheadOfMe = {},
+            getCurrentLocationDescription = { LocationDescription() },
+            shareLocation = {},
+            rateSoundscape = {},
+            streetPreviewState = StreetPreviewState(StreetPreviewEnabled.OFF),
+            streetPreviewExit = {},
+            streetPreviewGo = {},
+            tileGridGeoJson = "",
+            searchText = "Lille",
+            isSearching = true,
+            onSearchTextChange = {},
+            onToggleSearch = {},
+            searchItems = listOf(
+                LocationDescription(
+                    addressName = "Barrowland Ballroom",
+                    fullAddress = "Somewhere in Glasgow",
+                    distance = "10 km",
+                    location = LngLatAlt(-4.2366753, 55.8552688)
+                ),
+                LocationDescription(
+                    addressName = "King Tut's Wah Wah Hut",
+                    fullAddress = "Somewhere else in Glasgow",
+                    distance = "999 metres",
+                    location = LngLatAlt(-4.2649646, 55.8626180)
+                ),
+                LocationDescription(
+                    addressName = "St. Lukes and the Winged Ox",
+                    fullAddress = "Where else?",
+                    distance = "12km",
+                    location = LngLatAlt( -4.2347580, 55.8546320)
+                )
+            )
+        )
+    }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.res.ResourcesCompat
 import kotlinx.coroutines.launch
@@ -59,192 +60,196 @@ fun MapContainerLibre(
     onMarkerClick: (Marker) -> Boolean,
     tileGridGeoJson: String
 ) {
-    val cameraPosition = remember(mapCenter, mapViewRotation, allowScrolling) {
+    // We don't run the map code when in a Preview as it does not render
+    if(!LocalInspectionMode.current) {
+        val cameraPosition = remember(mapCenter, mapViewRotation, allowScrolling) {
 
-        // We always use the mapViewRotation, but we only recenter the map if scrolling has
-        // been disallowed
-        val cp = CameraPosition.Builder().bearing(mapViewRotation.toDouble())
-        if(!allowScrolling)
-            cp.target(mapCenter.toLatLng())
-        cp.build()
-    }
-
-    val symbolOptions = remember(userLocation, userSymbolRotation) {
-        SymbolOptions()
-            .withLatLng(userLocation.toLatLng())
-            .withIconImage(USER_POSITION_MARKER_NAME)
-            .withIconAnchor("center")
-            .withIconRotate(userSymbolRotation)
-    }
-
-    val beaconLocationMarker = remember { mutableStateOf<Marker?>(null) }
-    val symbol = remember { mutableStateOf<Symbol?>(null) }
-    val symbolManager = remember { mutableStateOf<SymbolManager?>(null) }
-    val filesDir = LocalContext.current.filesDir.toString()
-    var lastTileGridGeoJson by remember { mutableStateOf(tileGridGeoJson)}
-
-    val res = LocalContext.current.resources
-    val drawable = remember {
-        ResourcesCompat.getDrawable(
-            res,
-            R.drawable.navigation,
-            null
-        )
-    }
-    val coroutineScope = rememberCoroutineScope()
-    val map = rememberMapViewWithLifecycle { mapView: MapView ->
-        // This code will be run just before the MapView is destroyed to tidy up any map
-        // allocations that have been made. I did try replacing the LaunchedEffects below with
-        // DisposableEffects and putting the code there, but by the time onDisposal is called it's
-        // too late - the view has already been destroyed. Passing it into the helper means that
-        // it's called prior to the onDestroy call on mapView. As a result Leak Canary no longer
-        // detects any leaks.
-        runBlocking {
-            mapView.getMapAsync { map ->
-                Log.d("MapContainer", "MapView is being disposed, tidy up")
-                beaconLocationMarker.value?.let { currentBeacon ->
-                    map.removeMarker(currentBeacon)
-                    beaconLocationMarker.value = null
-                }
-                map.removeOnMapLongClickListener(onMapLongClick)
-                map.setOnMarkerClickListener(null)
-
-                symbol.value?.let { sym ->
-                    symbolManager.value?.delete(sym)
-                    symbol.value = null
-                }
-                symbolManager.value?.onDestroy()
-                symbolManager.value = null
-            }
+            // We always use the mapViewRotation, but we only recenter the map if scrolling has
+            // been disallowed
+            val cp = CameraPosition.Builder().bearing(mapViewRotation.toDouble())
+            if(!allowScrolling)
+                cp.target(mapCenter.toLatLng())
+            cp.build()
         }
-    }
 
-    LaunchedEffect(map) {
-        // init map first time it is displayed
-        map.getMapAsync { mapLibre ->
-            // val apiKey = BuildConfig.TILE_PROVIDER_API_KEY
-            val styleUrl = Uri.fromFile(File("$filesDir/osm-bright-gl-style/processedstyle.json")).toString()
-            mapLibre.setStyle(styleUrl) { style ->
-                style.addImage(USER_POSITION_MARKER_NAME, drawable!!)
-
-                val sm = SymbolManager(map, mapLibre, style)
-                // Disable symbol collisions
-                sm.iconAllowOverlap = true
-                sm.iconIgnorePlacement = true
-
-                // update with a new symbol at specified lat/lng
-                val sym = sm.create(symbolOptions)
-                sm.update(sym)
-
-                // Update our remembered state with the symbol manager and symbol
-                symbolManager.value = sm
-                symbol.value = sym
-
-                mapLibre.uiSettings.setAttributionMargins(15, 0, 0, 15)
-                mapLibre.uiSettings.isZoomGesturesEnabled = true
-                // The map rotation is set by the compass heading, so we disable it from the UI
-                mapLibre.uiSettings.isRotateGesturesEnabled = false
-                // When allowScrolling is false, the centering of the map is set by the location
-                // provider, and in that case we disable scrolling from the UI
-                mapLibre.uiSettings.isScrollGesturesEnabled = allowScrolling
-
-                // Disable the mapLibre logo as there's not enough screen estate for it
-                mapLibre.uiSettings.isLogoEnabled = false
-                // Enable the attribution so that we can still get to see who provided the maps
-                mapLibre.uiSettings.isAttributionEnabled = true
-
-                mapLibre.addOnMapLongClickListener(onMapLongClick)
-                mapLibre.setOnMarkerClickListener(onMarkerClick)
-            }
-
-            mapLibre.cameraPosition = CameraPosition.Builder()
-                .target(mapCenter.toLatLng())
-                .zoom(15.0) // we set the zoom only at init
-                .bearing(mapViewRotation.toDouble())
-                .build()
+        val symbolOptions = remember(userLocation, userSymbolRotation) {
+            SymbolOptions()
+                .withLatLng(userLocation.toLatLng())
+                .withIconImage(USER_POSITION_MARKER_NAME)
+                .withIconAnchor("center")
+                .withIconRotate(userSymbolRotation)
         }
-    }
 
-    LaunchedEffect(beaconLocation) {
-        map.getMapAsync { mapLibre ->
-            if (beaconLocation != null && beaconLocationMarker.value == null) {
-                // first time beacon is created
-                val markerOptions = MarkerOptions()
-                    .position(beaconLocation.toLatLng())
-                beaconLocationMarker.value = mapLibre.addMarker(markerOptions)
-            }
+        val beaconLocationMarker = remember { mutableStateOf<Marker?>(null) }
+        val symbol = remember { mutableStateOf<Symbol?>(null) }
+        val symbolManager = remember { mutableStateOf<SymbolManager?>(null) }
+        val filesDir = LocalContext.current.filesDir.toString()
+        var lastTileGridGeoJson by remember { mutableStateOf(tileGridGeoJson)}
+
+        val res = LocalContext.current.resources
+        val drawable = remember {
+            ResourcesCompat.getDrawable(
+                res,
+                R.drawable.navigation,
+                null
+            )
         }
-    }
+        val coroutineScope = rememberCoroutineScope()
+        val map = rememberMapViewWithLifecycle { mapView: MapView ->
+            // This code will be run just before the MapView is destroyed to tidy up any map
+            // allocations that have been made. I did try replacing the LaunchedEffects below with
+            // DisposableEffects and putting the code there, but by the time onDisposal is called it's
+            // too late - the view has already been destroyed. Passing it into the helper means that
+            // it's called prior to the onDestroy call on mapView. As a result Leak Canary no longer
+            // detects any leaks.
+            runBlocking {
+                mapView.getMapAsync { map ->
+                    Log.d("MapContainer", "MapView is being disposed, tidy up")
+                    beaconLocationMarker.value?.let { currentBeacon ->
+                        map.removeMarker(currentBeacon)
+                        beaconLocationMarker.value = null
+                    }
+                    map.removeOnMapLongClickListener(onMapLongClick)
+                    map.setOnMarkerClickListener(null)
 
-    AndroidView(
-        modifier = modifier,
-        factory = { map },
-        update = { mapView ->
-            coroutineScope.launch {
-                mapView.getMapAsync { mapLibre ->
-
-                    mapLibre.cameraPosition = cameraPosition
                     symbol.value?.let { sym ->
-                        // We have a symbol, so update it
-                        sym.latLng = userLocation.toLatLng()
-                        sym.iconRotate = userSymbolRotation
-                        symbolManager.value?.update(sym)
+                        symbolManager.value?.delete(sym)
+                        symbol.value = null
                     }
+                    symbolManager.value?.onDestroy()
+                    symbolManager.value = null
+                }
+            }
+        }
 
-                    if (beaconLocation != null) {
-                        // beacon to display
-                        beaconLocationMarker.value?.let { currentBeaconMarker ->
-                            // update beacon position
-                            currentBeaconMarker.position = beaconLocation.toLatLng()
-                            mapLibre.updateMarker(currentBeaconMarker)
-                        } ?: {
-                            // new beacon to display
-                            val markerOptions =
-                                MarkerOptions()
-                                    .position(beaconLocation.toLatLng())
-                            beaconLocationMarker.value = mapLibre.addMarker(markerOptions)
+        LaunchedEffect(map) {
+            // init map first time it is displayed
+            map.getMapAsync { mapLibre ->
+                // val apiKey = BuildConfig.TILE_PROVIDER_API_KEY
+                val styleUrl = Uri.fromFile(File("$filesDir/osm-bright-gl-style/processedstyle.json")).toString()
+                mapLibre.setStyle(styleUrl) { style ->
+                    style.addImage(USER_POSITION_MARKER_NAME, drawable!!)
+
+                    val sm = SymbolManager(map, mapLibre, style)
+                    // Disable symbol collisions
+                    sm.iconAllowOverlap = true
+                    sm.iconIgnorePlacement = true
+
+                    // update with a new symbol at specified lat/lng
+                    val sym = sm.create(symbolOptions)
+                    sm.update(sym)
+
+                    // Update our remembered state with the symbol manager and symbol
+                    symbolManager.value = sm
+                    symbol.value = sym
+
+                    mapLibre.uiSettings.setAttributionMargins(15, 0, 0, 15)
+                    mapLibre.uiSettings.isZoomGesturesEnabled = true
+                    // The map rotation is set by the compass heading, so we disable it from the UI
+                    mapLibre.uiSettings.isRotateGesturesEnabled = false
+                    // When allowScrolling is false, the centering of the map is set by the location
+                    // provider, and in that case we disable scrolling from the UI
+                    mapLibre.uiSettings.isScrollGesturesEnabled = allowScrolling
+
+                    // Disable the mapLibre logo as there's not enough screen estate for it
+                    mapLibre.uiSettings.isLogoEnabled = false
+                    // Enable the attribution so that we can still get to see who provided the maps
+                    mapLibre.uiSettings.isAttributionEnabled = true
+
+                    mapLibre.addOnMapLongClickListener(onMapLongClick)
+                    mapLibre.setOnMarkerClickListener(onMarkerClick)
+                }
+
+                mapLibre.cameraPosition = CameraPosition.Builder()
+                    .target(mapCenter.toLatLng())
+                    .zoom(15.0) // we set the zoom only at init
+                    .bearing(mapViewRotation.toDouble())
+                    .build()
+            }
+        }
+
+        LaunchedEffect(beaconLocation) {
+            map.getMapAsync { mapLibre ->
+                if (beaconLocation != null && beaconLocationMarker.value == null) {
+                    // first time beacon is created
+                    val markerOptions = MarkerOptions()
+                        .position(beaconLocation.toLatLng())
+                    beaconLocationMarker.value = mapLibre.addMarker(markerOptions)
+                }
+            }
+        }
+
+        AndroidView(
+            modifier = modifier,
+            factory = { map },
+            update = { mapView ->
+                coroutineScope.launch {
+                    mapView.getMapAsync { mapLibre ->
+
+                        mapLibre.cameraPosition = cameraPosition
+                        symbol.value?.let { sym ->
+                            // We have a symbol, so update it
+                            sym.latLng = userLocation.toLatLng()
+                            sym.iconRotate = userSymbolRotation
+                            symbolManager.value?.update(sym)
                         }
-                    } else {
-                        // if beacon is present we should remove it
-                        beaconLocationMarker.value?.let { currentBeacon ->
-                            mapLibre.removeMarker(currentBeacon)
-                            beaconLocationMarker.value = null
+
+                        if (beaconLocation != null) {
+                            // beacon to display
+                            beaconLocationMarker.value?.let { currentBeaconMarker ->
+                                // update beacon position
+                                currentBeaconMarker.position = beaconLocation.toLatLng()
+                                mapLibre.updateMarker(currentBeaconMarker)
+                            } ?: {
+                                // new beacon to display
+                                val markerOptions =
+                                    MarkerOptions()
+                                        .position(beaconLocation.toLatLng())
+                                beaconLocationMarker.value = mapLibre.addMarker(markerOptions)
+                            }
+                        } else {
+                            // if beacon is present we should remove it
+                            beaconLocationMarker.value?.let { currentBeacon ->
+                                mapLibre.removeMarker(currentBeacon)
+                                beaconLocationMarker.value = null
+                            }
                         }
-                    }
 
-                    if (BuildConfig.DEBUG && tileGridGeoJson.isNotEmpty()) {
-                        mapLibre.style?.let { style ->
-                            // Add the source to the style if it doesn't already exist, or if the
-                            // GeoJSON for it has changed
-                            if((style.getLayer("current-grid") == null) ||
-                               (tileGridGeoJson != lastTileGridGeoJson)) {
-                                Log.d("MapContainerLibre", "Redraw grid for new GeoJSON")
-                                // Remove any previously adder layer and source
-                                style.removeLayer("current-grid")
-                                style.removeSource("current-grid")
+                        if (BuildConfig.DEBUG && tileGridGeoJson.isNotEmpty()) {
+                            mapLibre.style?.let { style ->
+                                // Add the source to the style if it doesn't already exist, or if the
+                                // GeoJSON for it has changed
+                                if ((style.getLayer("current-grid") == null) ||
+                                    (tileGridGeoJson != lastTileGridGeoJson)
+                                ) {
+                                    Log.d("MapContainerLibre", "Redraw grid for new GeoJSON")
+                                    // Remove any previously adder layer and source
+                                    style.removeLayer("current-grid")
+                                    style.removeSource("current-grid")
 
-                                // Create a GeoJson Source from our feature GeoJSON which
-                                // was generated from the GeoEngine tile grid.
-                                val tileGeoJson = FeatureCollection.fromJson(tileGridGeoJson)
-                                val geojsonSource = GeoJsonSource("current-grid", tileGeoJson)
-                                // Add our new source
-                                style.addSource(geojsonSource)
-                                // And our new layer
-                                val layer = LineLayer("current-grid", "current-grid")
-                                    .withProperties(
-                                        PropertyFactory.lineCap(Property.LINE_CAP_SQUARE),
-                                        PropertyFactory.lineJoin(Property.LINE_JOIN_MITER),
-                                        PropertyFactory.lineOpacity(0.7f),
-                                        PropertyFactory.lineWidth(4f),
-                                        PropertyFactory.lineColor("#0094ff")
-                                    )
-                                style.addLayer(layer)
-                                lastTileGridGeoJson = tileGridGeoJson
+                                    // Create a GeoJson Source from our feature GeoJSON which
+                                    // was generated from the GeoEngine tile grid.
+                                    val tileGeoJson = FeatureCollection.fromJson(tileGridGeoJson)
+                                    val geojsonSource = GeoJsonSource("current-grid", tileGeoJson)
+                                    // Add our new source
+                                    style.addSource(geojsonSource)
+                                    // And our new layer
+                                    val layer = LineLayer("current-grid", "current-grid")
+                                        .withProperties(
+                                            PropertyFactory.lineCap(Property.LINE_CAP_SQUARE),
+                                            PropertyFactory.lineJoin(Property.LINE_JOIN_MITER),
+                                            PropertyFactory.lineOpacity(0.7f),
+                                            PropertyFactory.lineWidth(4f),
+                                            PropertyFactory.lineColor("#0094ff")
+                                        )
+                                    style.addLayer(layer)
+                                    lastTileGridGeoJson = tileGridGeoJson
+                                }
                             }
                         }
                     }
                 }
-            }
-        },
-    )
+            },
+        )
+    }
 }


### PR DESCRIPTION
I think MapContainerLibre is all a bit too non-standard for Preview to work, so I've wrapped it in `if(!LocalInspectionMode.current)` which means that it won't be used when in Preview. The result is that Home Preview and others that use maps will now work.