### PR TITLE
Make opening route via intent more robust

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -133,6 +133,15 @@ class MainActivity : AppCompatActivity() {
             installSplashScreen()
         }
 
+        // When opening a JSON file containing a route from Android File we can end up with two
+        // instances of the app running. This check ensures that we have only one instance.
+        if (!isTaskRoot) {
+            val newIntent = Intent(intent)
+            newIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(newIntent)
+            finish()
+        }
+
         if (isFirstLaunch) {
             // On the first launch, we want to take the user through the OnboardingActivity so
             // switch to it immediately.

--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeIntents.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeIntents.kt
@@ -227,6 +227,12 @@ class SoundscapeIntents
                                                     // This might be a saved route shared from iOS.
                                                     // We want to translate this into a RouteData
                                                     // format to write to our database.
+
+                                                    // Limit the size of routes to 1MB which would
+                                                    // be several thousand markers.
+                                                    if(input.available() > 1000000) {
+                                                        throw Exception("File too large")
+                                                    }
                                                     val json = inputStreamToJson(input) ?: throw Exception("Failed to parse JSON")
 
                                                     routeData = RouteData()


### PR DESCRIPTION
* Limit the size of routes to 1MB to prevent arbitrary files causing out of memory issues.
* Ensure that only one instance of the app is opened when opening from a route file using Android File explorer.