### PR TITLE
Reinstate Adam's polygon merging code with a bit of refactoring

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -136,8 +136,9 @@ class MainActivity : AppCompatActivity() {
             val timeNow = System.currentTimeMillis()
             installSplashScreen()
 
-            // Keep the splash screen visible to allow time to see the attribution acknowledgements
-            val attributionDelay = 3000
+            // Keep the splash screen visible to allow time to see the attribution acknowledgements,
+            // But not too long as this delay happens coming out of sleep too.
+            val attributionDelay = 2000
             val content: View = findViewById(android.R.id.content)
             content.viewTreeObserver.addOnPreDrawListener(
                 object : ViewTreeObserver.OnPreDrawListener {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -320,7 +320,7 @@ class GeoEngine {
                         UserGeometry(
                             location = LngLatAlt(location?.longitude ?: 0.0, location?.latitude ?: 0.0),
                             phoneHeading = phoneHeading,
-                            speed = location?.speed?.toDouble() ?: 0.0,
+                            speed = speed,
                             travelHeading = travelHeading
                         )
                     }.collect { geometry ->

--- a/app/src/test/java/org/scottishtecharmy/soundscape/MvtTileTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/MvtTileTest.kt
@@ -7,6 +7,7 @@ import org.scottishtecharmy.soundscape.geoengine.mvttranslation.vectorTileToGeoJ
 import org.scottishtecharmy.soundscape.geoengine.utils.FeatureTree
 import org.scottishtecharmy.soundscape.geoengine.utils.TileGrid.Companion.getTileGrid
 import org.scottishtecharmy.soundscape.geoengine.utils.getLatLonTileWithOffset
+import org.scottishtecharmy.soundscape.geoengine.utils.mergeAllPolygonsInFeatureCollection
 import org.scottishtecharmy.soundscape.geoengine.utils.searchFeaturesByName
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
@@ -185,16 +186,18 @@ class MvtTileTest {
         // Add lines to connect all of the interpolated points
         joiner.addJoiningLines(featureCollection)
 
+        val mergedCollection = mergeAllPolygonsInFeatureCollection(featureCollection)
+
         val adapter = GeoJsonObjectMoshiAdapter()
 
         // Check that the de-duplication of the points worked (without that there are two points
         // for Graeme Pharmacy, one each from two separate tiles).
-        val searchResults = searchFeaturesByName(featureCollection, "Graeme")
+        val searchResults = searchFeaturesByName(mergedCollection, "Graeme")
         println(adapter.toJson(searchResults))
         assert(searchResults.features.size == 1)
 
         val outputFile = FileOutputStream("2x2.geojson")
-        outputFile.write(adapter.toJson(featureCollection).toByteArray())
+        outputFile.write(adapter.toJson(mergedCollection).toByteArray())
         outputFile.close()
     }
 


### PR DESCRIPTION
I refactored mergeAllPolygonsInFeatureCollection a little so that it would merge all duplicates of a polygon into a single one. It seems to work well, so I've re-enabled it to see what happens.