### PR TITLE
Enable minify and shrink on release builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,8 +74,20 @@ android {
     }
 
     buildTypes {
+
+// For debugging proguard uncomment the following:
+//        debug {
+//            isMinifyEnabled = true
+//            isShrinkResources = true
+//            proguardFiles(
+//                getDefaultProguardFile("proguard-android-optimize.txt"),
+//                "proguard-rules.pro"
+//            )
+//        }
+
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -12,10 +12,12 @@
 #   public *;
 #}
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
+# For debugging, uncomment the next two lines
 #-keepattributes SourceFile,LineNumberTable
+#-dontobfuscate
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# Preserve fmod library
+-keep class org.fmod.** { *; }
+
+# Preserve protobuf generated classes (for MVT vector_tiles)
+-keep class * extends com.google.protobuf.GeneratedMessageLite { *; }


### PR DESCRIPTION
Two new proguard rules were required. One to preserve FMOD library and the other for protobuf generated files. With these in place the shrunk app now runs successfully.