### PR TITLE
Rationalize LocationDescription by removing distance string

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeIntents.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeIntents.kt
@@ -54,7 +54,7 @@ class SoundscapeIntents
                             Log.d(TAG, "$address")
                             val ld =
                                 LocationDescription(
-                                    addressName = address.getAddressLine(0),
+                                    name = address.getAddressLine(0),
                                     location = LngLatAlt(address.longitude, address.latitude)
                                 )
                             navigator.navigate(generateLocationDetailsRoute(ld))
@@ -71,7 +71,7 @@ class SoundscapeIntents
                     Log.d(TAG, "Address: $address")
                     val ld =
                         LocationDescription(
-                            addressName = address.getAddressLine(0),
+                            name = address.getAddressLine(0),
                             location = LngLatAlt(address.longitude, address.latitude)
                         )
                     navigator.navigate(generateLocationDetailsRoute(ld))
@@ -202,7 +202,7 @@ class SoundscapeIntents
                                 // No Geocoder available, so just report the uriData
                                 val ld =
                                     LocationDescription(
-                                        addressName = URLEncoder.encode(uriData, "utf-8"),
+                                        name = URLEncoder.encode(uriData, "utf-8"),
                                         location = LngLatAlt(longitude.toDouble(), latitude.toDouble())
                                     )
                                 mainActivity.navigator.navigate(generateLocationDetailsRoute(ld))
