### PR TITLE
Import route now goes via Add Route Screen and some UI tweaking

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeIntents.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeIntents.kt
@@ -223,7 +223,7 @@ class SoundscapeIntents
 
                                             if (input != null) {
                                                 val routeData: RouteData?
-                                                if(intent.type == "application/json") {
+                                                if((intent.type == "application/json") or (intent.type == "application/octet-stream")) {
                                                     // This might be a saved route shared from iOS.
                                                     // We want to translate this into a RouteData
                                                     // format to write to our database.
@@ -245,9 +245,11 @@ class SoundscapeIntents
                                                             val coordinate = location.get("coordinate") as JSONObject
                                                             val latitude = coordinate.get("latitude") as Double
                                                             val longitude = coordinate.get("longitude") as Double
-                                                            val nickname = marker.get("nickname")
-                                                            val estimatedAddress = marker.getString("estimatedAddress")
-
+                                                            // Soundscape community doesn't have estimatedAddress,
+                                                            // but STA iOS Soundscape does
+                                                            var estimatedAddress = ""
+                                                            if(marker.has("estimatedAddress"))
+                                                                estimatedAddress = marker.getString("estimatedAddress")
                                                             routeData.waypoints.add(
                                                                 MarkerData(name, Location(latitude, longitude), estimatedAddress)
                                                             )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeIntents.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeIntents.kt
@@ -8,18 +8,15 @@ import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
-import org.scottishtecharmy.soundscape.database.local.RealmConfiguration
-import org.scottishtecharmy.soundscape.database.local.dao.RoutesDao
 import org.scottishtecharmy.soundscape.database.local.model.Location
 import org.scottishtecharmy.soundscape.database.local.model.RouteData
 import org.scottishtecharmy.soundscape.database.local.model.MarkerData
-import org.scottishtecharmy.soundscape.database.repository.RoutesRepository
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.Navigator
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.home.locationDetails.generateLocationDetailsRoute
+import org.scottishtecharmy.soundscape.screens.markers_routes.screens.addandeditroutescreen.generateRouteDetailsRoute
 import org.scottishtecharmy.soundscape.utils.parseGpxFile
 import java.io.BufferedReader
 import java.io.IOException
@@ -261,24 +258,9 @@ class SoundscapeIntents
                                                     routeData = parseGpxFile(input)
                                                 }
                                                 if(routeData != null) {
-                                                    // The parsing has succeeded, write the result to a
-                                                    // new markers database.
-                                                    // TODO: This intent should really open up the RouteDetails
-                                                    //  page and defer to that the action of inserting the
-                                                    //  route into the database. This is a temporary solution
-                                                    //  so that we can work on the code that uses the routes.
-                                                    val realm =
-                                                        RealmConfiguration.getMarkersInstance(true)
-                                                    val routesDao = RoutesDao(realm)
-                                                    val routesRepository =
-                                                        RoutesRepository(routesDao)
-                                                    runBlocking {
-                                                        launch {
-                                                            // Write the routeData to the database
-                                                            Log.d("gpx", "Inserting route")
-                                                            routesRepository.insertRoute(routeData)
-                                                        }
-                                                    }
+                                                    // The parsing has succeeded, pass the data to
+                                                    // the new route screen.
+                                                    mainActivity.navigator.navigate(generateRouteDetailsRoute(routeData))
                                                 }
                                             }
                                         } catch (e: Exception) {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/components/LocationItem.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/components/LocationItem.kt
@@ -1,5 +1,6 @@
 package org.scottishtecharmy.soundscape.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -61,8 +62,13 @@ fun LocationItem(
         )
     }
     Row(
-        modifier = modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.fillMaxWidth()
+                           .clickable {
+           if(decoration.details.enabled) {
+               decoration.details.functionString(item.name!!)
+           }
+       },
+        verticalAlignment = Alignment.CenterVertically
     ) {
         if(decoration.location) {
             Icon(
@@ -117,17 +123,11 @@ fun LocationItem(
                 )
             )
         } else if(decoration.details.enabled) {
-            Button(
-                onClick = {
-                    decoration.details.functionString(item.name!!)
-                },
-            ) {
-                Icon(
-                    Icons.Rounded.ChevronRight,
-                    contentDescription = null,
-                    tint = Color.White,
-                )
-            }
+            Icon(
+                Icons.Rounded.ChevronRight,
+                contentDescription = null,
+                tint = Color.White,
+            )
         }
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
@@ -12,10 +12,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.google.gson.GsonBuilder
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.scottishtecharmy.soundscape.database.local.model.RouteData
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.screens.home.home.HelpScreen
@@ -27,7 +30,7 @@ import org.scottishtecharmy.soundscape.screens.home.settings.Settings
 import org.scottishtecharmy.soundscape.screens.markers_routes.screens.MarkersAndRoutesScreen
 import org.scottishtecharmy.soundscape.screens.markers_routes.screens.addandeditroutescreen.AddAndEditRouteScreenVM
 import org.scottishtecharmy.soundscape.screens.markers_routes.screens.addandeditroutescreen.AddAndEditRouteViewModel
-import org.scottishtecharmy.soundscape.screens.markers_routes.screens.addandeditroutescreen.newRouteName
+import org.scottishtecharmy.soundscape.screens.markers_routes.screens.addandeditroutescreen.parseSimpleRouteData
 import org.scottishtecharmy.soundscape.screens.markers_routes.screens.routedetailsscreen.RouteDetailsScreenVM
 import org.scottishtecharmy.soundscape.viewmodels.SettingsViewModel
 import org.scottishtecharmy.soundscape.viewmodels.home.HomeViewModel
@@ -161,25 +164,58 @@ fun HomeScreen(
             )
         }
 
