### PR TITLE
Add translations of beacon types to UI - #175

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/StreetPreviewUi.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/StreetPreviewUi.kt
@@ -74,7 +74,7 @@ fun StreetPreview(
                 exit()
             },
             // TODO: Internationalization
-            text = "Exit street preview"
+            text = stringResource(R.string.street_preview_exit)
         )
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
@@ -329,7 +329,7 @@ fun IconWithTextButton(
 fun IconsWithTextActionsPreview() {
     IconWithTextButton(
         icon = Icons.Filled.LocationOn,
-        text = "Start Audio Beacon",
+        text = stringResource(R.string.location_detail_action_beacon),
         action = {},
     )
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
@@ -89,7 +89,7 @@ fun Settings(
 
             item {
                 Text(
-                    text = "Manage Audio Engine",
+                    text = stringResource(R.string.menu_manage_audio),
                     color = MaterialTheme.colorScheme.onPrimary,
                     modifier = Modifier.semantics { heading() },
                     )
@@ -98,7 +98,7 @@ fun Settings(
                 key = MainActivity.BEACON_TYPE_KEY,
                 defaultValue = MainActivity.BEACON_TYPE_DEFAULT,
                 values = beaconTypes,
-                title = { Text(text = "Beacon type") },
+                title = { Text(text = stringResource(R.string.beacon_settings_style)) },
                 summary = { Text(text = it, color = MaterialTheme.colorScheme.onPrimary) },
             )
 
@@ -106,14 +106,14 @@ fun Settings(
                 key = MainActivity.VOICE_TYPE_KEY,
                 defaultValue = MainActivity.VOICE_TYPE_DEFAULT,
                 values = uiState.voiceTypes,
-                title = { Text(text = "Voice type") },
+                title = { Text(text = stringResource(R.string.voice_voices)) },
                 summary = { Text(text = it, color = MaterialTheme.colorScheme.onPrimary) },
             )
 
             sliderPreference(
                 key = MainActivity.SPEECH_RATE_KEY,
                 defaultValue = MainActivity.SPEECH_RATE_DEFAULT,
-                title = { Text(text = "Speech rate") },
+                title = { Text(text = stringResource(R.string.voice_settings_speaking_rate)) },
                 valueRange = 0.5f..2.0f,
                 valueSteps = 10,
                 valueText = { Text(text = "%.1fx".format(it), color = MaterialTheme.colorScheme.onPrimary) },

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
@@ -40,6 +40,8 @@ fun Settings(
     modifier: Modifier = Modifier,
 )
 {
+    val beaconTypes = uiState.beaconTypes.map { stringResource(it) }
+
     ProvidePreferenceLocals {
         LazyColumn (modifier = modifier){
             stickyHeader {
@@ -95,7 +97,7 @@ fun Settings(
             listPreference(
                 key = MainActivity.BEACON_TYPE_KEY,
                 defaultValue = MainActivity.BEACON_TYPE_DEFAULT,
-                values = uiState.beaconTypes,
+                values = beaconTypes,
                 title = { Text(text = "Beacon type") },
                 summary = { Text(text = it, color = MaterialTheme.colorScheme.onPrimary) },
             )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/components/CustomFloatingActionButton.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/components/CustomFloatingActionButton.kt
@@ -16,10 +16,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.ui.theme.SoundscapeTheme
 
 @Composable
@@ -112,7 +114,7 @@ fun SmallCustomFloatingActionButtonWithTextPreview() {
                 iconSize = 48.dp // Example of customizing the icon size
             )
             CustomTextButton(
-                text = "Add Route",
+                text = stringResource(R.string.route_detail_action_create),
                 modifier = Modifier,
                 onClick = { },
                 contentColor = MaterialTheme.colorScheme.onPrimary,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/components/CustomTextButton.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/components/CustomTextButton.kt
@@ -7,10 +7,12 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.ui.theme.SoundscapeTheme
 
 @Composable
@@ -47,7 +49,7 @@ fun CustomTextButtonPreview() {
         // Default preview
         CustomTextButton(
             onClick = { /*TODO*/ },
-            text = "Done",
+            text = stringResource(R.string.general_alert_done),
             contentColor = MaterialTheme.colorScheme.onPrimary,
             textStyle = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/audiobeacons/AudioBeacons.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/audiobeacons/AudioBeacons.kt
@@ -36,6 +36,26 @@ import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.components.OnboardButton
 import org.scottishtecharmy.soundscape.screens.onboarding.component.BoxWithGradientBackground
 
+fun getBeaconResourceId(beaconName: String) : Int {
+    when (beaconName) {
+        "Original" -> return R.string.beacon_styles_original
+        "Current" -> return R.string.beacon_styles_current
+        "Tactile" -> return R.string.beacon_styles_tactile
+        "Flare" -> return R.string.beacon_styles_flare
+        "Shimmer" -> return R.string.beacon_styles_shimmer
+        "Ping" -> return R.string.beacon_styles_ping
+        "Drop" -> return R.string.beacon_styles_drop
+        "Signal" -> return R.string.beacon_styles_signal
+        "Signal Slow" -> return R.string.beacon_styles_signal_slow
+        "Signal Very Slow" -> return R.string.beacon_styles_signal_very_slow
+        "Mallet" -> return R.string.beacon_styles_mallet
+        "Mallet Slow" -> return R.string.beacon_styles_mallet_slow
+        "Mallet Very Slow" -> return R.string.beacon_styles_mallet_very_slow
+        else -> assert(false)
+    }
+    return 0
+}
+
 @Composable
 fun AudioBeaconsScreen(
     onNavigate: () -> Unit,
@@ -124,7 +144,7 @@ fun AudioBeacons(
             ) {
                 items(beacons) { beacon ->
                     AudioBeaconItem(
-                        text = beacon,
+                        text = stringResource(getBeaconResourceId(beacon)),
                         isSelected = beacon == selectedBeacon,
                         onSelect = {
                             onBeaconSelected(beacon)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/SettingsViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.scottishtecharmy.soundscape.SoundscapeServiceConnection
+import org.scottishtecharmy.soundscape.screens.onboarding.audiobeacons.getBeaconResourceId
 import org.scottishtecharmy.soundscape.utils.getCurrentLocale
 import javax.inject.Inject
 
@@ -20,7 +21,7 @@ class SettingsViewModel @Inject constructor(
 ) : ViewModel() {
     data class SettingsUiState(
         // Data for the ViewMode that affects the UI
-        var beaconTypes : List<String> = emptyList(),
+        var beaconTypes : List<Int> = emptyList(),
         var voiceTypes : List<String> = emptyList()
     )
 
@@ -70,9 +71,9 @@ class SettingsViewModel @Inject constructor(
                                 }
 
                                 val audioEngineBeaconTypes = audioEngine.getListOfBeaconTypes()
-                                val beaconTypes = mutableListOf<String>()
+                                val beaconTypes = mutableListOf<Int>()
                                 for (type in audioEngineBeaconTypes) {
-                                    beaconTypes.add(type)
+                                    beaconTypes.add(getBeaconResourceId(type))
                                 }
                                 _state.value = SettingsUiState(
                                     beaconTypes = beaconTypes,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3573,7 +3573,7 @@ Alternatively, you may continue previewing the app with a predefined test locati
   <string name="faq_tip_two_finger_double_tap">"Tapping the screen twice with two fingers will silence any active callouts."</string>
 
   <!-- New language strings since iOS -->
-  <string name="no_language_selected">Ingen sprog valgt</string>
+  <string name="no_language_selected">No language selected</string>
   <string name="street_preview_enabled">Street Preview enabled</string>
   <string name="street_preview_disabled">Street Preview disabled</string>
 
@@ -3591,6 +3591,8 @@ Alternatively, you may continue previewing the app with a predefined test locati
   <string name="enter_street_preview"  translatable="false">Enter Street Preview</string>
   <string name="osm_tag_train_station"  translatable="false">"Train station"</string>
   <string name="osm_tag_train_station_named"  translatable="false">"%s Train station"</string>
+  <string name="menu_manage_audio" translatable="false">"Manage Audio"</string>
+  <string name="street_preview_exit" translatable="false">"Exit Street Preview"</string>
 
   <!-- We need to encode < as &lt; to prevent them being stripped prior to use -->
   <!-- Licensing strings -->


### PR DESCRIPTION
The beacon type strings are returned from C++. This change adds in a mapping function to resource ids which are then used in the UI.