### PR TITLE
LocationDetails start beacon now creates a temporary Route

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
@@ -54,8 +54,8 @@ class SoundscapeServiceConnection @Inject constructor() {
         soundscapeService?.setStreetPreviewMode(on, location)
     }
 
-    fun startRoute(routeId: ObjectId) {
-        soundscapeService?.startRoute(routeId)
+    fun routeStart(routeId: ObjectId) {
+        soundscapeService?.routeStart(routeId)
     }
 
     fun routeSkipPrevious() {
@@ -67,8 +67,8 @@ class SoundscapeServiceConnection @Inject constructor() {
     fun routeMute() {
         soundscapeService?.routeMute()
     }
-    fun stopRoute() {
-        soundscapeService?.stopRoute()
+    fun routeStop() {
+        soundscapeService?.routeStop()
     }
 
     // needed to communicate with the service.

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
@@ -61,6 +61,7 @@ data class RouteFunctions(val viewModel: HomeViewModel?) {
     val skipPrevious = { viewModel?.routeSkipPrevious() }
     val skipNext = { viewModel?.routeSkipNext() }
     val mute = { viewModel?.routeMute() }
+    val stop =  { viewModel?.routeStop() }
 }
 
 data class StreetPreviewFunctions(val viewModel: HomeViewModel?) {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.automirrored.filled.VolumeOff
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
@@ -170,16 +171,29 @@ fun HomeContent(
                                         contentDescription = stringResource(R.string.route_detail_action_next)
                                     )
                                 }
-                                Button(onClick = {
-                                        onNavigate("${HomeRoutes.RouteDetails.route}/${routePlayerState.routeData.objectId.toHexString()}")
+                                Button(
+                                    onClick = {
+                                        if (routePlayerState.beaconOnly) {
+                                            routeFunctions.stop()
+                                        } else {
+                                            onNavigate("${HomeRoutes.RouteDetails.route}/${routePlayerState.routeData.objectId.toHexString()}")
+                                        }
                                     }
                                 )
                                 {
-                                    Icon(
-                                        modifier = Modifier,
-                                        imageVector = Icons.Filled.Info,
-                                        contentDescription = stringResource(R.string.behavior_experiences_route_nav_title),
-                                    )
+                                    if (routePlayerState.beaconOnly) {
+                                        Icon(
+                                            modifier = Modifier,
+                                            imageVector = Icons.Filled.Stop,
+                                            contentDescription = stringResource(R.string.route_detail_action_stop_route),
+                                        )
+                                    } else {
+                                        Icon(
+                                            modifier = Modifier,
+                                            imageVector = Icons.Filled.Info,
+                                            contentDescription = stringResource(R.string.behavior_experiences_route_nav_title),
+                                        )
+                                    }
                                 }
                                 Button(onClick = { routeFunctions.mute() })
                                 {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
@@ -70,7 +70,8 @@ fun LocationDetailsScreen(
         navController = navController,
         locationDescription = locationDescription,
         createBeacon = { loc ->
-            viewModel.createBeacon(loc)
+            viewModel.startBeacon(loc, locationDescription.name ?: "")
+            navController.popBackStack(HomeRoutes.Home.route, false)
         },
         saveMarker = { description, successMessage, failureMessage ->
             viewModel.createMarker(

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/routedetailsscreen/RouteDetailsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/routedetailsscreen/RouteDetailsViewModel.kt
@@ -46,11 +46,11 @@ class RouteDetailsViewModel @Inject constructor(
     }
 
     fun startRoute(routeId: ObjectId) {
-        soundscapeServiceConnection.startRoute(routeId)
+        soundscapeServiceConnection.routeStart(routeId)
     }
 
     fun stopRoute() {
-        soundscapeServiceConnection.stopRoute()
+        soundscapeServiceConnection.routeStop()
     }
 
     fun clearErrorMessage() {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -10,7 +10,6 @@ import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.net.Uri
 import android.os.Binder
-import android.os.Build
 import android.os.IBinder
 import android.util.Log
 import android.widget.Toast
@@ -388,10 +387,13 @@ class SoundscapeService : MediaSessionService() {
         return geoEngine.getLocationDescription(location)
     }
 
-    fun startRoute(routeId: ObjectId) {
+    fun startBeacon(location: LngLatAlt, name: String) {
+        routePlayer.startBeacon(location, name)
+    }
+    fun routeStart(routeId: ObjectId) {
         routePlayer.startRoute(routeId)
     }
-    fun stopRoute() {
+    fun routeStop() {
         routePlayer.stopRoute()
     }
     fun routeSkipPrevious(): Boolean {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
@@ -26,8 +26,8 @@ class LocationDetailsViewModel @Inject constructor(
     private val routesRepository: RoutesRepository
 ): ViewModel() {
 
-    fun createBeacon(location: LngLatAlt) {
-        soundscapeServiceConnection.soundscapeService?.createBeacon(location)
+    fun startBeacon(location: LngLatAlt, name: String) {
+        soundscapeServiceConnection.soundscapeService?.startBeacon(location, name)
     }
 
     fun enableStreetPreview(location: LngLatAlt) {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/home/HomeViewModel.kt
@@ -222,6 +222,11 @@ class HomeViewModel
             soundscapeServiceConnection.routeMute()
         }
     }
+    fun routeStop() {
+        viewModelScope.launch {
+            soundscapeServiceConnection.routeStop()
+        }
+    }
 
     fun getLocationDescription(location: LngLatAlt) : LocationDescription? {
         return soundscapeServiceConnection.soundscapeService?.getLocationDescription(location)


### PR DESCRIPTION
By creating a temporary Route for the RoutePlayer that contains a single Waypoint, we can re-use the UI that is used for Route control. However, because there's no other information about the Route the Info icon is altered to be a Stop icon instead. This allows easy stopping of the beacon.