-        composable(HomeRoutes.AddAndEditRoute.route + "/{routeName}") { backStackEntry ->
-            val routeName = backStackEntry.arguments?.getString("routeName") ?: newRouteName
+        composable(HomeRoutes.AddAndEditRoute.route + "?command={command}&data={data}",
+            arguments = listOf(
+                navArgument("command") {
+                    type = NavType.StringType
+                    defaultValue = ""
+                },
+                navArgument("data") {
+                    type = NavType.StringType
+                    defaultValue = ""
+                }
+            )
+        ) { backStackEntry ->
+            val command = backStackEntry.arguments?.getString("command") ?: ""
+            val data = backStackEntry.arguments?.getString("data") ?: ""
+            var routeName : String
+
+            var routeData : RouteData? = null
+            when(command) {
+                "import" -> {
+                    try {
+                        routeData = parseSimpleRouteData(data)
+                    } catch(e: Exception) {
+                        Log.e("RouteDetailsScreen", "Error parsing route data: $e")
+                    }
+                }
+            }
+
             val addAndEditRouteViewModel: AddAndEditRouteViewModel = hiltViewModel()
 
             // Call the ViewModel's function to initialize the route data
-            LaunchedEffect(routeName) {
+            LaunchedEffect(data) {
                 addAndEditRouteViewModel.loadMarkers()
-                addAndEditRouteViewModel.initializeRoute(routeName)
+                if(routeData != null) {
+                    addAndEditRouteViewModel.initializeRoute(routeData)
+                    routeName = routeData.name
+                } else if(command == "edit") {
+                    addAndEditRouteViewModel.initializeRouteFromDatabase(data)
+                    routeName = data
+                } else {
+                    routeName = "New route"
+                }
             }
 
             // Pass any route details to the EditRouteScreen composable
             val uiState by addAndEditRouteViewModel.uiState.collectAsStateWithLifecycle()
             AddAndEditRouteScreenVM(
                 routeObjectId = uiState.routeObjectId,
-                routeName = routeName,
                 navController = navController,
                 viewModel = addAndEditRouteViewModel,
                 modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing),
-                userLocation = state.value.location
+                userLocation = state.value.location,
+                editRoute = (command == "edit")
             )
         }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
@@ -54,7 +54,7 @@ import org.scottishtecharmy.soundscape.ui.theme.SoundscapeTheme
 import org.scottishtecharmy.soundscape.viewmodels.LocationDetailsViewModel
 
 fun generateLocationDetailsRoute(locationDescription: LocationDescription): String {
-    // Generate JSON for the LocationDescription and append it to the rout
+    // Generate JSON for the LocationDescription and append it to the route
     val json = GsonBuilder().create().toJson(locationDescription)
 
     return "${HomeRoutes.LocationDetails.route}/$json"

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/AddWaypointsList.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/AddWaypointsList.kt
@@ -1,9 +1,12 @@
 package org.scottishtecharmy.soundscape.screens.markers_routes.screens.addandeditroutescreen
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -51,6 +54,10 @@ fun AddWaypointsList(
         items(locations) { locationDescription ->
             LocationItem(
                 item = locationDescription,
+                modifier = Modifier
+                    .padding(4.dp)
+                    .background(MaterialTheme.colorScheme.primary)
+                    .fillMaxWidth(),
                 decoration = LocationItemDecoration(
                     location = false,
                     editRoute = EnabledFunction(

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/ReorderableLocationList.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/ReorderableLocationList.kt
@@ -1,5 +1,6 @@
 package org.scottishtecharmy.soundscape.screens.markers_routes.screens.addandeditroutescreen
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.key
@@ -89,7 +91,6 @@ fun ReorderableLocationList(
                 Box(
                     modifier = Modifier
                         .fillParentMaxWidth()
-                        .padding(horizontal = 12.dp)
                         .offset { IntOffset(0, verticalTranslation) }
                         .onGloballyPositioned {
                             // This is called to update our array of list item heights. That's then
@@ -116,6 +117,9 @@ fun ReorderableLocationList(
                 ) {
                     LocationItem(
                         item = locationDescription,
+                        modifier = Modifier
+                            .padding(4.dp)
+                            .background(MaterialTheme.colorScheme.primary),
                         decoration = LocationItemDecoration(
                             index = idx
                         ),

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/markersscreen/MarkersScreenList.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/markersscreen/MarkersScreenList.kt
@@ -1,10 +1,13 @@
 package org.scottishtecharmy.soundscape.screens.markers_routes.screens.markersscreen
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -29,6 +32,9 @@ fun MarkersList(
         items(uiState.markers) { locationDescription ->
             LocationItem(
                 item = locationDescription,
+                modifier = Modifier
+                    .padding(4.dp)
+                    .background(MaterialTheme.colorScheme.primary),
                 decoration = LocationItemDecoration(
                     location = true,
                     details = EnabledFunction(

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/routedetailsscreen/RouteDetailsScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/routedetailsscreen/RouteDetailsScreen.kt
@@ -159,6 +159,7 @@ fun RouteDetailsScreen(
                         }
                         Column(modifier = Modifier.weight(0.6f)) {
                             IconWithTextButton(
+                                modifier = Modifier.fillMaxWidth(),
                                 icon = Icons.Default.PlayArrow,
                                 iconModifier = Modifier.size(40.dp),
                                 textModifier = Modifier.padding(horizontal = 4.dp),
@@ -176,14 +177,16 @@ fun RouteDetailsScreen(
                                     }
                                 })
                             IconWithTextButton(
+                                modifier = Modifier.fillMaxWidth(),
                                 icon = Icons.Default.Edit,
                                 iconModifier = Modifier.size(40.dp),
                                 textModifier = Modifier.padding(horizontal = 4.dp),
                                 iconText = stringResource(R.string.route_detail_action_edit),
                                 fontSize = 28.sp,
                                 fontWeight = FontWeight.Bold,
-                                onClick = { navController.navigate("${HomeRoutes.AddAndEditRoute.route}/${uiState.route.name}") })
+                                onClick = { navController.navigate("${HomeRoutes.AddAndEditRoute.route}?command=edit&data=${uiState.route.name}") })
                             IconWithTextButton(
+                                modifier = Modifier.fillMaxWidth(),
                                 icon = Icons.Default.Share,
                                 iconModifier = Modifier.size(40.dp),
                                 textModifier = Modifier.padding(horizontal = 4.dp),
@@ -227,6 +230,9 @@ fun RouteDetailsScreen(
                                         location = marker.location?.location() ?: LngLatAlt(),
                                         fullAddress = marker.fullAddress
                                     ),
+                                    modifier = Modifier
+                                        .padding(4.dp)
+                                        .background(MaterialTheme.colorScheme.primary),
                                     decoration = LocationItemDecoration(
                                         location = false,
                                         index = index,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/routesscreen/RoutesScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/routesscreen/RoutesScreen.kt
@@ -36,7 +36,6 @@ import org.scottishtecharmy.soundscape.database.local.model.RouteData
 import org.scottishtecharmy.soundscape.screens.home.HomeRoutes
 import org.scottishtecharmy.soundscape.screens.markers_routes.components.CustomFloatingActionButton
 import org.scottishtecharmy.soundscape.screens.markers_routes.components.MarkersAndRoutesListSort
-import org.scottishtecharmy.soundscape.screens.markers_routes.screens.addandeditroutescreen.newRouteName
 import org.scottishtecharmy.soundscape.ui.theme.SoundscapeTheme
 
 @Composable
@@ -151,7 +150,7 @@ fun RoutesScreen(
             }
         }
         CustomFloatingActionButton(
-            onClick = { homeNavController.navigate("${HomeRoutes.AddAndEditRoute.route}/$newRouteName") },
+            onClick = { homeNavController.navigate("${HomeRoutes.AddAndEditRoute.route}?command=new") },
             modifier = Modifier.align(Alignment.BottomCenter),
             icon = Icons.Rounded.AddCircleOutline,
             contentDescription = stringResource(R.string.general_alert_add),

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/routesscreen/RoutesScreenList.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/routesscreen/RoutesScreenList.kt
@@ -37,7 +37,8 @@ fun RouteList(
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(MaterialTheme.colorScheme.primary)
-                        .padding(16.dp),
+                        .padding(16.dp)
+                        .clickable { navController.navigate("${HomeRoutes.RouteDetails.route}/${route.name}") },
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -56,9 +57,7 @@ fun RouteList(
                     }
                     Icon(
                         modifier = Modifier
-                            .align(Alignment.CenterVertically)
-                            .clickable { navController.navigate("${HomeRoutes.RouteDetails.route}/${route.name}") },
-
+                            .align(Alignment.CenterVertically),
                         imageVector = Icons.Default.ChevronRight,
                         contentDescription = ""
                     )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/RoutePlayer.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/RoutePlayer.kt
@@ -64,7 +64,7 @@ class RoutePlayer(val service: SoundscapeService) {
                     AudioType.LOCALIZED, location.latitude, location.longitude, 0.0
                 )
 
-                service.createBeacon(LngLatAlt(location.latitude, location.longitude))
+                service.createBeacon(location.location())
             }
         }
     }


### PR DESCRIPTION
Importing a route via an intent now goes via the add route screen. This passes JSON describing the route from the intent into the screen which then displays it and allows adding it to the database.

There are also numerous amateur tweaks to improve the click sites within the markers/routes UI. Plenty still to do.