### PR TITLE
Use country as well as language when matching locale

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -966,10 +966,13 @@ fun localReverseGeocode(location: LngLatAlt,
             if (roadName == null) {
                 roadName = properties["highway"]
             }
-            return LocationDescription(
-                name = localizedContext.getString(R.string.directions_near_name).format(roadName as String),
-                location = location,
-            )
+            if(roadName != null) {
+                return LocationDescription(
+                    name = localizedContext.getString(R.string.directions_near_name)
+                        .format(roadName as String),
+                    location = location,
+                )
+            }
         }
     }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/language/LanguageViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/language/LanguageViewModel.kt
@@ -59,16 +59,29 @@ class LanguageViewModel @Inject constructor(private val audioEngine : NativeAudi
         addIfSpeechSupports(allLanguages, Language("日本語", "ja", "JP"))
         addIfSpeechSupports(allLanguages, Language("Norsk", "nb", "NO"))
         addIfSpeechSupports(allLanguages, Language("Nederlands", "nl", "NL"))
-        addIfSpeechSupports(allLanguages, Language("Português (Brasil)", "pt", "BR"))
         addIfSpeechSupports(allLanguages, Language("Português (Portugal)", "pt", "PT"))
+        addIfSpeechSupports(allLanguages, Language("Português (Brasil)", "pt", "BR"))
         addIfSpeechSupports(allLanguages, Language("Svenska", "sv", "SE"))
 
         return allLanguages
     }
 
     private fun List<Language>.indexOfLanguageMatchingDeviceLanguage(): Int {
-        val deviceLanguage = Locale.getDefault().language
-        return this.indexOfFirst { it.code == deviceLanguage }
+        val phoneLocale = Locale.getDefault()
+        val deviceLanguage = phoneLocale.language
+        val deviceRegion = phoneLocale.country
+        var bestIndex = -1
+        for (language in this) {
+            if (language.code == deviceLanguage && language.region == deviceRegion) {
+                return this.indexOf(language)
+            }
+            else if (language.code == deviceLanguage) {
+                if(bestIndex == -1) {
+                    bestIndex = this.indexOf(language)
+                }
+            }
+        }
+        return bestIndex
     }
 
     fun updateLanguage(selectedLanguage: Language): Boolean {


### PR DESCRIPTION
Two fixes here:

Language selection - the code to show the default language in the onboarding screen was only using the phone language and not the country. As a result on UK English phones it was showing English (US) as the selected language. This change adds the country into the mix. If the country isn't supported, the language selected will be the first in the list i.e. French from France, non-UK English and Portuguese from Portugal.

Travelling by train!