### PR TITLE
Fix StreetPreview behaviour to work with NearestRoad changes

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/filters/NearestRoadFilter.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/filters/NearestRoadFilter.kt
@@ -74,17 +74,24 @@ class NearestRoadFilter {
                     bestFitness = fitness
                     bestIndex = index
                 }
-//                println("fitness: ${fitness} for ${sensedRoad.properties?.get("name")} (${sensedRoadInfo.distance}m, ${headingOffSensedRoad}deg -> $currentHeading vs. ${sensedRoadInfo.heading}")
+                println("fitness: ${fitness} for ${sensedRoad.properties?.get("name")} (${sensedRoadInfo.distance}m, ${headingOffSensedRoad}deg -> $currentHeading vs. ${sensedRoadInfo.heading}")
             }
             val bestMatch = sensedNearestRoads.features[bestIndex]
             nearestRoad?.let { road ->
                 if (road != bestMatch) {
-                    // It needs to be easier to stay on the current road than to switch to the new one
-                    // so make sure it calculates it more than once.
-                    debounceCount--
-                    if (debounceCount == 0) {
+                    if(locationAccuracy == 0.0) {
+                        // The static location provider sets the location accuracy to 0.0 and in
+                        // this case we can trust the calculation without debounce
                         nearestRoad = bestMatch
-                        debounceCount = 2
+                    }
+                    else {
+                        // It needs to be easier to stay on the current road than to switch to the new one
+                        // so make sure it calculates it more than once.
+                        debounceCount--
+                        if (debounceCount == 0) {
+                            nearestRoad = bestMatch
+                            debounceCount = 2
+                        }
                     }
                     return
                 } else {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/GeoUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/GeoUtils.kt
@@ -1337,3 +1337,12 @@ fun calculateHeadingOffset(heading1: Double, heading2: Double): Double {
 
     return diff
 }
+
+/**
+ * normaliseHeading turns a possibly negative heading into a heading between 0 and 360 degrees
+ * @param heading
+ * @return A heading between 0 and 360 degrees
+ */
+fun normaliseHeading(heading: Double): Double {
+    return (heading + 3600.0) % 360.0
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/GpxDrivenProvider.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/GpxDrivenProvider.kt
@@ -77,7 +77,9 @@ class GpxDrivenProvider  {
                         LngLatAlt(
                             interpolatedPoint.longitude,
                             interpolatedPoint.latitude
-                        ), walkingSpeed.toFloat()
+                        ),
+                        heading.toFloat(),
+                        walkingSpeed.toFloat()
                     )
                     directionProvider.audioEngine?.updateGeometry(
                         interpolatedPoint.latitude,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/LocationProvider.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/LocationProvider.kt
@@ -9,7 +9,7 @@ import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 abstract class LocationProvider {
     abstract fun start(context : Context)
     abstract fun destroy()
-    open fun updateLocation(newLocation: LngLatAlt, speed: Float) { }
+    open fun updateLocation(newLocation: LngLatAlt, heading: Float, speed: Float) { }
 
     fun hasValidLocation(): Boolean{
         return mutableLocationFlow.value != null

--- a/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/StaticLocationProvider.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/locationprovider/StaticLocationProvider.kt
@@ -12,20 +12,22 @@ class StaticLocationProvider(private var location: LngLatAlt) :
     }
 
     override fun start(context : Context){
-        // Simply set our flow source as the passed in location with 10m accuracy so that it's not ignored
+        // Simply set our flow source as the passed in location with 0.0m accuracy so that it's not ignored
         val passiveLocation = Location(LocationManager.PASSIVE_PROVIDER)
         passiveLocation.latitude = location.latitude
         passiveLocation.longitude = location.longitude
-        passiveLocation.accuracy = 10.0F
+        passiveLocation.accuracy = 0.0F
         mutableLocationFlow.value = passiveLocation
     }
 
-    override fun updateLocation(newLocation: LngLatAlt, speed: Float) {
+    override fun updateLocation(newLocation: LngLatAlt, heading: Float, speed: Float) {
         val passiveLocation = Location(LocationManager.PASSIVE_PROVIDER)
         passiveLocation.latitude = newLocation.latitude
         passiveLocation.longitude = newLocation.longitude
+        passiveLocation.accuracy = 0.0F
+        passiveLocation.bearing = heading
+        passiveLocation.bearingAccuracyDegrees = 10.0F
         passiveLocation.speed = speed
-        passiveLocation.accuracy = 10.0F
         mutableLocationFlow.value = passiveLocation
     }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeViewModel.kt
@@ -130,11 +130,14 @@ class HomeViewModel
             // Observe street preview mode from the service so we can update state
             soundscapeServiceConnection.getStreetPreviewModeFlow()?.collect { value ->
                 Log.d(TAG, "Street Preview Mode: $value")
+                val enabled = state.value.streetPreviewState.enabled
                 _state.update { it.copy(streetPreviewState = value) }
 
-                // Restart location monitoring for new provider
-                stopMonitoringLocation()
-                startMonitoringLocation()
+                if(enabled != value.enabled) {
+                    // Restart location monitoring for new provider
+                    stopMonitoringLocation()
+                    startMonitoringLocation()
+                }
             }
         }
     }


### PR DESCRIPTION
The NearestRoadFilter uses the direction of travel along with the location to determine the nearest road. If we provide the direction of travel to the StaticLocationProvider from the StreetPreview go function then we can indicate which road we arrived at the intersection on. The direction of travel is always the heading of the road that was travelled along.