@@ -225,7 +225,7 @@ class SoundscapeIntents
                                                 mainActivity.contentResolver.openInputStream(uri)
 
                                             if (input != null) {
-                                                var routeData: RouteData? = null
+                                                val routeData: RouteData?
                                                 if(intent.type == "application/json") {
                                                     // This might be a saved route shared from iOS.
                                                     // We want to translate this into a RouteData

--- a/app/src/main/java/org/scottishtecharmy/soundscape/components/LocationItem.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/components/LocationItem.kt
@@ -16,13 +16,16 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.scottishtecharmy.soundscape.geoengine.formatDistance
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.ui.theme.Foreground2
@@ -45,9 +48,18 @@ data class LocationItemDecoration(
 @Composable
 fun LocationItem(
     item: LocationDescription,
+    userLocation: LngLatAlt?,
     modifier: Modifier = Modifier,
     decoration: LocationItemDecoration = LocationItemDecoration(),
 ) {
+    val context = LocalContext.current
+    var distanceString = ""
+    if(userLocation != null) {
+        distanceString = formatDistance(
+            userLocation.distance(item.location),
+            context
+        )
+    }
     Row(
         modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
@@ -70,7 +82,7 @@ fun LocationItem(
             modifier = Modifier.padding(start = 18.dp),
             verticalArrangement = Arrangement.spacedBy(5.dp),
         ) {
-            item.addressName?.let {
+            item.name?.let {
                 Text(
                     text = it,
                     fontWeight = FontWeight(700),
@@ -78,9 +90,9 @@ fun LocationItem(
                     color = Color.White,
                 )
             }
-            item.distance?.let {
+            if(distanceString.isNotEmpty()) {
                 Text(
-                    text = it,
+                    text = distanceString,
                     color = Foreground2,
                     fontWeight = FontWeight(450),
                     fontSize = 12.sp,
@@ -107,7 +119,7 @@ fun LocationItem(
         } else if(decoration.details.enabled) {
             Button(
                 onClick = {
-                    decoration.details.functionString(item.addressName!!)
+                    decoration.details.functionString(item.name!!)
                 },
             ) {
                 Icon(
@@ -134,13 +146,13 @@ fun PreviewSearchItemButton() {
         ) {
             val test =
                 LocationDescription(
-                    addressName = "Bristol",
+                    name = "Bristol",
                     fullAddress = "18 Street \n59000 Lille\nFrance",
-                    distance = "17 Km",
                     location = LngLatAlt(8.00, 9.55)
                 )
             LocationItem(
                 item = test,
+                userLocation = LngLatAlt(9.00, 9.55),
                 decoration = LocationItemDecoration(
                     location = true,
                     editRoute = EnabledFunction(true, {}, {}, true),
@@ -166,8 +178,7 @@ fun PreviewCompactSearchItemButton() {
         ) {
             val test =
                 LocationDescription(
-                    addressName = "Bristol",
-                    distance = "17 Km",
+                    name = "Bristol",
                     location = LngLatAlt(8.00, 9.55)
                 )
             LocationItem(
@@ -178,6 +189,7 @@ fun PreviewCompactSearchItemButton() {
                     details = EnabledFunction(true),
                 ),
                 modifier = Modifier.width(200.dp),
+                userLocation = LngLatAlt(8.00, 10.55)
             )
         }
     }
@@ -197,8 +209,7 @@ fun PreviewOrderedItemButton() {
         ) {
             val test =
                 LocationDescription(
-                    addressName = "Bristol",
-                    distance = "17 Km",
+                    name = "Bristol",
                     location = LngLatAlt(8.00, 9.55)
                 )
             LocationItem(
@@ -207,6 +218,7 @@ fun PreviewOrderedItemButton() {
                     index = 2,
                 ),
                 modifier = Modifier.width(200.dp),
+                userLocation = LngLatAlt(8.20, 9.55)
             )
         }
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/components/MainSearchBar.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/components/MainSearchBar.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.semantics.collectionItemInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import org.scottishtecharmy.soundscape.R
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -41,6 +42,7 @@ fun MainSearchBar(
     onSearchTextChange: (String) -> Unit,
     onToggleSearch: () -> Unit,
     onItemClick: (LocationDescription) -> Unit,
+    userLocation: LngLatAlt?
 ) {
     SearchBar(
         modifier =
@@ -130,6 +132,7 @@ fun MainSearchBar(
                                             columnIndex = 0,
                                         )
                                 },
+                            userLocation = userLocation
                         )
                         HorizontalDivider(color = Color.White)
                     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
@@ -64,7 +64,7 @@ fun HomeScreen(
                 onNavigate = { dest -> navController.navigate(dest) },
                 onMapLongClick = { latLong ->
                     val location = LngLatAlt(latLong.longitude, latLong.latitude)
-                    val ld = viewModel.getLocationDescription(location) ?: LocationDescription()
+                    val ld = viewModel.getLocationDescription(location) ?: LocationDescription("", location)
                     navController.navigate(generateLocationDetailsRoute(ld))
                     true
                 },
@@ -80,9 +80,9 @@ fun HomeScreen(
                             state.value.location!!.longitude,
                             state.value.location!!.latitude
                         )
-                        viewModel.getLocationDescription(location) ?: LocationDescription()
+                        viewModel.getLocationDescription(location) ?: LocationDescription("", location)
                     } else {
-                        LocationDescription()
+                        LocationDescription("", LngLatAlt())
                     }
                 },
                 searchText = searchText.value,
@@ -156,7 +156,8 @@ fun HomeScreen(
             RouteDetailsScreenVM(
                 routeName = routeName,
                 navController = navController,
-                modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing)
+                modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing),
+                userLocation = state.value.location
             )
         }
 
@@ -175,10 +176,10 @@ fun HomeScreen(
             AddAndEditRouteScreenVM(
                 routeObjectId = uiState.routeObjectId,
                 routeName = routeName,
-                routeDescription = uiState.description,
                 navController = navController,
                 viewModel = addAndEditRouteViewModel,
-                modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing)
+                modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing),
+                userLocation = state.value.location
             )
         }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/data/LocationDescription.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/data/LocationDescription.kt
@@ -4,9 +4,8 @@ import org.mongodb.kbson.ObjectId
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 
 data class LocationDescription(
-    var addressName: String? = null,
+    var name: String? = null,
+    var location: LngLatAlt,
     var fullAddress: String? = null,
-    var distance: String? = null,
-    var location: LngLatAlt = LngLatAlt(),
     var markerObjectId: ObjectId? = null
 )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
@@ -121,6 +121,7 @@ fun Home(
                                 generateLocationDetailsRoute(item),
                             )
                         },
+                        userLocation = location
                     )
                 },
                 onMapLongClick = onMapLongClick,
@@ -199,7 +200,7 @@ fun HomePreview() {
             getMyLocation = {},
             getWhatsAroundMe = {},
             getWhatsAheadOfMe = {},
-            getCurrentLocationDescription = { LocationDescription() },
+            getCurrentLocationDescription = { LocationDescription("Current Location", LngLatAlt()) },
             shareLocation = {},
             rateSoundscape = {},
             streetPreviewState = StreetPreviewState(StreetPreviewEnabled.OFF),
@@ -230,7 +231,7 @@ fun HomeSearchPreview() {
             getMyLocation = {},
             getWhatsAroundMe = {},
             getWhatsAheadOfMe = {},
-            getCurrentLocationDescription = { LocationDescription() },
+            getCurrentLocationDescription = { LocationDescription("Current Location", LngLatAlt()) },
             shareLocation = {},
             rateSoundscape = {},
             streetPreviewState = StreetPreviewState(StreetPreviewEnabled.OFF),
@@ -248,33 +249,33 @@ fun HomeSearchPreview() {
 
 val previewLocationList = listOf(
     LocationDescription(
-        addressName = "Barrowland Ballroom",
+        name = "Barrowland Ballroom",
         fullAddress = "Somewhere in Glasgow",
-        distance = "10 km",
         location = LngLatAlt(-4.2366753, 55.8552688)
     ),
     LocationDescription(
-        addressName = "King Tut's Wah Wah Hut",
+        name = "King Tut's Wah Wah Hut",
         fullAddress = "Somewhere else in Glasgow",
-        distance = "999 metres",
         location = LngLatAlt(-4.2649646, 55.8626180)
     ),
     LocationDescription(
-        addressName = "St. Lukes and the Winged Ox",
+        name = "St. Lukes and the Winged Ox",
         fullAddress = "Where else?",
-        distance = "12km",
         location = LngLatAlt( -4.2347580, 55.8546320)
     )
 )
 
 val previewLocationListShort = listOf(
     LocationDescription(
-        addressName = "Barrowland Ballroom"
+        name = "Barrowland Ballroom",
+        location = LngLatAlt(-4.2366753, 55.8552688)
     ),
     LocationDescription(
-        addressName = "King Tut's Wah Wah Hut"
+        name = "King Tut's Wah Wah Hut",
+        location = LngLatAlt(-4.2649646, 55.8626180)
     ),
     LocationDescription(
-        addressName = "St. Lukes and the Winged Ox"
+        name = "St. Lukes and the Winged Ox",
+        location = LngLatAlt( -4.2347580, 55.8546320)
     )
 )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
@@ -54,7 +54,7 @@ fun HomeContent(
                         // screen which location to provide details of. The JSON is appended to the route.
                         val ld =
                             LocationDescription(
-                                addressName = "Barrowland Ballroom",
+                                name = "Barrowland Ballroom",
                                 location = LngLatAlt(-4.2366753, 55.8552688)
                             )
                         onNavigate(generateLocationDetailsRoute(ld))
@@ -111,7 +111,7 @@ fun StreetPreviewHomeContent() {
         streetPreviewState = StreetPreviewState(StreetPreviewEnabled.ON),
         streetPreviewGo = {},
         streetPreviewExit = {},
-        getCurrentLocationDescription = { LocationDescription() }
+        getCurrentLocationDescription = { LocationDescription("Current location", LngLatAlt()) }
     )
 }
 
@@ -130,6 +130,6 @@ fun PreviewHomeContent() {
         streetPreviewState = StreetPreviewState(StreetPreviewEnabled.OFF),
         streetPreviewGo = {},
         streetPreviewExit = {},
-        getCurrentLocationDescription = { LocationDescription() }
+        getCurrentLocationDescription = { LocationDescription("Current location", LngLatAlt()) }
     )
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/SaveAndEditMarkerDialog.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/SaveAndEditMarkerDialog.kt
@@ -40,7 +40,7 @@ fun SaveAndEditMarkerDialog(
     modifier: Modifier = Modifier,
     dialogState: MutableState<Boolean>
 ) {
-    var name by rememberSaveable { mutableStateOf(locationDescription.addressName ?: "") }
+    var name by rememberSaveable { mutableStateOf(locationDescription.name ?: "") }
     var annotation by rememberSaveable { mutableStateOf(locationDescription.fullAddress ?: "") }
     val objectId = locationDescription.markerObjectId
 
@@ -80,7 +80,7 @@ fun SaveAndEditMarkerDialog(
                     Modifier
                         .fillMaxWidth(),
                     onClick = {
-                        locationDescription.addressName = name
+                        locationDescription.name = name
                         locationDescription.fullAddress = annotation
                         saveMarker(locationDescription)
                         dialogState.value = false
@@ -153,8 +153,7 @@ fun AddRouteScreenPreview() {
     SoundscapeTheme {
         SaveAndEditMarkerDialog(
             locationDescription = LocationDescription(
-                addressName = "Pizza hut",
-                distance = "3,5 km",
+                name = "Pizza hut",
                 location = LngLatAlt(),
                 fullAddress = "139 boulevard gambetta",
             ),

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/MarkersAndRoutesScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/MarkersAndRoutesScreen.kt
@@ -43,7 +43,7 @@ fun MarkersAndRoutesScreen(
             if(state.routesTabSelected) {
                 RoutesScreenVM(navController)
             } else {
-                MarkersScreenVM(navController)
+                MarkersScreenVM(navController, state.location)
             }
         }
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/AddAndEditRouteScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/AddAndEditRouteScreen.kt
@@ -29,6 +29,7 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import org.mongodb.kbson.ObjectId
 import org.scottishtecharmy.soundscape.R
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.HomeRoutes
 import org.scottishtecharmy.soundscape.screens.home.home.previewLocationListShort
 import org.scottishtecharmy.soundscape.screens.markers_routes.components.CustomAppBar
@@ -40,16 +41,15 @@ import org.scottishtecharmy.soundscape.ui.theme.SoundscapeTheme
 fun AddAndEditRouteScreenVM(
     routeObjectId: ObjectId?,
     routeName: String,
-    routeDescription: String,
     navController: NavController,
     modifier: Modifier,
+    userLocation: LngLatAlt?,
     viewModel: AddAndEditRouteViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     AddAndEditRouteScreen(
         routeObjectId,
         routeName,
-        routeDescription,
         navController,
         modifier,
         uiState,
@@ -58,7 +58,8 @@ fun AddAndEditRouteScreenVM(
         onNameChange = { viewModel.onNameChange(it) },
         onDescriptionChange = { viewModel.onDescriptionChange(it) },
         onDeleteRoute = { viewModel.deleteRoute(it) },
-        onDoneClicked = { viewModel.onDoneClicked() }
+        onDoneClicked = { viewModel.onDoneClicked() },
+        userLocation = userLocation
     )
 }
 
@@ -67,10 +68,10 @@ fun AddAndEditRouteScreenVM(
 fun AddAndEditRouteScreen(
     routeObjectId: ObjectId?,
     routeName: String,
-    routeDescription: String,
     navController: NavController,
     modifier: Modifier,
     uiState: AddAndEditRouteUiState,
+    userLocation: LngLatAlt?,
     onClearErrorMessage: () -> Unit,
     onResetDoneAction: () -> Unit,
     onNameChange: (newText: String) -> Unit,
@@ -122,7 +123,8 @@ fun AddAndEditRouteScreen(
                 addWaypointDialog.value = false
             },
             onCancel = { addWaypointDialog.value = false },
-            modifier = modifier
+            modifier = modifier,
+            userLocation = userLocation
         )
     }
     else {
@@ -233,7 +235,8 @@ fun AddAndEditRouteScreen(
                             )
                         } else {
                             ReorderableLocationList(
-                                locations = uiState.routeMembers
+                                locations = uiState.routeMembers,
+                                userLocation = userLocation
                             )
                         }
                     }
@@ -250,7 +253,6 @@ fun NewRouteScreenPreview() {
         AddAndEditRouteScreen(
             routeObjectId = ObjectId(),
             routeName = newRouteName,
-            routeDescription = "Description of route",
             navController = rememberNavController(),
             modifier = Modifier,
             uiState = AddAndEditRouteUiState(),
@@ -259,7 +261,8 @@ fun NewRouteScreenPreview() {
             onNameChange = {},
             onDescriptionChange = {},
             onDeleteRoute = {},
-            onDoneClicked = {}
+            onDoneClicked = {},
+            userLocation = LngLatAlt()
         )
     }
 }
@@ -271,7 +274,6 @@ fun EditRouteScreenPreview() {
         AddAndEditRouteScreen(
             routeObjectId = ObjectId(),
             routeName = "Route to preview",
-            routeDescription = "Description of route",
             navController = rememberNavController(),
             modifier = Modifier,
             uiState = AddAndEditRouteUiState(
@@ -282,7 +284,8 @@ fun EditRouteScreenPreview() {
             onNameChange = {},
             onDescriptionChange = {},
             onDeleteRoute = {},
-            onDoneClicked = {}
+            onDoneClicked = {},
+            userLocation = LngLatAlt()
         )
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/AddWaypointsDialog.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/AddWaypointsDialog.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.scottishtecharmy.soundscape.R
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.markers_routes.components.CustomAppBar
 import org.scottishtecharmy.soundscape.screens.markers_routes.components.CustomButton
@@ -27,7 +28,8 @@ fun AddWaypointsDialog(
     uiState: AddAndEditRouteUiState,
     modifier: Modifier,
     onDone: () -> Unit,
-    onCancel: () -> Unit
+    onCancel: () -> Unit,
+    userLocation: LngLatAlt?
 ) {
     Scaffold(
         modifier = modifier,
@@ -65,7 +67,8 @@ fun AddWaypointsDialog(
             ) {
                 // Display the list of routes
                 AddWaypointsList(
-                    uiState = uiState
+                    uiState = uiState,
+                    userLocation = userLocation
                 )
             }
         }
@@ -80,29 +83,30 @@ fun AddWaypointsScreenPopulatedPreview() {
             modifier = Modifier,
             onCancel = {},
             onDone = { },
+            userLocation = null,
             uiState =
                 AddAndEditRouteUiState(
                     routeMembers =
                     mutableListOf(
-                        LocationDescription("Route point 1"),
-                        LocationDescription("Route point 2"),
-                        LocationDescription("Route point 3"),
-                        LocationDescription("Route point 4"),
-                        LocationDescription("Route point 5"),
-                        LocationDescription("Route point 6"),
-                        LocationDescription("Route point 7"),
-                        LocationDescription("Route point 8"),
+                        LocationDescription(name = "Route point 1", location = LngLatAlt()),
+                        LocationDescription(name = "Route point 2", location = LngLatAlt()),
+                        LocationDescription(name = "Route point 3", location = LngLatAlt()),
+                        LocationDescription(name = "Route point 4", location = LngLatAlt()),
+                        LocationDescription(name = "Route point 5", location = LngLatAlt()),
+                        LocationDescription(name = "Route point 6", location = LngLatAlt()),
+                        LocationDescription(name = "Route point 7", location = LngLatAlt()),
+                        LocationDescription(name = "Route point 8", location = LngLatAlt()),
                     ),
                     markers =
                     mutableListOf(
-                        LocationDescription("Waypoint 1"),
-                        LocationDescription("Waypoint 2"),
-                        LocationDescription("Waypoint 3"),
-                        LocationDescription("Waypoint 4"),
-                        LocationDescription("Waypoint 5"),
-                        LocationDescription("Waypoint 6"),
-                        LocationDescription("Waypoint 7"),
-                        LocationDescription("Waypoint 8"),
+                        LocationDescription(name = "Waypoint 1", location = LngLatAlt()),
+                        LocationDescription(name = "Waypoint 2", location = LngLatAlt()),
+                        LocationDescription(name = "Waypoint 3", location = LngLatAlt()),
+                        LocationDescription(name = "Waypoint 4", location = LngLatAlt()),
+                        LocationDescription(name = "Waypoint 5", location = LngLatAlt()),
+                        LocationDescription(name = "Waypoint 6", location = LngLatAlt()),
+                        LocationDescription(name = "Waypoint 7", location = LngLatAlt()),
+                        LocationDescription(name = "Waypoint 8", location = LngLatAlt()),
                     )
                 )
         )
@@ -118,6 +122,7 @@ fun AddWaypointsScreenPreview() {
             onCancel = {},
             onDone = {},
             uiState = AddAndEditRouteUiState(),
+            userLocation = null
         )
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/AddWaypointsList.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/AddWaypointsList.kt
@@ -13,11 +13,13 @@ import androidx.compose.ui.unit.dp
 import org.scottishtecharmy.soundscape.components.EnabledFunction
 import org.scottishtecharmy.soundscape.components.LocationItem
 import org.scottishtecharmy.soundscape.components.LocationItemDecoration
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 
 @Composable
 fun AddWaypointsList(
-    uiState: AddAndEditRouteUiState
+    uiState: AddAndEditRouteUiState,
+    userLocation: LngLatAlt?,
 ) {
     // Create our list of locations, with those already in the route first
     val locations = remember(uiState) {
@@ -62,7 +64,8 @@ fun AddWaypointsList(
                         },
                         value = routeMember[locationDescription] ?: false
                     )
-                )
+                ),
+                userLocation = userLocation
             )
         }
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/ReorderableLocationList.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/ReorderableLocationList.kt
@@ -24,12 +24,14 @@ import org.scottishtecharmy.soundscape.components.LocationItem
 import org.scottishtecharmy.soundscape.components.LocationItemDecoration
 import org.scottishtecharmy.soundscape.components.SlideState
 import org.scottishtecharmy.soundscape.components.dragToReorder
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.ui.theme.SoundscapeTheme
 
 @Composable
 fun ReorderableLocationList(
-    locations: MutableList<LocationDescription>
+    locations: MutableList<LocationDescription>,
+    userLocation: LngLatAlt?
 )
 {
     val listState = rememberLazyListState()
@@ -117,6 +119,7 @@ fun ReorderableLocationList(
                         decoration = LocationItemDecoration(
                             index = idx
                         ),
+                        userLocation = userLocation
                     )
                 }
             }
@@ -132,12 +135,13 @@ fun PreviewReorderableLocationList() {
     SoundscapeTheme {
         ReorderableLocationList(
             locations = mutableListOf(
-                LocationDescription("Marker1", fullAddress = "111 A street"),
-                LocationDescription("Marker2", fullAddress = "111 B street"),
-                LocationDescription("Marker3", fullAddress = "111 C street"),
-                LocationDescription("Marker4", fullAddress = "111 D street"),
-                LocationDescription("Marker5", fullAddress = "111 E street")
-            )
+                LocationDescription(name ="Marker1", location = LngLatAlt(), fullAddress = "111 A street"),
+                LocationDescription(name ="Marker2", location = LngLatAlt(), fullAddress = "111 B street"),
+                LocationDescription(name ="Marker3", location = LngLatAlt(), fullAddress = "111 C street"),
+                LocationDescription(name ="Marker4", location = LngLatAlt(), fullAddress = "111 D street"),
+                LocationDescription(name ="Marker5", location = LngLatAlt(), fullAddress = "111 E street"),
+            ),
+            userLocation = LngLatAlt(1.0, 0.0)
         )
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/markersscreen/MarkersScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/markersscreen/MarkersScreen.kt
@@ -40,15 +40,18 @@ import org.scottishtecharmy.soundscape.ui.theme.SoundscapeTheme
 @Composable
 fun MarkersScreenVM(
     homeNavController: NavController,
+    userLocation: LngLatAlt?,
     viewModel: MarkersViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    uiState.userLocation = userLocation
     MarkersScreen(
         homeNavController,
         uiState,
         clearErrorMessage = { viewModel.clearErrorMessage() },
         onToggleSortOrder = { viewModel.toggleSortOrder() },
         onToggleSortByName = { viewModel.toggleSortByName() },
+        userLocation = userLocation
     )
 }
 
@@ -59,6 +62,7 @@ fun MarkersScreen(
     clearErrorMessage: () -> Unit,
     onToggleSortOrder: () -> Unit,
     onToggleSortByName: () -> Unit,
+    userLocation: LngLatAlt?
 ) {
     Column(
         modifier =
@@ -151,6 +155,7 @@ fun MarkersScreen(
                         MarkersList(
                             uiState = uiState,
                             navController = homeNavController,
+                            userLocation = userLocation
                         )
                     }
                 }
@@ -171,15 +176,15 @@ fun MarkersScreenPopulatedPreview() {
                         listOf(
                             LocationDescription(
                                 "Waypoint 1",
-                                "Street Blabla, Blabla City",
                                 location = LngLatAlt(),
-                                distance = "2 km",
+                                "Street Blabla, Blabla City",
                             ),
                         ),
                 ),
             clearErrorMessage = {},
             onToggleSortOrder = {},
             onToggleSortByName = {},
+            userLocation = null
         )
     }
 }
@@ -194,6 +199,7 @@ fun MarkersScreenPreview() {
             clearErrorMessage = {},
             onToggleSortOrder = {},
             onToggleSortByName = {},
+            userLocation = null
         )
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/markersscreen/MarkersScreenList.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/markersscreen/MarkersScreenList.kt
@@ -12,12 +12,14 @@ import androidx.navigation.NavController
 import org.scottishtecharmy.soundscape.components.EnabledFunction
 import org.scottishtecharmy.soundscape.components.LocationItem
 import org.scottishtecharmy.soundscape.components.LocationItemDecoration
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.locationDetails.generateLocationDetailsRoute
 import org.scottishtecharmy.soundscape.screens.markers_routes.navigation.ScreensForMarkersAndRoutes
 
 @Composable
 fun MarkersList(
     uiState: MarkersUiState,
+    userLocation: LngLatAlt?,
     navController: NavController,
 ) {
     LazyColumn(
@@ -42,6 +44,7 @@ fun MarkersList(
                         }
                     )
                 ),
+                userLocation = userLocation
             )
         }
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/markersscreen/MarkersUiState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/markersscreen/MarkersUiState.kt
@@ -1,6 +1,6 @@
 package org.scottishtecharmy.soundscape.screens.markers_routes.screens.markersscreen
 
-import org.scottishtecharmy.soundscape.database.local.model.MarkerData
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 
 data class MarkersUiState(
@@ -9,9 +9,5 @@ data class MarkersUiState(
     val errorMessage: String? = null,
     val isSortByName: Boolean = false,
     val isSortAscending: Boolean = true,
-)
-
-data class MarkerVM(
-    val markerData: MarkerData,
-    val distance: String?,
+    var userLocation: LngLatAlt? = null
 )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/markersscreen/MarkersViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/markersscreen/MarkersViewModel.kt
@@ -7,11 +7,8 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
-import org.scottishtecharmy.soundscape.SoundscapeServiceConnection
 import org.scottishtecharmy.soundscape.database.repository.RoutesRepository
-import org.scottishtecharmy.soundscape.geoengine.formatDistance
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.markers_routes.screens.getSortFieldPreference
@@ -25,7 +22,6 @@ class MarkersViewModel
     @Inject
     constructor(
         private val routesRepository: RoutesRepository,
-        private val soundscapeServiceConnection: SoundscapeServiceConnection,
         @ApplicationContext private val context: Context,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(MarkersUiState())
@@ -35,28 +31,20 @@ class MarkersViewModel
             // Load the saved sort orders
             _uiState.value = _uiState.value.copy(
                 isSortByName = getSortFieldPreference(context),
-                isSortAscending = getSortOrderPreference(context))
+                isSortAscending = getSortOrderPreference(context)
+            )
 
             // Collect the flow of routes from the repository so that we update when routes are added
             // and deleted
             viewModelScope.launch {
                 routesRepository.getMarkerFlow().collect { markers ->
-                    val userLocation = soundscapeServiceConnection.getLocationFlow()?.firstOrNull()
                     val locations = markers.map {
                         val markerLngLat =
                             LngLatAlt(it.location?.longitude ?: 0.0, it.location?.latitude ?: 0.0)
                         LocationDescription(
-                            addressName = it.addressName,
+                            name = it.addressName,
                             fullAddress = it.fullAddress,
                             location = markerLngLat,
-                            distance =
-                            if (userLocation == null)
-                                ""
-                            else {
-                                val userLngLat =
-                                    LngLatAlt(userLocation.longitude, userLocation.latitude)
-                                formatDistance(userLngLat.distance(markerLngLat), context)
-                            },
                             markerObjectId = it.objectId
                         )
                     }
@@ -80,15 +68,14 @@ class MarkersViewModel
         private fun sortMarkers(markers: List<LocationDescription>) : List<LocationDescription> {
             return if(_uiState.value.isSortByName) {
                 if(_uiState.value.isSortAscending)
-                    markers.sortedBy { it.addressName }
+                    markers.sortedBy { it.name }
                 else
-                    markers.sortedByDescending { it.addressName }
-
+                    markers.sortedByDescending { it.name }
             } else {
                 if(_uiState.value.isSortAscending)
-                    markers.sortedBy { it.distance }
+                    markers.sortedBy { _uiState.value.userLocation?.distance(it.location) }
                 else
-                    markers.sortedByDescending { it.distance }
+                    markers.sortedByDescending { _uiState.value.userLocation?.distance(it.location) }
             }
         }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/routedetailsscreen/RouteDetailsScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/routedetailsscreen/RouteDetailsScreen.kt
@@ -54,7 +54,8 @@ fun RouteDetailsScreenVM(
     navController: NavController,
     routeName: String,
     viewModel: RouteDetailsViewModel = hiltViewModel(),
-    modifier: Modifier
+    modifier: Modifier,
+    userLocation: LngLatAlt?
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     RouteDetailsScreen(
@@ -64,7 +65,8 @@ fun RouteDetailsScreenVM(
         uiState,
         getRouteByName = { viewModel.getRouteByName(routeName) },
         startRoute = { viewModel.startRoute(routeName) },
-        clearErrorMessage = { viewModel.clearErrorMessage() }
+        clearErrorMessage = { viewModel.clearErrorMessage() },
+        userLocation = userLocation
     )
 }
 
@@ -77,6 +79,7 @@ fun RouteDetailsScreen(
     getRouteByName: (routeName: String) -> Unit,
     startRoute: (routeName: String) -> Unit,
     clearErrorMessage: () -> Unit,
+    userLocation: LngLatAlt?
 ) {
     // Observe the UI state from the ViewModel
     val context = LocalContext.current
@@ -220,13 +223,15 @@ fun RouteDetailsScreen(
                             itemsIndexed(uiState.route.waypoints) { index, marker ->
                                 LocationItem(
                                     item = LocationDescription(
-                                        addressName = marker.addressName,
+                                        name = marker.addressName,
+                                        location = marker.location?.location() ?: LngLatAlt(),
                                         fullAddress = marker.fullAddress
                                     ),
                                     decoration = LocationItemDecoration(
                                         location = false,
-                                        index = index
-                                    )
+                                        index = index,
+                                    ),
+                                    userLocation = userLocation
                                 )
                             }
                         }
@@ -271,7 +276,8 @@ fun RoutesDetailsPopulatedPreview() {
             ),
             getRouteByName = {},
             startRoute = {},
-            clearErrorMessage = {}
+            clearErrorMessage = {},
+            userLocation = null
         )
     }
 }
@@ -287,7 +293,8 @@ fun RoutesDetailsLoadingPreview() {
             modifier = Modifier,
             getRouteByName = {},
             startRoute = {},
-            clearErrorMessage = {}
+            clearErrorMessage = {},
+            userLocation = null
         )
     }
 }
@@ -303,7 +310,8 @@ fun RoutesDetailsEmptyPreview() {
             uiState = RouteDetailsUiState(),
             getRouteByName = {},
             startRoute = {},
-            clearErrorMessage = {}
+            clearErrorMessage = {},
+            userLocation = null
         )
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/utils/LocationExt.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/utils/LocationExt.kt
@@ -1,17 +1,10 @@
 package org.scottishtecharmy.soundscape.utils
 
-import android.content.Context
-import org.mongodb.kbson.ObjectId
-import org.scottishtecharmy.soundscape.geoengine.formatDistance
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
-import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 
-fun ArrayList<Feature>.toLocationDescriptions(
-    currentLocation: LngLatAlt,
-    localizedContext: Context
-): List<LocationDescription> =
+fun ArrayList<Feature>.toLocationDescriptions(): List<LocationDescription> =
     mapNotNull { feature ->
         feature.properties?.let { properties ->
             val streetNumberAndName =
@@ -28,13 +21,8 @@ fun ArrayList<Feature>.toLocationDescriptions(
 
             val fullAddress = buildAddressFormat(streetNumberAndName, postcodeAndLocality, country)
             LocationDescription(
-                addressName = properties["name"]?.toString(),
+                name = properties["name"]?.toString(),
                 fullAddress = fullAddress,
-                distance =
-                    formatDistance(
-                        currentLocation.distance((feature.geometry as Point).coordinates),
-                        localizedContext
-                    ),
                 location = (feature.geometry as Point).coordinates
             )
         }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
@@ -31,7 +31,7 @@ class LocationDetailsViewModel @Inject constructor(
 
     fun createMarker(locationDescription: LocationDescription) {
         viewModelScope.launch {
-            var name = locationDescription.addressName
+            var name = locationDescription.name
             if (name == null) name = locationDescription.fullAddress
             name = name ?: "Unknown"
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeViewModel.kt
@@ -12,7 +12,6 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -38,7 +37,6 @@ class HomeViewModel
     @Inject
     constructor(
         private val soundscapeServiceConnection: SoundscapeServiceConnection,
-        @ApplicationContext context: Context
     ) : ViewModel() {
     private val _state: MutableStateFlow<HomeState> = MutableStateFlow(HomeState())
     val state: StateFlow<HomeState> = _state.asStateFlow()
@@ -50,7 +48,7 @@ class HomeViewModel
 
     init {
         handleMonitoring()
-        fetchSearchResult(context)
+        fetchSearchResult()
     }
 
     private fun handleMonitoring() {
@@ -237,7 +235,7 @@ class HomeViewModel
         _searchText.value = text
     }
 
-    private fun fetchSearchResult(context: Context) {
+    private fun fetchSearchResult() {
         viewModelScope.launch {
             _searchText
                 .debounce(500)
@@ -251,11 +249,7 @@ class HomeViewModel
 
                         _state.update {
                             it.copy(
-                                searchItems =
-                                    result?.toLocationDescriptions(
-                                        currentLocation = state.value.location ?: LngLatAlt(),
-                                        localizedContext = context
-                                    ),
+                                searchItems = result?.toLocationDescriptions(),
                             )
                         }
                     }


### PR DESCRIPTION
Instead of storing the distance string, we calculate as and when it's required by the UI. This should enable us to update the values as the user moves.