### PR TITLE
Increase sidewalk support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 .externalNativeBuild
 .cxx
 app/*.geojson
-app/callout-text.txt
+app/callout*.txt
 
 # Gradle files
 .gradle/

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/IntersectionUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/IntersectionUtils.kt
@@ -63,7 +63,7 @@ fun getRoadsDescriptionFromFov(gridState: GridState,
 
     // If we're on a mapped sidewalk, use the associated road for intersection detection instead of
     // the sidewalk itself.
-    if(nearestRoad?.properties?.get("footway") == "sidewalk") {
+    if(nearestRoad?.isSidewalkOrCrossing() == true) {
         if(nearestRoad.properties?.get("pavement") == null) {
             // Confect the names for the sidewalk first, this should come up with the name of the
             // associated road.
@@ -106,7 +106,7 @@ fun getRoadsDescriptionFromFov(gridState: GridState,
         val intersection = i as Intersection
         var add = true
         for(way in i.members) {
-            if(way.properties?.get("footway") == "sidewalk")
+            if(way.isSidewalkOrCrossing())
                 add = false
             else if(way.isSidewalkConnector(intersection, nearestRoad, gridState))
                 add = false
@@ -153,7 +153,7 @@ fun getRoadsDescriptionFromFov(gridState: GridState,
                                 if (next.members.size > 2) {
                                     for(member in next.members) {
                                         if(member.properties != null) {
-                                            if ((member.properties?.get("footway") != "sidewalk") &&
+                                            if (member.isSidewalkOrCrossing() &&
                                                 !member.isSidewalkConnector(intersection, nearestRoad, gridState)
                                             ) {
                                                 count++

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/mvttranslation/WayGenerator.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/mvttranslation/WayGenerator.kt
@@ -162,6 +162,11 @@ class Way : Feature() {
         return null
     }
 
+    fun isSidewalkOrCrossing() : Boolean {
+        val footway = properties?.get("footway")
+        return ((footway == "sidewalk") || (footway == "crossing"))
+    }
+
     /**
      * isSidewalkConnector returns true if this way is joining mainWay from intersection to its
      * own sidewalk e.g. https://www.openstreetmap.org/way/958596881. If we are map matched to the
@@ -184,7 +189,7 @@ class Way : Feature() {
         getOtherIntersection(intersection)?.let { otherIntersection ->
             for(way in otherIntersection.members) {
                 if(way == this) continue
-                if(way.properties?.get("footway") != "sidewalk") {
+                if(isSidewalkOrCrossing()){
                     // This does connect to something that isn't a sidewalk, so it's not a simple
                     // connector i.e. it may connect to a sidewalk, but it goes further.
                     return false

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileUtils.kt
@@ -1938,23 +1938,25 @@ fun getSuperCategoryElements(category: String): Set<String> {
 
 
 fun addSidewalk(currentRoad: Way,
-                start: LngLatAlt,
-                end: LngLatAlt,
                 roadTree: FeatureTree) : Boolean {
 
     if(currentRoad.isSidewalkOrCrossing()){
         if(currentRoad.properties?.containsKey("pavement") == true)
             return true
 
+        val line = currentRoad.geometry as LineString
+        val start = line.coordinates.first()
+        val end = line.coordinates.last()
+
         val startRoads = roadTree.getNearestCollection(
             location = start,
-            distance = 15.0,
-            maxCount = 10
+            distance = 20.0,
+            maxCount = 25
         )
         val endRoads = roadTree.getNearestCollection(
             location = end,
-            distance = 15.0,
-            maxCount = 10
+            distance = 20.0,
+            maxCount = 25
         )
         // Find common road that's near the start and the end of our road - ignoring any sidewalks
         var name: Any? = null
@@ -1998,9 +2000,11 @@ fun addSidewalk(currentRoad: Way,
 }
 
 fun addPoiDestinations(currentRoad: Feature,
-                       startLocation: LngLatAlt,
-                       endLocation: LngLatAlt,
                        gridState: GridState) : Boolean {
+
+    val line = currentRoad.geometry as LineString
+    val startLocation = line.coordinates.first()
+    val endLocation = line.coordinates.last()
 
     // Only add in destinations tag if they don't already exist
     val startDestinationAdded = currentRoad.properties?.get("destination:backward") != null
@@ -2071,14 +2075,11 @@ fun confectNamesForRoad(road: Feature,
     val roadTree = gridState.featureTrees[TreeId.ROADS_AND_PATHS.id]
     if (road.properties?.get("name") == null) {
 
-        val line = road.geometry as LineString
-        val start = line.coordinates.first()
-        val end = line.coordinates.last()
-        if (addSidewalk(road as Way, start, end, roadTree)) {
+        if (addSidewalk(road as Way, roadTree)) {
             return
         }
 
-        addPoiDestinations(road, start, end, gridState)
+        addPoiDestinations(road, gridState)
     }
 }
 

--- a/app/src/test/java/org/scottishtecharmy/soundscape/MvtTileTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/MvtTileTest.kt
@@ -545,19 +545,17 @@ class MvtTileTest {
         return true
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Test
-    fun testMovingGrid() {
+    fun testMovingGrid(gpxFilename: String, calloutFilename: String, geojsonFilename: String) {
 
         val gridState = FileGridState()
         val mapMatchFilter = MapMatchFilter()
-        val gps = parseGpxFromFile("travel-3.gpx")
+        val gps = parseGpxFromFile(gpxFilename)
         val collection = FeatureCollection()
         val startIndex = 0
         val endIndex = gps.features.size
         val autoCallout = AutoCallout(null, null)
         var lastCallout : List<PositionedString> = emptyList()
-        val callOutText = FileOutputStream("callout-text.txt")
+        val callOutText = FileOutputStream(calloutFilename)
 
         val markers = FeatureCollection()
         val marker = Feature()
@@ -631,9 +629,17 @@ class MvtTileTest {
         callOutText.close()
 
         val adapter = GeoJsonObjectMoshiAdapter()
-        val mapMatchingOutput = FileOutputStream("map-matching.geojson")
+        val mapMatchingOutput = FileOutputStream(geojsonFilename)
         mapMatchingOutput.write(adapter.toJson(collection).toByteArray())
         mapMatchingOutput.close()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testCallouts() {
+        testMovingGrid("travel.gpx", "callout-travel.txt", "map-matching.geojson")
+        testMovingGrid("travel-2.gpx", "callout-travel-2.txt", "map-matching-2.geojson")
+        testMovingGrid("travel-3.gpx", "callout-travel-3.txt", "map-matching-3.geojson")
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/test/java/org/scottishtecharmy/soundscape/MvtTileTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/MvtTileTest.kt
@@ -551,7 +551,7 @@ class MvtTileTest {
 
         val gridState = FileGridState()
         val mapMatchFilter = MapMatchFilter()
-        val gps = parseGpxFromFile("travel-2.gpx")
+        val gps = parseGpxFromFile("travel-3.gpx")
         val collection = FeatureCollection()
         val startIndex = 0
         val endIndex = gps.features.size

--- a/app/src/test/res/org/scottishtecharmy/soundscape/travel-3.gpx
+++ b/app/src/test/res/org/scottishtecharmy/soundscape/travel-3.gpx
@@ -1,0 +1,21217 @@
+<?xml version='1.0' encoding='utf-8'?>
+<gpx xmlns="http://www.topografix.com/GPX/1/0" version="1.0" creator="Soundscape">
+<trk>
+<name>Track 0</name>
+<number>0</number>
+<trkseg>
+<trkpt lat="55.9472179" lon="-4.3081343">
+<ele>149.38631512651972></ele>
+<accuracy>3.116</accuracy>
+<speed>1.1777722</speed>
+<bearing>108.95233</bearing>
+<bearingAccuracyDegrees>9.038431</bearingAccuracyDegrees>
+<time>1746103376373</time>
+</trkpt>
+<trkpt lat="55.9472355" lon="-4.3081427">
+<ele>149.25841118674703></ele>
+<accuracy>6.013</accuracy>
+<speed>0.0</speed>
+<bearing>186.78156</bearing>
+<bearingAccuracyDegrees>52.364162</bearingAccuracyDegrees>
+<time>1746103383618</time>
+</trkpt>
+<trkpt lat="55.9472342" lon="-4.3080932">
+<ele>149.18636817244953></ele>
+<accuracy>6.401</accuracy>
+<speed>0.8542439</speed>
+<bearing>211.99142</bearing>
+<bearingAccuracyDegrees>61.634724</bearingAccuracyDegrees>
+<time>1746103385164</time>
+</trkpt>
+<trkpt lat="55.9472404" lon="-4.30806">
+<ele>149.33254303436746></ele>
+<accuracy>5.325</accuracy>
+<speed>0.713967</speed>
+<bearing>249.40149</bearing>
+<bearingAccuracyDegrees>36.241295</bearingAccuracyDegrees>
+<time>1746103386514</time>
+</trkpt>
+<trkpt lat="55.9472505" lon="-4.3080567">
+<ele>149.41711676765226></ele>
+<accuracy>4.771</accuracy>
+<speed>0.09392627</speed>
+<bearing>0.0</bearing>
+<bearingAccuracyDegrees>0.0</bearingAccuracyDegrees>
+<time>1746103388520</time>
+</trkpt>
+<trkpt lat="55.9472641" lon="-4.3080451">
+<ele>149.1347035116346></ele>
+<accuracy>3.06</accuracy>
+<speed>0.677406</speed>
+<bearing>262.0152</bearing>
+<bearingAccuracyDegrees>10.0</bearingAccuracyDegrees>
+<time>1746103394446</time>
+</trkpt>
+<trkpt lat="55.9472581" lon="-4.3080578">
+<ele>149.07205783435882></ele>
+<accuracy>3.21</accuracy>
+<speed>0.41306558</speed>
+<bearing>244.5882</bearing>
+<bearingAccuracyDegrees>72.260376</bearingAccuracyDegrees>
+<time>1746103396461</time>
+</trkpt>
+<trkpt lat="55.9472543" lon="-4.30808">
+<ele>149.30854765631344></ele>
+<accuracy>3.859</accuracy>
+<speed>0.9856835</speed>
+<bearing>262.0787</bearing>
+<bearingAccuracyDegrees>60.24949</bearingAccuracyDegrees>
+<time>1746103398285</time>
+</trkpt>
+<trkpt lat="55.9472488" lon="-4.3081086">
+<ele>149.4870734471518></ele>
+<accuracy>4.402</accuracy>
+<speed>1.2055187</speed>
+<bearing>253.60191</bearing>
+<bearingAccuracyDegrees>39.947678</bearingAccuracyDegrees>
+<time>1746103399349</time>
+</trkpt>
+<trkpt lat="55.9472434" lon="-4.3081424">
+<ele>149.4682790594398></ele>
+<accuracy>4.903</accuracy>
+<speed>1.3387269</speed>
+<bearing>254.1331</bearing>
+<bearingAccuracyDegrees>24.880306</bearingAccuracyDegrees>
+<time>1746103400351</time>
+</trkpt>
+<trkpt lat="55.9472452" lon="-4.3082769">
+<ele>149.35551359570516></ele>
+<accuracy>5.135</accuracy>
+<speed>1.475866</speed>
+<bearing>264.88492</bearing>
+<bearingAccuracyDegrees>16.159496</bearingAccuracyDegrees>
+<time>1746103404499</time>
+</trkpt>
+<trkpt lat="55.947245" lon="-4.3083044">
+<ele>149.38005039944983></ele>
+<accuracy>5.069</accuracy>
+<speed>1.4645374</speed>
+<bearing>262.1302</bearing>
+<bearingAccuracyDegrees>16.102985</bearingAccuracyDegrees>
+<time>1746103405503</time>
+</trkpt>
+<trkpt lat="55.9472468" lon="-4.3083393">
+<ele>149.54032443538264></ele>
+<accuracy>5.368</accuracy>
+<speed>1.419538</speed>
+<bearing>245.2635</bearing>
+<bearingAccuracyDegrees>14.684407</bearingAccuracyDegrees>
+<time>1746103406565</time>
+</trkpt>
+<trkpt lat="55.947242" lon="-4.3083651">
+<ele>149.69068194673764></ele>
+<accuracy>5.675</accuracy>
+<speed>1.4161794</speed>
+<bearing>246.79758</bearing>
+<bearingAccuracyDegrees>13.162575</bearingAccuracyDegrees>
+<time>1746103407608</time>
+</trkpt>
+<trkpt lat="55.947238" lon="-4.308387">
+<ele>149.81548262880096></ele>
+<accuracy>5.948</accuracy>
+<speed>1.4086597</speed>
+<bearing>242.06325</bearing>
+<bearingAccuracyDegrees>12.957432</bearingAccuracyDegrees>
+<time>1746103408637</time>
+</trkpt>
+<trkpt lat="55.9472336" lon="-4.3084082">
+<ele>149.97315541705547></ele>
+<accuracy>6.201</accuracy>
+<speed>1.3887022</speed>
+<bearing>246.57433</bearing>
+<bearingAccuracyDegrees>13.1590605</bearingAccuracyDegrees>
+<time>1746103409668</time>
+</trkpt>
+<trkpt lat="55.9472315" lon="-4.3084257">
+<ele>150.1845831051735></ele>
+<accuracy>6.363</accuracy>
+<speed>1.3759911</speed>
+<bearing>254.60187</bearing>
+<bearingAccuracyDegrees>12.99447</bearingAccuracyDegrees>
+<time>1746103410593</time>
+</trkpt>
+<trkpt lat="55.947239" lon="-4.3084487">
+<ele>150.29842993777407></ele>
+<accuracy>6.556</accuracy>
+<speed>1.32242</speed>
+<bearing>266.51328</bearing>
+<bearingAccuracyDegrees>15.712876</bearingAccuracyDegrees>
+<time>1746103411594</time>
+</trkpt>
+<trkpt lat="55.9472431" lon="-4.3084701">
+<ele>150.3563854374049></ele>
+<accuracy>6.689</accuracy>
+<speed>1.317599</speed>
+<bearing>273.55185</bearing>
+<bearingAccuracyDegrees>15.297731</bearingAccuracyDegrees>
+<time>1746103412598</time>
+</trkpt>
+<trkpt lat="55.9472461" lon="-4.3084923">
+<ele>150.4414919690668></ele>
+<accuracy>6.81</accuracy>
+<speed>1.3617806</speed>
+<bearing>276.24377</bearing>
+<bearingAccuracyDegrees>13.862523</bearingAccuracyDegrees>
+<time>1746103413600</time>
+</trkpt>
+<trkpt lat="55.9472475" lon="-4.3085145">
+<ele>150.50780254987717></ele>
+<accuracy>6.916</accuracy>
+<speed>1.3384786</speed>
+<bearing>275.85703</bearing>
+<bearingAccuracyDegrees>13.095087</bearingAccuracyDegrees>
+<time>1746103414603</time>
+</trkpt>
+<trkpt lat="55.9472484" lon="-4.3085365">
+<ele>150.50780254987717></ele>
+<accuracy>6.978</accuracy>
+<speed>1.3102282</speed>
+<bearing>264.51263</bearing>
+<bearingAccuracyDegrees>12.938301</bearingAccuracyDegrees>
+<time>1746103415531</time>
+</trkpt>
+<trkpt lat="55.947259" lon="-4.3085708">
+<ele>150.52137800742685></ele>
+<accuracy>6.966</accuracy>
+<speed>1.2991456</speed>
+<bearing>223.37666</bearing>
+<bearingAccuracyDegrees>11.765747</bearingAccuracyDegrees>
+<time>1746103416652</time>
+</trkpt>
+<trkpt lat="55.9472535" lon="-4.3085885">
+<ele>150.53808629228774></ele>
+<accuracy>6.867</accuracy>
+<speed>1.305373</speed>
+<bearing>251.50389</bearing>
+<bearingAccuracyDegrees>10.404196</bearingAccuracyDegrees>
+<time>1746103417646</time>
+</trkpt>
+<trkpt lat="55.9472492" lon="-4.3086111">
+<ele>150.51876734084794></ele>
+<accuracy>6.687</accuracy>
+<speed>1.3552938</speed>
+<bearing>250.52531</bearing>
+<bearingAccuracyDegrees>11.616874</bearingAccuracyDegrees>
+<time>1746103418644</time>
+</trkpt>
+<trkpt lat="55.9472426" lon="-4.3086354">
+<ele>150.3788367719493></ele>
+<accuracy>6.468</accuracy>
+<speed>1.3944132</speed>
+<bearing>248.53346</bearing>
+<bearingAccuracyDegrees>11.631203</bearingAccuracyDegrees>
+<time>1746103419648</time>
+</trkpt>
+<trkpt lat="55.9472369" lon="-4.308658">
+<ele>150.22481135275126></ele>
+<accuracy>6.223</accuracy>
+<speed>1.4551471</speed>
+<bearing>249.17226</bearing>
+<bearingAccuracyDegrees>9.766535</bearingAccuracyDegrees>
+<time>1746103420611</time>
+</trkpt>
+<trkpt lat="55.9472343" lon="-4.3086802">
+<ele>150.16215773423346></ele>
+<accuracy>6.211</accuracy>
+<speed>1.466634</speed>
+<bearing>247.59364</bearing>
+<bearingAccuracyDegrees>9.721491</bearingAccuracyDegrees>
+<time>1746103421583</time>
+</trkpt>
+<trkpt lat="55.9472291" lon="-4.3087033">
+<ele>149.99821625891715></ele>
+<accuracy>6.188</accuracy>
+<speed>1.4889761</speed>
+<bearing>244.31058</bearing>
+<bearingAccuracyDegrees>10.39548</bearingAccuracyDegrees>
+<time>1746103422623</time>
+</trkpt>
+<trkpt lat="55.9472054" lon="-4.3087648">
+<ele>149.4975353677911></ele>
+<accuracy>6.187</accuracy>
+<speed>1.5021513</speed>
+<bearing>245.50525</bearing>
+<bearingAccuracyDegrees>10.089277</bearingAccuracyDegrees>
+<time>1746103425644</time>
+</trkpt>
+<trkpt lat="55.9471991" lon="-4.308782">
+<ele>149.57636848599196></ele>
+<accuracy>6.215</accuracy>
+<speed>1.4970864</speed>
+<bearing>243.09811</bearing>
+<bearingAccuracyDegrees>12.012905</bearingAccuracyDegrees>
+<time>1746103426631</time>
+</trkpt>
+<trkpt lat="55.9471912" lon="-4.3088026">
+<ele>149.66562217895677></ele>
+<accuracy>6.247</accuracy>
+<speed>1.512359</speed>
+<bearing>242.2332</bearing>
+<bearingAccuracyDegrees>12.047633</bearingAccuracyDegrees>
+<time>1746103427634</time>
+</trkpt>
+<trkpt lat="55.9471828" lon="-4.308825">
+<ele>149.7141755453501></ele>
+<accuracy>6.278</accuracy>
+<speed>1.5113034</speed>
+<bearing>239.15321</bearing>
+<bearingAccuracyDegrees>12.23695</bearingAccuracyDegrees>
+<time>1746103428635</time>
+</trkpt>
+<trkpt lat="55.947173" lon="-4.3088491">
+<ele>149.6583130937761></ele>
+<accuracy>6.298</accuracy>
+<speed>1.5436809</speed>
+<bearing>237.22722</bearing>
+<bearingAccuracyDegrees>11.912283</bearingAccuracyDegrees>
+<time>1746103429639</time>
+</trkpt>
+<trkpt lat="55.9471618" lon="-4.3088731">
+<ele>149.64787155429536></ele>
+<accuracy>6.32</accuracy>
+<speed>1.571352</speed>
+<bearing>238.28606</bearing>
+<bearingAccuracyDegrees>9.956098</bearingAccuracyDegrees>
+<time>1746103430641</time>
+</trkpt>
+<trkpt lat="55.9471496" lon="-4.3088952">
+<ele>149.6243781368119></ele>
+<accuracy>6.312</accuracy>
+<speed>1.5588001</speed>
+<bearing>237.11583</bearing>
+<bearingAccuracyDegrees>10.328851</bearingAccuracyDegrees>
+<time>1746103431543</time>
+</trkpt>
+<trkpt lat="55.9471365" lon="-4.3089193">
+<ele>149.6228119112617></ele>
+<accuracy>6.326</accuracy>
+<speed>1.559687</speed>
+<bearing>239.02312</bearing>
+<bearingAccuracyDegrees>10.244906</bearingAccuracyDegrees>
+<time>1746103432646</time>
+</trkpt>
+<trkpt lat="55.9471159" lon="-4.3089442">
+<ele>149.62176776105224></ele>
+<accuracy>6.016</accuracy>
+<speed>1.5623872</speed>
+<bearing>233.30309</bearing>
+<bearingAccuracyDegrees>9.286224</bearingAccuracyDegrees>
+<time>1746103433647</time>
+</trkpt>
+<trkpt lat="55.9471018" lon="-4.3089686">
+<ele>149.63273134456333></ele>
+<accuracy>5.641</accuracy>
+<speed>1.5756801</speed>
+<bearing>233.74757</bearing>
+<bearingAccuracyDegrees>9.447392</bearingAccuracyDegrees>
+<time>1746103434651</time>
+</trkpt>
+<trkpt lat="55.9470912" lon="-4.3089935">
+<ele>149.6938144228433></ele>
+<accuracy>5.053</accuracy>
+<speed>1.5806837</speed>
+<bearing>232.3498</bearing>
+<bearingAccuracyDegrees>10.03631</bearingAccuracyDegrees>
+<time>1746103435552</time>
+</trkpt>
+<trkpt lat="55.9470813" lon="-4.3090183">
+<ele>149.7146976260478></ele>
+<accuracy>4.637</accuracy>
+<speed>1.5885091</speed>
+<bearing>225.53055</bearing>
+<bearingAccuracyDegrees>10.062776</bearingAccuracyDegrees>
+<time>1746103436555</time>
+</trkpt>
+<trkpt lat="55.9470731" lon="-4.30904">
+<ele>149.7146976260478></ele>
+<accuracy>3.978</accuracy>
+<speed>1.545264</speed>
+<bearing>213.34889</bearing>
+<bearingAccuracyDegrees>9.662293</bearingAccuracyDegrees>
+<time>1746103437489</time>
+</trkpt>
+<trkpt lat="55.9470629" lon="-4.3090533">
+<ele>149.7146976260478></ele>
+<accuracy>3.683</accuracy>
+<speed>1.5188524</speed>
+<bearing>183.24327</bearing>
+<bearingAccuracyDegrees>10.303589</bearingAccuracyDegrees>
+<time>1746103438483</time>
+</trkpt>
+<trkpt lat="55.9470521" lon="-4.309057">
+<ele>149.67710789679205></ele>
+<accuracy>3.504</accuracy>
+<speed>1.5115864</speed>
+<bearing>176.06953</bearing>
+<bearingAccuracyDegrees>12.314049</bearingAccuracyDegrees>
+<time>1746103439506</time>
+</trkpt>
+<trkpt lat="55.9470411" lon="-4.3090662">
+<ele>149.528838900227></ele>
+<accuracy>3.44</accuracy>
+<speed>1.5282845</speed>
+<bearing>179.78287</bearing>
+<bearingAccuracyDegrees>12.808812</bearingAccuracyDegrees>
+<time>1746103440537</time>
+</trkpt>
+<trkpt lat="55.9470299" lon="-4.3090801">
+<ele>149.4077196451045></ele>
+<accuracy>3.426</accuracy>
+<speed>1.5287257</speed>
+<bearing>186.96272</bearing>
+<bearingAccuracyDegrees>12.309726</bearingAccuracyDegrees>
+<time>1746103441552</time>
+</trkpt>
+<trkpt lat="55.9470202" lon="-4.3090929">
+<ele>149.23126447281754></ele>
+<accuracy>3.472</accuracy>
+<speed>1.5385709</speed>
+<bearing>189.355</bearing>
+<bearingAccuracyDegrees>12.174686</bearingAccuracyDegrees>
+<time>1746103442522</time>
+</trkpt>
+<trkpt lat="55.9470092" lon="-4.3091017">
+<ele>149.0897897160445></ele>
+<accuracy>3.56</accuracy>
+<speed>1.5619751</speed>
+<bearing>188.19016</bearing>
+<bearingAccuracyDegrees>10.194849</bearingAccuracyDegrees>
+<time>1746103443486</time>
+</trkpt>
+<trkpt lat="55.9469969" lon="-4.3091074">
+<ele>147.3000030517578></ele>
+<accuracy>3.656</accuracy>
+<speed>1.5651234</speed>
+<bearing>189.64572</bearing>
+<bearingAccuracyDegrees>10.096975</bearingAccuracyDegrees>
+<time>1746103444487</time>
+</trkpt>
+<trkpt lat="55.9469844" lon="-4.3091077">
+<ele>147.3000030517578></ele>
+<accuracy>3.736</accuracy>
+<speed>1.5505445</speed>
+<bearing>183.041</bearing>
+<bearingAccuracyDegrees>10.055805</bearingAccuracyDegrees>
+<time>1746103445500</time>
+</trkpt>
+<trkpt lat="55.9469726" lon="-4.3091029">
+<ele>146.90000915527344></ele>
+<accuracy>3.826</accuracy>
+<speed>1.5490897</speed>
+<bearing>179.75165</bearing>
+<bearingAccuracyDegrees>10.274316</bearingAccuracyDegrees>
+<time>1746103446579</time>
+</trkpt>
+<trkpt lat="55.9469599" lon="-4.3090999">
+<ele>146.90000915527344></ele>
+<accuracy>3.894</accuracy>
+<speed>1.5294825</speed>
+<bearing>185.44997</bearing>
+<bearingAccuracyDegrees>9.945808</bearingAccuracyDegrees>
+<time>1746103447582</time>
+</trkpt>
+<trkpt lat="55.946948" lon="-4.3091004">
+<ele>146.90000915527344></ele>
+<accuracy>3.958</accuracy>
+<speed>1.5217396</speed>
+<bearing>187.5482</bearing>
+<bearingAccuracyDegrees>9.909398</bearingAccuracyDegrees>
+<time>1746103448583</time>
+</trkpt>
+<trkpt lat="55.9469367" lon="-4.3090996">
+<ele>146.90000915527344></ele>
+<accuracy>4.021</accuracy>
+<speed>1.5115963</speed>
+<bearing>184.08183</bearing>
+<bearingAccuracyDegrees>11.898891</bearingAccuracyDegrees>
+<time>1746103449489</time>
+</trkpt>
+<trkpt lat="55.9469246" lon="-4.3090962">
+<ele>146.90000915527344></ele>
+<accuracy>4.119</accuracy>
+<speed>1.5396568</speed>
+<bearing>180.33295</bearing>
+<bearingAccuracyDegrees>9.830412</bearingAccuracyDegrees>
+<time>1746103450452</time>
+</trkpt>
+<trkpt lat="55.94691" lon="-4.3090899">
+<ele>146.90000915527344></ele>
+<accuracy>4.236</accuracy>
+<speed>1.545081</speed>
+<bearing>178.71655</bearing>
+<bearingAccuracyDegrees>10.115321</bearingAccuracyDegrees>
+<time>1746103451484</time>
+</trkpt>
+<trkpt lat="55.946896" lon="-4.3090836">
+<ele>146.90000915527344></ele>
+<accuracy>4.367</accuracy>
+<speed>1.5447748</speed>
+<bearing>180.64772</bearing>
+<bearingAccuracyDegrees>9.828592</bearingAccuracyDegrees>
+<time>1746103452509</time>
+</trkpt>
+<trkpt lat="55.9468834" lon="-4.3090799">
+<ele>146.90000915527344></ele>
+<accuracy>4.441</accuracy>
+<speed>1.5324124</speed>
+<bearing>180.28339</bearing>
+<bearingAccuracyDegrees>9.732175</bearingAccuracyDegrees>
+<time>1746103453490</time>
+</trkpt>
+<trkpt lat="55.9468689" lon="-4.3090772">
+<ele>146.90000915527344></ele>
+<accuracy>4.451</accuracy>
+<speed>1.5401012</speed>
+<bearing>182.58601</bearing>
+<bearingAccuracyDegrees>9.771094</bearingAccuracyDegrees>
+<time>1746103454497</time>
+</trkpt>
+<trkpt lat="55.9468517" lon="-4.309076">
+<ele>146.90000915527344></ele>
+<accuracy>4.403</accuracy>
+<speed>1.5394093</speed>
+<bearing>183.64798</bearing>
+<bearingAccuracyDegrees>9.429649</bearingAccuracyDegrees>
+<time>1746103455487</time>
+</trkpt>
+<trkpt lat="55.9468345" lon="-4.3090767">
+<ele>146.90000915527344></ele>
+<accuracy>4.37</accuracy>
+<speed>1.5879617</speed>
+<bearing>186.15945</bearing>
+<bearingAccuracyDegrees>9.720417</bearingAccuracyDegrees>
+<time>1746103456444</time>
+</trkpt>
+<trkpt lat="55.9468149" lon="-4.3090867">
+<ele>146.90000915527344></ele>
+<accuracy>4.238</accuracy>
+<speed>1.5817084</speed>
+<bearing>237.90242</bearing>
+<bearingAccuracyDegrees>9.609845</bearingAccuracyDegrees>
+<time>1746103457606</time>
+</trkpt>
+<trkpt lat="55.946804" lon="-4.3091067">
+<ele>146.90000915527344></ele>
+<accuracy>4.24</accuracy>
+<speed>1.6083707</speed>
+<bearing>205.8006</bearing>
+<bearingAccuracyDegrees>34.16179</bearingAccuracyDegrees>
+<time>1746103458608</time>
+</trkpt>
+<trkpt lat="55.9467895" lon="-4.309111">
+<ele>146.90000915527344></ele>
+<accuracy>4.329</accuracy>
+<speed>1.4539014</speed>
+<bearing>191.36713</bearing>
+<bearingAccuracyDegrees>32.057022</bearingAccuracyDegrees>
+<time>1746103459611</time>
+</trkpt>
+<trkpt lat="55.9467755" lon="-4.3091082">
+<ele>146.90000915527344></ele>
+<accuracy>4.64</accuracy>
+<speed>1.3663338</speed>
+<bearing>181.61688</bearing>
+<bearingAccuracyDegrees>31.245642</bearingAccuracyDegrees>
+<time>1746103460512</time>
+</trkpt>
+<trkpt lat="55.9467584" lon="-4.3090977">
+<ele>146.90000915527344></ele>
+<accuracy>5.021</accuracy>
+<speed>1.3775824</speed>
+<bearing>144.46725</bearing>
+<bearingAccuracyDegrees>27.748808</bearingAccuracyDegrees>
+<time>1746103461533</time>
+</trkpt>
+<trkpt lat="55.9467485" lon="-4.3090695">
+<ele>146.90000915527344></ele>
+<accuracy>5.456</accuracy>
+<speed>1.438997</speed>
+<bearing>102.560394</bearing>
+<bearingAccuracyDegrees>18.75197</bearingAccuracyDegrees>
+<time>1746103462617</time>
+</trkpt>
+<trkpt lat="55.9467396" lon="-4.3090451">
+<ele>146.90000915527344></ele>
+<accuracy>5.908</accuracy>
+<speed>1.4901992</speed>
+<bearing>132.22556</bearing>
+<bearingAccuracyDegrees>41.93018</bearingAccuracyDegrees>
+<time>1746103463620</time>
+</trkpt>
+<trkpt lat="55.9467244" lon="-4.3090347">
+<ele>144.93584016799912></ele>
+<accuracy>6.255</accuracy>
+<speed>1.5580884</speed>
+<bearing>139.69101</bearing>
+<bearingAccuracyDegrees>45.853157</bearingAccuracyDegrees>
+<time>1746103464623</time>
+</trkpt>
+<trkpt lat="55.9467066" lon="-4.3090305">
+<ele>144.68590389331672></ele>
+<accuracy>6.654</accuracy>
+<speed>1.6037575</speed>
+<bearing>148.78613</bearing>
+<bearingAccuracyDegrees>42.67789</bearingAccuracyDegrees>
+<time>1746103465625</time>
+</trkpt>
+<trkpt lat="55.9466861" lon="-4.3090323">
+<ele>144.10413881795438></ele>
+<accuracy>6.965</accuracy>
+<speed>1.6083994</speed>
+<bearing>159.73404</bearing>
+<bearingAccuracyDegrees>30.812346</bearingAccuracyDegrees>
+<time>1746103466627</time>
+</trkpt>
+<trkpt lat="55.9466655" lon="-4.309036">
+<ele>143.98466009971312></ele>
+<accuracy>7.315</accuracy>
+<speed>1.6227558</speed>
+<bearing>162.68155</bearing>
+<bearingAccuracyDegrees>27.930168</bearingAccuracyDegrees>
+<time>1746103467630</time>
+</trkpt>
+<trkpt lat="55.9466468" lon="-4.3090382">
+<ele>143.8150970827055></ele>
+<accuracy>7.662</accuracy>
+<speed>1.6477226</speed>
+<bearing>165.69835</bearing>
+<bearingAccuracyDegrees>25.238716</bearingAccuracyDegrees>
+<time>1746103468532</time>
+</trkpt>
+<trkpt lat="55.9466287" lon="-4.3090374">
+<ele>143.71235160109828></ele>
+<accuracy>7.93</accuracy>
+<speed>1.6518173</speed>
+<bearing>166.17328</bearing>
+<bearingAccuracyDegrees>23.435638</bearingAccuracyDegrees>
+<time>1746103469635</time>
+</trkpt>
+<trkpt lat="55.9466019" lon="-4.3090606">
+<ele>143.33411668172124></ele>
+<accuracy>7.388</accuracy>
+<speed>1.6757703</speed>
+<bearing>182.24771</bearing>
+<bearingAccuracyDegrees>13.053758</bearingAccuracyDegrees>
+<time>1746103470637</time>
+</trkpt>
+<trkpt lat="55.9465814" lon="-4.309073">
+<ele>143.08266487899135></ele>
+<accuracy>6.784</accuracy>
+<speed>1.6692675</speed>
+<bearing>193.10068</bearing>
+<bearingAccuracyDegrees>9.847113</bearingAccuracyDegrees>
+<time>1746103471639</time>
+</trkpt>
+<trkpt lat="55.9465616" lon="-4.3090827">
+<ele>143.08266487899135></ele>
+<accuracy>6.201</accuracy>
+<speed>1.6596788</speed>
+<bearing>195.2002</bearing>
+<bearingAccuracyDegrees>9.379474</bearingAccuracyDegrees>
+<time>1746103472624</time>
+</trkpt>
+<trkpt lat="55.9465443" lon="-4.3090877">
+<ele>142.82913378296095></ele>
+<accuracy>5.42</accuracy>
+<speed>1.6624049</speed>
+<bearing>191.93874</bearing>
+<bearingAccuracyDegrees>9.389877</bearingAccuracyDegrees>
+<time>1746103473588</time>
+</trkpt>
+<trkpt lat="55.9464789" lon="-4.3090889">
+<ele>141.57926489391207></ele>
+<accuracy>3.824</accuracy>
+<speed>1.6836951</speed>
+<bearing>181.56985</bearing>
+<bearingAccuracyDegrees>11.8580065</bearingAccuracyDegrees>
+<time>1746103477654</time>
+</trkpt>
+<trkpt lat="55.9464643" lon="-4.3090862">
+<ele>141.23449976016786></ele>
+<accuracy>3.758</accuracy>
+<speed>1.6719795</speed>
+<bearing>181.46454</bearing>
+<bearingAccuracyDegrees>11.755012</bearingAccuracyDegrees>
+<time>1746103478556</time>
+</trkpt>
+<trkpt lat="55.9464487" lon="-4.3090842">
+<ele>140.99979615433358></ele>
+<accuracy>3.734</accuracy>
+<speed>1.6540674</speed>
+<bearing>180.0332</bearing>
+<bearingAccuracyDegrees>13.036912</bearingAccuracyDegrees>
+<time>1746103479557</time>
+</trkpt>
+<trkpt lat="55.9464337" lon="-4.3090808">
+<ele>140.82820579360305></ele>
+<accuracy>3.781</accuracy>
+<speed>1.6369362</speed>
+<bearing>179.36584</bearing>
+<bearingAccuracyDegrees>12.810247</bearingAccuracyDegrees>
+<time>1746103480561</time>
+</trkpt>
+<trkpt lat="55.9464182" lon="-4.3090774">
+<ele>140.6602696066921></ele>
+<accuracy>3.831</accuracy>
+<speed>1.6301906</speed>
+<bearing>179.81635</bearing>
+<bearingAccuracyDegrees>12.6866045</bearingAccuracyDegrees>
+<time>1746103481563</time>
+</trkpt>
+<trkpt lat="55.946402" lon="-4.3090734">
+<ele>140.4777339925272></ele>
+<accuracy>3.879</accuracy>
+<speed>1.6457245</speed>
+<bearing>178.94144</bearing>
+<bearingAccuracyDegrees>12.253885</bearingAccuracyDegrees>
+<time>1746103482565</time>
+</trkpt>
+<trkpt lat="55.9463852" lon="-4.309072">
+<ele>140.2686050939036></ele>
+<accuracy>3.922</accuracy>
+<speed>1.6818893</speed>
+<bearing>181.68695</bearing>
+<bearingAccuracyDegrees>12.391624</bearingAccuracyDegrees>
+<time>1746103483567</time>
+</trkpt>
+<trkpt lat="55.9463686" lon="-4.3090715">
+<ele>140.01880442141118></ele>
+<accuracy>3.991</accuracy>
+<speed>1.6877931</speed>
+<bearing>183.35927</bearing>
+<bearingAccuracyDegrees>11.682204</bearingAccuracyDegrees>
+<time>1746103484569</time>
+</trkpt>
+<trkpt lat="55.9463524" lon="-4.309073">
+<ele>139.7757902708304></ele>
+<accuracy>4.013</accuracy>
+<speed>1.6794596</speed>
+<bearing>185.55394</bearing>
+<bearingAccuracyDegrees>11.462771</bearingAccuracyDegrees>
+<time>1746103485573</time>
+</trkpt>
+<trkpt lat="55.9463365" lon="-4.3090752">
+<ele>139.7757902708304></ele>
+<accuracy>4.016</accuracy>
+<speed>1.675936</speed>
+<bearing>186.70648</bearing>
+<bearingAccuracyDegrees>11.958046</bearingAccuracyDegrees>
+<time>1746103486508</time>
+</trkpt>
+<trkpt lat="55.9463184" lon="-4.3090751">
+<ele>139.55468464951298></ele>
+<accuracy>4.079</accuracy>
+<speed>1.6438339</speed>
+<bearing>200.32199</bearing>
+<bearingAccuracyDegrees>10.3536215</bearingAccuracyDegrees>
+<time>1746103487530</time>
+</trkpt>
+<trkpt lat="55.946305" lon="-4.3090861">
+<ele>139.36487209430342></ele>
+<accuracy>4.131</accuracy>
+<speed>1.6342046</speed>
+<bearing>232.99878</bearing>
+<bearingAccuracyDegrees>9.924712</bearingAccuracyDegrees>
+<time>1746103488481</time>
+</trkpt>
+<trkpt lat="55.9462964" lon="-4.3091075">
+<ele>139.16359192844595></ele>
+<accuracy>4.148</accuracy>
+<speed>1.6320785</speed>
+<bearing>240.77019</bearing>
+<bearingAccuracyDegrees>9.783303</bearingAccuracyDegrees>
+<time>1746103489582</time>
+</trkpt>
+<trkpt lat="55.9462894" lon="-4.3091262">
+<ele>138.40000915527344></ele>
+<accuracy>4.106</accuracy>
+<speed>1.6329067</speed>
+<bearing>237.44952</bearing>
+<bearingAccuracyDegrees>9.550497</bearingAccuracyDegrees>
+<time>1746103490585</time>
+</trkpt>
+<trkpt lat="55.9462823" lon="-4.3091423">
+<ele>138.40000915527344></ele>
+<accuracy>4.065</accuracy>
+<speed>1.6237895</speed>
+<bearing>237.96878</bearing>
+<bearingAccuracyDegrees>9.249472</bearingAccuracyDegrees>
+<time>1746103491587</time>
+</trkpt>
+<trkpt lat="55.9462765" lon="-4.3091606">
+<ele>138.40000915527344></ele>
+<accuracy>3.932</accuracy>
+<speed>1.6102067</speed>
+<bearing>235.3313</bearing>
+<bearingAccuracyDegrees>9.316658</bearingAccuracyDegrees>
+<time>1746103492590</time>
+</trkpt>
+<trkpt lat="55.9462705" lon="-4.309177">
+<ele>138.40000915527344></ele>
+<accuracy>3.806</accuracy>
+<speed>1.6268189</speed>
+<bearing>234.86911</bearing>
+<bearingAccuracyDegrees>9.105611</bearingAccuracyDegrees>
+<time>1746103493592</time>
+</trkpt>
+<trkpt lat="55.9462645" lon="-4.3091975">
+<ele>138.40000915527344></ele>
+<accuracy>3.699</accuracy>
+<speed>1.6504517</speed>
+<bearing>230.35178</bearing>
+<bearingAccuracyDegrees>9.253429</bearingAccuracyDegrees>
+<time>1746103494594</time>
+</trkpt>
+<trkpt lat="55.9462572" lon="-4.3092168">
+<ele>138.40000915527344></ele>
+<accuracy>3.628</accuracy>
+<speed>1.6551582</speed>
+<bearing>230.47015</bearing>
+<bearingAccuracyDegrees>9.323887</bearingAccuracyDegrees>
+<time>1746103495597</time>
+</trkpt>
+<trkpt lat="55.9462475" lon="-4.3092385">
+<ele>138.20679338789805></ele>
+<accuracy>3.662</accuracy>
+<speed>1.6204182</speed>
+<bearing>234.0403</bearing>
+<bearingAccuracyDegrees>9.365215</bearingAccuracyDegrees>
+<time>1746103496599</time>
+</trkpt>
+<trkpt lat="55.9462388" lon="-4.3092623">
+<ele>138.1119014602728></ele>
+<accuracy>3.786</accuracy>
+<speed>1.6213415</speed>
+<bearing>235.30618</bearing>
+<bearingAccuracyDegrees>9.739936</bearingAccuracyDegrees>
+<time>1746103497601</time>
+</trkpt>
+<trkpt lat="55.9462304" lon="-4.3092857">
+<ele>138.10365985643608></ele>
+<accuracy>4.032</accuracy>
+<speed>1.6218342</speed>
+<bearing>237.5835</bearing>
+<bearingAccuracyDegrees>11.558823</bearingAccuracyDegrees>
+<time>1746103498604</time>
+</trkpt>
+<trkpt lat="55.9462237" lon="-4.3093076">
+<ele>137.9894795612824></ele>
+<accuracy>4.406</accuracy>
+<speed>1.621058</speed>
+<bearing>238.86275</bearing>
+<bearingAccuracyDegrees>12.011043</bearingAccuracyDegrees>
+<time>1746103499506</time>
+</trkpt>
+<trkpt lat="55.9462165" lon="-4.3093312">
+<ele>137.85340365516896></ele>
+<accuracy>5.049</accuracy>
+<speed>1.6371055</speed>
+<bearing>235.22705</bearing>
+<bearingAccuracyDegrees>12.648233</bearingAccuracyDegrees>
+<time>1746103500609</time>
+</trkpt>
+<trkpt lat="55.9462083" lon="-4.3093533">
+<ele>137.67927134500553></ele>
+<accuracy>5.428</accuracy>
+<speed>1.6601565</speed>
+<bearing>232.21475</bearing>
+<bearingAccuracyDegrees>12.779362</bearingAccuracyDegrees>
+<time>1746103501531</time>
+</trkpt>
+<trkpt lat="55.946198" lon="-4.3093804">
+<ele>137.67927134500553></ele>
+<accuracy>5.938</accuracy>
+<speed>1.6324251</speed>
+<bearing>227.34818</bearing>
+<bearingAccuracyDegrees>12.736085</bearingAccuracyDegrees>
+<time>1746103502645</time>
+</trkpt>
+<trkpt lat="55.946189" lon="-4.3094066">
+<ele>137.22727368887263></ele>
+<accuracy>6.275</accuracy>
+<speed>1.5923846</speed>
+<bearing>231.16264</bearing>
+<bearingAccuracyDegrees>12.269632</bearingAccuracyDegrees>
+<time>1746103503648</time>
+</trkpt>
+<trkpt lat="55.9461806" lon="-4.3094301">
+<ele>137.22727368887263></ele>
+<accuracy>6.523</accuracy>
+<speed>1.6158558</speed>
+<bearing>236.12042</bearing>
+<bearingAccuracyDegrees>12.089765</bearingAccuracyDegrees>
+<time>1746103504631</time>
+</trkpt>
+<trkpt lat="55.9461733" lon="-4.3094593">
+<ele>137.00519357873682></ele>
+<accuracy>6.759</accuracy>
+<speed>1.6387682</speed>
+<bearing>244.01648</bearing>
+<bearingAccuracyDegrees>12.109389</bearingAccuracyDegrees>
+<time>1746103505622</time>
+</trkpt>
+<trkpt lat="55.9461683" lon="-4.3094909">
+<ele>136.8561007597867></ele>
+<accuracy>6.856</accuracy>
+<speed>1.663267</speed>
+<bearing>246.89412</bearing>
+<bearingAccuracyDegrees>12.095909</bearingAccuracyDegrees>
+<time>1746103506585</time>
+</trkpt>
+<trkpt lat="55.946163" lon="-4.3095232">
+<ele>136.73724539906553></ele>
+<accuracy>6.937</accuracy>
+<speed>1.6980149</speed>
+<bearing>241.10367</bearing>
+<bearingAccuracyDegrees>12.867683</bearingAccuracyDegrees>
+<time>1746103507588</time>
+</trkpt>
+<trkpt lat="55.9461621" lon="-4.3095791">
+<ele>136.53226107868318></ele>
+<accuracy>6.658</accuracy>
+<speed>1.7067748</speed>
+<bearing>244.35103</bearing>
+<bearingAccuracyDegrees>11.442507</bearingAccuracyDegrees>
+<time>1746103508570</time>
+</trkpt>
+<trkpt lat="55.946157" lon="-4.3096241">
+<ele>136.27474985600765></ele>
+<accuracy>6.233</accuracy>
+<speed>1.7374243</speed>
+<bearing>244.75449</bearing>
+<bearingAccuracyDegrees>10.2325735</bearingAccuracyDegrees>
+<time>1746103509544</time>
+</trkpt>
+<trkpt lat="55.9461492" lon="-4.3096669">
+<ele>136.2241868171307></ele>
+<accuracy>5.409</accuracy>
+<speed>1.7488877</speed>
+<bearing>245.60158</bearing>
+<bearingAccuracyDegrees>9.29711</bearingAccuracyDegrees>
+<time>1746103510524</time>
+</trkpt>
+<trkpt lat="55.9461408" lon="-4.3097071">
+<ele>136.14234830170957></ele>
+<accuracy>4.75</accuracy>
+<speed>1.7427777</speed>
+<bearing>248.40433</bearing>
+<bearingAccuracyDegrees>9.785189</bearingAccuracyDegrees>
+<time>1746103511548</time>
+</trkpt>
+<trkpt lat="55.9461346" lon="-4.3097379">
+<ele>136.07875457902807></ele>
+<accuracy>4.379</accuracy>
+<speed>1.7056091</speed>
+<bearing>251.09836</bearing>
+<bearingAccuracyDegrees>9.641659</bearingAccuracyDegrees>
+<time>1746103512529</time>
+</trkpt>
+<trkpt lat="55.9461287" lon="-4.3097627">
+<ele>136.1492483057578></ele>
+<accuracy>4.024</accuracy>
+<speed>1.6875814</speed>
+<bearing>244.80655</bearing>
+<bearingAccuracyDegrees>10.344704</bearingAccuracyDegrees>
+<time>1746103513502</time>
+</trkpt>
+<trkpt lat="55.9461211" lon="-4.3097851">
+<ele>136.1221430261203></ele>
+<accuracy>3.825</accuracy>
+<speed>1.6570445</speed>
+<bearing>245.31183</bearing>
+<bearingAccuracyDegrees>9.970322</bearingAccuracyDegrees>
+<time>1746103514505</time>
+</trkpt>
+<trkpt lat="55.9461152" lon="-4.3098068">
+<ele>136.05385895034857></ele>
+<accuracy>3.755</accuracy>
+<speed>1.6403315</speed>
+<bearing>247.51762</bearing>
+<bearingAccuracyDegrees>9.685579</bearingAccuracyDegrees>
+<time>1746103515486</time>
+</trkpt>
+<trkpt lat="55.9461094" lon="-4.3098294">
+<ele>134.3000030517578></ele>
+<accuracy>3.728</accuracy>
+<speed>1.6383961</speed>
+<bearing>247.2689</bearing>
+<bearingAccuracyDegrees>9.655725</bearingAccuracyDegrees>
+<time>1746103516452</time>
+</trkpt>
+<trkpt lat="55.9461023" lon="-4.3098522">
+<ele>134.3000030517578></ele>
+<accuracy>3.706</accuracy>
+<speed>1.6209968</speed>
+<bearing>246.64436</bearing>
+<bearingAccuracyDegrees>9.533434</bearingAccuracyDegrees>
+<time>1746103517434</time>
+</trkpt>
+<trkpt lat="55.9460946" lon="-4.3098756">
+<ele>134.3000030517578></ele>
+<accuracy>3.677</accuracy>
+<speed>1.614882</speed>
+<bearing>245.71553</bearing>
+<bearingAccuracyDegrees>9.54012</bearingAccuracyDegrees>
+<time>1746103518423</time>
+</trkpt>
+<trkpt lat="55.946086" lon="-4.3098967">
+<ele>134.3000030517578></ele>
+<accuracy>3.662</accuracy>
+<speed>1.605611</speed>
+<bearing>239.17592</bearing>
+<bearingAccuracyDegrees>9.873774</bearingAccuracyDegrees>
+<time>1746103519389</time>
+</trkpt>
+<trkpt lat="55.9460751" lon="-4.309918">
+<ele>134.3000030517578></ele>
+<accuracy>3.674</accuracy>
+<speed>1.6088105</speed>
+<bearing>238.68152</bearing>
+<bearingAccuracyDegrees>9.449361</bearingAccuracyDegrees>
+<time>1746103520369</time>
+</trkpt>
+<trkpt lat="55.9460657" lon="-4.3099385">
+<ele>134.3000030517578></ele>
+<accuracy>3.708</accuracy>
+<speed>1.6247759</speed>
+<bearing>240.75209</bearing>
+<bearingAccuracyDegrees>9.33664</bearingAccuracyDegrees>
+<time>1746103521330</time>
+</trkpt>
+<trkpt lat="55.9460562" lon="-4.3099606">
+<ele>134.3000030517578></ele>
+<accuracy>3.729</accuracy>
+<speed>1.625538</speed>
+<bearing>237.40515</bearing>
+<bearingAccuracyDegrees>9.347414</bearingAccuracyDegrees>
+<time>1746103522323</time>
+</trkpt>
+<trkpt lat="55.9460466" lon="-4.3099827">
+<ele>134.3000030517578></ele>
+<accuracy>3.728</accuracy>
+<speed>1.6535685</speed>
+<bearing>239.97874</bearing>
+<bearingAccuracyDegrees>9.093594</bearingAccuracyDegrees>
+<time>1746103523304</time>
+</trkpt>
+<trkpt lat="55.9460392" lon="-4.310007">
+<ele>134.3000030517578></ele>
+<accuracy>3.71</accuracy>
+<speed>1.6648295</speed>
+<bearing>242.63774</bearing>
+<bearingAccuracyDegrees>9.128944</bearingAccuracyDegrees>
+<time>1746103524247</time>
+</trkpt>
+<trkpt lat="55.9460315" lon="-4.31003">
+<ele>134.3000030517578></ele>
+<accuracy>3.699</accuracy>
+<speed>1.6688197</speed>
+<bearing>234.72789</bearing>
+<bearingAccuracyDegrees>9.070655</bearingAccuracyDegrees>
+<time>1746103525208</time>
+</trkpt>
+<trkpt lat="55.9460211" lon="-4.3100516">
+<ele>134.3000030517578></ele>
+<accuracy>3.668</accuracy>
+<speed>1.640238</speed>
+<bearing>228.91252</bearing>
+<bearingAccuracyDegrees>7.2459965</bearingAccuracyDegrees>
+<time>1746103526226</time>
+</trkpt>
+<trkpt lat="55.9460117" lon="-4.3100751">
+<ele>134.3000030517578></ele>
+<accuracy>3.657</accuracy>
+<speed>1.628734</speed>
+<bearing>235.35359</bearing>
+<bearingAccuracyDegrees>9.167593</bearingAccuracyDegrees>
+<time>1746103527229</time>
+</trkpt>
+<trkpt lat="55.9460044" lon="-4.3100996">
+<ele>134.3000030517578></ele>
+<accuracy>3.663</accuracy>
+<speed>1.6341614</speed>
+<bearing>236.47151</bearing>
+<bearingAccuracyDegrees>9.503956</bearingAccuracyDegrees>
+<time>1746103528206</time>
+</trkpt>
+<trkpt lat="55.9459971" lon="-4.3101228">
+<ele>134.3000030517578></ele>
+<accuracy>3.676</accuracy>
+<speed>1.605304</speed>
+<bearing>236.45465</bearing>
+<bearingAccuracyDegrees>9.76173</bearingAccuracyDegrees>
+<time>1746103529189</time>
+</trkpt>
+<trkpt lat="55.9459909" lon="-4.3101459">
+<ele>134.3000030517578></ele>
+<accuracy>3.668</accuracy>
+<speed>1.5695728</speed>
+<bearing>237.49734</bearing>
+<bearingAccuracyDegrees>10.282939</bearingAccuracyDegrees>
+<time>1746103530182</time>
+</trkpt>
+<trkpt lat="55.9459833" lon="-4.3101686">
+<ele>134.3000030517578></ele>
+<accuracy>3.644</accuracy>
+<speed>1.5786858</speed>
+<bearing>236.4324</bearing>
+<bearingAccuracyDegrees>9.996367</bearingAccuracyDegrees>
+<time>1746103531203</time>
+</trkpt>
+<trkpt lat="55.9459757" lon="-4.31019">
+<ele>134.3000030517578></ele>
+<accuracy>3.619</accuracy>
+<speed>1.5597858</speed>
+<bearing>230.50058</bearing>
+<bearingAccuracyDegrees>9.899776</bearingAccuracyDegrees>
+<time>1746103532258</time>
+</trkpt>
+<trkpt lat="55.945968" lon="-4.3102109">
+<ele>134.3000030517578></ele>
+<accuracy>3.61</accuracy>
+<speed>1.5486842</speed>
+<bearing>230.40005</bearing>
+<bearingAccuracyDegrees>9.495241</bearingAccuracyDegrees>
+<time>1746103533267</time>
+</trkpt>
+<trkpt lat="55.945961" lon="-4.3102317">
+<ele>134.3000030517578></ele>
+<accuracy>3.605</accuracy>
+<speed>1.5546893</speed>
+<bearing>229.33281</bearing>
+<bearingAccuracyDegrees>9.289389</bearingAccuracyDegrees>
+<time>1746103534229</time>
+</trkpt>
+<trkpt lat="55.9459532" lon="-4.310252">
+<ele>134.3000030517578></ele>
+<accuracy>3.595</accuracy>
+<speed>1.5364832</speed>
+<bearing>227.08151</bearing>
+<bearingAccuracyDegrees>9.943031</bearingAccuracyDegrees>
+<time>1746103535260</time>
+</trkpt>
+<trkpt lat="55.9459454" lon="-4.3102724">
+<ele>134.3000030517578></ele>
+<accuracy>3.599</accuracy>
+<speed>1.5398054</speed>
+<bearing>226.3209</bearing>
+<bearingAccuracyDegrees>9.846932</bearingAccuracyDegrees>
+<time>1746103536248</time>
+</trkpt>
+<trkpt lat="55.945937" lon="-4.3102919">
+<ele>134.3000030517578></ele>
+<accuracy>3.601</accuracy>
+<speed>1.5410643</speed>
+<bearing>226.93492</bearing>
+<bearingAccuracyDegrees>9.8663025</bearingAccuracyDegrees>
+<time>1746103537190</time>
+</trkpt>
+<trkpt lat="55.9459267" lon="-4.3103135">
+<ele>134.3000030517578></ele>
+<accuracy>3.613</accuracy>
+<speed>1.5449063</speed>
+<bearing>225.64885</bearing>
+<bearingAccuracyDegrees>9.839823</bearingAccuracyDegrees>
+<time>1746103538192</time>
+</trkpt>
+<trkpt lat="55.9459164" lon="-4.3103345">
+<ele>134.3000030517578></ele>
+<accuracy>3.625</accuracy>
+<speed>1.5713897</speed>
+<bearing>226.5369</bearing>
+<bearingAccuracyDegrees>10.0650625</bearingAccuracyDegrees>
+<time>1746103539205</time>
+</trkpt>
+<trkpt lat="55.9459069" lon="-4.3103529">
+<ele>134.3000030517578></ele>
+<accuracy>3.644</accuracy>
+<speed>1.5542125</speed>
+<bearing>224.3881</bearing>
+<bearingAccuracyDegrees>9.800546</bearingAccuracyDegrees>
+<time>1746103540167</time>
+</trkpt>
+<trkpt lat="55.9458961" lon="-4.3103688">
+<ele>134.3000030517578></ele>
+<accuracy>3.678</accuracy>
+<speed>1.568512</speed>
+<bearing>219.62381</bearing>
+<bearingAccuracyDegrees>9.784698</bearingAccuracyDegrees>
+<time>1746103541169</time>
+</trkpt>
+<trkpt lat="55.9458844" lon="-4.3103841">
+<ele>134.3000030517578></ele>
+<accuracy>3.709</accuracy>
+<speed>1.5787841</speed>
+<bearing>217.1638</bearing>
+<bearingAccuracyDegrees>9.809456</bearingAccuracyDegrees>
+<time>1746103542176</time>
+</trkpt>
+<trkpt lat="55.9458728" lon="-4.3103986">
+<ele>134.3000030517578></ele>
+<accuracy>3.751</accuracy>
+<speed>1.5906693</speed>
+<bearing>215.37181</bearing>
+<bearingAccuracyDegrees>9.519998</bearingAccuracyDegrees>
+<time>1746103543159</time>
+</trkpt>
+<trkpt lat="55.9458609" lon="-4.3104125">
+<ele>134.3000030517578></ele>
+<accuracy>3.771</accuracy>
+<speed>1.5804964</speed>
+<bearing>214.45427</bearing>
+<bearingAccuracyDegrees>9.099141</bearingAccuracyDegrees>
+<time>1746103544125</time>
+</trkpt>
+<trkpt lat="55.9458465" lon="-4.3104278">
+<ele>134.3000030517578></ele>
+<accuracy>3.801</accuracy>
+<speed>1.589729</speed>
+<bearing>206.95071</bearing>
+<bearingAccuracyDegrees>9.337169</bearingAccuracyDegrees>
+<time>1746103545106</time>
+</trkpt>
+<trkpt lat="55.9458313" lon="-4.3104389">
+<ele>134.3000030517578></ele>
+<accuracy>3.826</accuracy>
+<speed>1.6304003</speed>
+<bearing>203.87006</bearing>
+<bearingAccuracyDegrees>8.941817</bearingAccuracyDegrees>
+<time>1746103546090</time>
+</trkpt>
+<trkpt lat="55.9458175" lon="-4.3104483">
+<ele>134.3000030517578></ele>
+<accuracy>3.803</accuracy>
+<speed>1.6163847</speed>
+<bearing>207.10449</bearing>
+<bearingAccuracyDegrees>9.706005</bearingAccuracyDegrees>
+<time>1746103547084</time>
+</trkpt>
+<trkpt lat="55.9458033" lon="-4.3104593">
+<ele>134.3000030517578></ele>
+<accuracy>3.776</accuracy>
+<speed>1.6250995</speed>
+<bearing>206.56503</bearing>
+<bearingAccuracyDegrees>9.749817</bearingAccuracyDegrees>
+<time>1746103548067</time>
+</trkpt>
+<trkpt lat="55.9457889" lon="-4.3104706">
+<ele>134.3000030517578></ele>
+<accuracy>3.771</accuracy>
+<speed>1.6303854</speed>
+<bearing>206.71725</bearing>
+<bearingAccuracyDegrees>9.994248</bearingAccuracyDegrees>
+<time>1746103549068</time>
+</trkpt>
+<trkpt lat="55.9457753" lon="-4.3104827">
+<ele>134.3000030517578></ele>
+<accuracy>3.774</accuracy>
+<speed>1.5855271</speed>
+<bearing>206.81888</bearing>
+<bearingAccuracyDegrees>10.341539</bearingAccuracyDegrees>
+<time>1746103550069</time>
+</trkpt>
+<trkpt lat="55.9457624" lon="-4.3104955">
+<ele>134.3000030517578></ele>
+<accuracy>3.806</accuracy>
+<speed>1.5810884</speed>
+<bearing>207.90184</bearing>
+<bearingAccuracyDegrees>9.91226</bearingAccuracyDegrees>
+<time>1746103551043</time>
+</trkpt>
+<trkpt lat="55.945748" lon="-4.3105111">
+<ele>134.3000030517578></ele>
+<accuracy>3.921</accuracy>
+<speed>1.5887963</speed>
+<bearing>209.28163</bearing>
+<bearingAccuracyDegrees>9.76383</bearingAccuracyDegrees>
+<time>1746103552045</time>
+</trkpt>
+<trkpt lat="55.9457345" lon="-4.3105276">
+<ele>134.3000030517578></ele>
+<accuracy>4.015</accuracy>
+<speed>1.5959996</speed>
+<bearing>205.57968</bearing>
+<bearingAccuracyDegrees>9.759336</bearingAccuracyDegrees>
+<time>1746103553009</time>
+</trkpt>
+<trkpt lat="55.9457227" lon="-4.3105437">
+<ele>134.3000030517578></ele>
+<accuracy>4.068</accuracy>
+<speed>1.5874739</speed>
+<bearing>206.73845</bearing>
+<bearingAccuracyDegrees>9.790204</bearingAccuracyDegrees>
+<time>1746103553971</time>
+</trkpt>
+<trkpt lat="55.9457101" lon="-4.3105608">
+<ele>134.3000030517578></ele>
+<accuracy>4.126</accuracy>
+<speed>1.600526</speed>
+<bearing>204.48601</bearing>
+<bearingAccuracyDegrees>9.393307</bearingAccuracyDegrees>
+<time>1746103554954</time>
+</trkpt>
+<trkpt lat="55.9456969" lon="-4.3105751">
+<ele>134.3000030517578></ele>
+<accuracy>4.174</accuracy>
+<speed>1.6034672</speed>
+<bearing>203.10942</bearing>
+<bearingAccuracyDegrees>9.679482</bearingAccuracyDegrees>
+<time>1746103555962</time>
+</trkpt>
+<trkpt lat="55.9456838" lon="-4.3105862">
+<ele>134.3000030517578></ele>
+<accuracy>4.186</accuracy>
+<speed>1.59315</speed>
+<bearing>200.20447</bearing>
+<bearingAccuracyDegrees>9.572281</bearingAccuracyDegrees>
+<time>1746103556946</time>
+</trkpt>
+<trkpt lat="55.94567" lon="-4.3105978">
+<ele>134.3000030517578></ele>
+<accuracy>4.127</accuracy>
+<speed>1.5822825</speed>
+<bearing>200.5128</bearing>
+<bearingAccuracyDegrees>9.708386</bearingAccuracyDegrees>
+<time>1746103557951</time>
+</trkpt>
+<trkpt lat="55.9456568" lon="-4.3106072">
+<ele>134.3000030517578></ele>
+<accuracy>4.071</accuracy>
+<speed>1.5773256</speed>
+<bearing>199.07887</bearing>
+<bearingAccuracyDegrees>9.781289</bearingAccuracyDegrees>
+<time>1746103558910</time>
+</trkpt>
+<trkpt lat="55.9456432" lon="-4.3106152">
+<ele>134.3000030517578></ele>
+<accuracy>4.015</accuracy>
+<speed>1.5614821</speed>
+<bearing>195.15712</bearing>
+<bearingAccuracyDegrees>9.842419</bearingAccuracyDegrees>
+<time>1746103559904</time>
+</trkpt>
+<trkpt lat="55.9456285" lon="-4.3106213">
+<ele>134.3000030517578></ele>
+<accuracy>3.963</accuracy>
+<speed>1.5457958</speed>
+<bearing>193.11516</bearing>
+<bearingAccuracyDegrees>9.886181</bearingAccuracyDegrees>
+<time>1746103560892</time>
+</trkpt>
+<trkpt lat="55.9456131" lon="-4.3106247">
+<ele>134.3000030517578></ele>
+<accuracy>3.92</accuracy>
+<speed>1.5560377</speed>
+<bearing>193.08595</bearing>
+<bearingAccuracyDegrees>9.654501</bearingAccuracyDegrees>
+<time>1746103561891</time>
+</trkpt>
+<trkpt lat="55.945598" lon="-4.3106272">
+<ele>134.3000030517578></ele>
+<accuracy>3.913</accuracy>
+<speed>1.5345944</speed>
+<bearing>192.2682</bearing>
+<bearingAccuracyDegrees>9.884727</bearingAccuracyDegrees>
+<time>1746103562896</time>
+</trkpt>
+<trkpt lat="55.9455828" lon="-4.3106281">
+<ele>134.3000030517578></ele>
+<accuracy>3.935</accuracy>
+<speed>1.5912058</speed>
+<bearing>191.51088</bearing>
+<bearingAccuracyDegrees>9.693538</bearingAccuracyDegrees>
+<time>1746103563822</time>
+</trkpt>
+<trkpt lat="55.9455658" lon="-4.3106302">
+<ele>134.3000030517578></ele>
+<accuracy>3.937</accuracy>
+<speed>1.5928162</speed>
+<bearing>191.21959</bearing>
+<bearingAccuracyDegrees>9.759882</bearingAccuracyDegrees>
+<time>1746103564825</time>
+</trkpt>
+<trkpt lat="55.9455504" lon="-4.3106337">
+<ele>134.3000030517578></ele>
+<accuracy>3.895</accuracy>
+<speed>1.6113781</speed>
+<bearing>191.62477</bearing>
+<bearingAccuracyDegrees>10.026293</bearingAccuracyDegrees>
+<time>1746103565786</time>
+</trkpt>
+<trkpt lat="55.9455348" lon="-4.3106369">
+<ele>131.40000915527344></ele>
+<accuracy>3.868</accuracy>
+<speed>1.6198739</speed>
+<bearing>188.50836</bearing>
+<bearingAccuracyDegrees>10.37706</bearingAccuracyDegrees>
+<time>1746103566757</time>
+</trkpt>
+<trkpt lat="55.9455189" lon="-4.3106385">
+<ele>131.40000915527344></ele>
+<accuracy>3.859</accuracy>
+<speed>1.6339794</speed>
+<bearing>188.66808</bearing>
+<bearingAccuracyDegrees>10.29791</bearingAccuracyDegrees>
+<time>1746103567693</time>
+</trkpt>
+<trkpt lat="55.9454558" lon="-4.310649">
+<ele>130.8000030517578></ele>
+<accuracy>3.914</accuracy>
+<speed>1.6452975</speed>
+<bearing>187.79362</bearing>
+<bearingAccuracyDegrees>9.453579</bearingAccuracyDegrees>
+<time>1746103571572</time>
+</trkpt>
+<trkpt lat="55.9454391" lon="-4.3106529">
+<ele>130.8000030517578></ele>
+<accuracy>3.902</accuracy>
+<speed>1.6493846</speed>
+<bearing>187.34018</bearing>
+<bearingAccuracyDegrees>9.5068865</bearingAccuracyDegrees>
+<time>1746103572571</time>
+</trkpt>
+<trkpt lat="55.9454217" lon="-4.3106574">
+<ele>130.8000030517578></ele>
+<accuracy>3.877</accuracy>
+<speed>1.6567925</speed>
+<bearing>185.1274</bearing>
+<bearingAccuracyDegrees>9.557128</bearingAccuracyDegrees>
+<time>1746103573565</time>
+</trkpt>
+<trkpt lat="55.9454036" lon="-4.3106616">
+<ele>130.8000030517578></ele>
+<accuracy>3.872</accuracy>
+<speed>1.6634127</speed>
+<bearing>186.40883</bearing>
+<bearingAccuracyDegrees>9.334924</bearingAccuracyDegrees>
+<time>1746103574567</time>
+</trkpt>
+<trkpt lat="55.945386" lon="-4.3106663">
+<ele>130.8000030517578></ele>
+<accuracy>3.824</accuracy>
+<speed>1.6566154</speed>
+<bearing>187.48654</bearing>
+<bearingAccuracyDegrees>9.892005</bearingAccuracyDegrees>
+<time>1746103575550</time>
+</trkpt>
+<trkpt lat="55.9453691" lon="-4.3106715">
+<ele>130.8000030517578></ele>
+<accuracy>3.776</accuracy>
+<speed>1.6383122</speed>
+<bearing>186.43912</bearing>
+<bearingAccuracyDegrees>9.48996</bearingAccuracyDegrees>
+<time>1746103576523</time>
+</trkpt>
+<trkpt lat="55.9453525" lon="-4.3106766">
+<ele>130.8000030517578></ele>
+<accuracy>3.735</accuracy>
+<speed>1.6124259</speed>
+<bearing>186.3355</bearing>
+<bearingAccuracyDegrees>10.089199</bearingAccuracyDegrees>
+<time>1746103577546</time>
+</trkpt>
+<trkpt lat="55.9453063" lon="-4.3106846">
+<ele>130.8000030517578></ele>
+<accuracy>3.574</accuracy>
+<speed>1.6053265</speed>
+<bearing>180.85663</bearing>
+<bearingAccuracyDegrees>9.907509</bearingAccuracyDegrees>
+<time>1746103580524</time>
+</trkpt>
+<trkpt lat="55.9452904" lon="-4.3106893">
+<ele>130.8000030517578></ele>
+<accuracy>3.464</accuracy>
+<speed>1.5916318</speed>
+<bearing>187.07632</bearing>
+<bearingAccuracyDegrees>9.607877</bearingAccuracyDegrees>
+<time>1746103581526</time>
+</trkpt>
+<trkpt lat="55.9452734" lon="-4.3106978">
+<ele>130.8000030517578></ele>
+<accuracy>3.385</accuracy>
+<speed>1.5683829</speed>
+<bearing>195.92444</bearing>
+<bearingAccuracyDegrees>9.601782</bearingAccuracyDegrees>
+<time>1746103582624</time>
+</trkpt>
+<trkpt lat="55.9452587" lon="-4.3107142">
+<ele>130.8000030517578></ele>
+<accuracy>3.237</accuracy>
+<speed>1.5727245</speed>
+<bearing>210.2039</bearing>
+<bearingAccuracyDegrees>9.580791</bearingAccuracyDegrees>
+<time>1746103583550</time>
+</trkpt>
+<trkpt lat="55.945245" lon="-4.3107325">
+<ele>130.8000030517578></ele>
+<accuracy>3.141</accuracy>
+<speed>1.5969462</speed>
+<bearing>211.85052</bearing>
+<bearingAccuracyDegrees>9.34199</bearingAccuracyDegrees>
+<time>1746103584547</time>
+</trkpt>
+<trkpt lat="55.9452318" lon="-4.3107511">
+<ele>130.8000030517578></ele>
+<accuracy>3.07</accuracy>
+<speed>1.6212167</speed>
+<bearing>217.44644</bearing>
+<bearingAccuracyDegrees>9.594338</bearingAccuracyDegrees>
+<time>1746103585551</time>
+</trkpt>
+<trkpt lat="55.9451954" lon="-4.3108494">
+<ele>130.8000030517578></ele>
+<accuracy>3.025</accuracy>
+<speed>1.6219109</speed>
+<bearing>239.1968</bearing>
+<bearingAccuracyDegrees>9.764337</bearingAccuracyDegrees>
+<time>1746103589444</time>
+</trkpt>
+<trkpt lat="55.9451882" lon="-4.3108758">
+<ele>130.8000030517578></ele>
+<accuracy>3.034</accuracy>
+<speed>1.6019241</speed>
+<bearing>243.38185</bearing>
+<bearingAccuracyDegrees>9.92213</bearingAccuracyDegrees>
+<time>1746103590453</time>
+</trkpt>
+<trkpt lat="55.9451822" lon="-4.3109001">
+<ele>130.8000030517578></ele>
+<accuracy>3.054</accuracy>
+<speed>1.6172646</speed>
+<bearing>245.99817</bearing>
+<bearingAccuracyDegrees>9.572731</bearingAccuracyDegrees>
+<time>1746103591409</time>
+</trkpt>
+<trkpt lat="55.9451745" lon="-4.3110036">
+<ele>130.8000030517578></ele>
+<accuracy>3.239</accuracy>
+<speed>1.5732216</speed>
+<bearing>269.48297</bearing>
+<bearingAccuracyDegrees>10.250898</bearingAccuracyDegrees>
+<time>1746103595408</time>
+</trkpt>
+<trkpt lat="55.9451717" lon="-4.3110258">
+<ele>130.8000030517578></ele>
+<accuracy>3.319</accuracy>
+<speed>1.554684</speed>
+<bearing>268.41196</bearing>
+<bearingAccuracyDegrees>10.244638</bearingAccuracyDegrees>
+<time>1746103596398</time>
+</trkpt>
+<trkpt lat="55.9451691" lon="-4.3110482">
+<ele>130.8000030517578></ele>
+<accuracy>3.349</accuracy>
+<speed>1.5435636</speed>
+<bearing>267.65332</bearing>
+<bearingAccuracyDegrees>9.82052</bearingAccuracyDegrees>
+<time>1746103597385</time>
+</trkpt>
+<trkpt lat="55.9451681" lon="-4.31107">
+<ele>130.8000030517578></ele>
+<accuracy>3.403</accuracy>
+<speed>1.5350662</speed>
+<bearing>270.97147</bearing>
+<bearingAccuracyDegrees>9.680219</bearingAccuracyDegrees>
+<time>1746103598405</time>
+</trkpt>
+<trkpt lat="55.9451693" lon="-4.3110881">
+<ele>130.8000030517578></ele>
+<accuracy>3.468</accuracy>
+<speed>1.5463597</speed>
+<bearing>271.70728</bearing>
+<bearingAccuracyDegrees>10.201071</bearingAccuracyDegrees>
+<time>1746103599390</time>
+</trkpt>
+<trkpt lat="55.9451713" lon="-4.3111064">
+<ele>130.8000030517578></ele>
+<accuracy>3.506</accuracy>
+<speed>1.5379826</speed>
+<bearing>271.2459</bearing>
+<bearingAccuracyDegrees>10.056415</bearingAccuracyDegrees>
+<time>1746103600371</time>
+</trkpt>
+<trkpt lat="55.9451743" lon="-4.3111259">
+<ele>130.8000030517578></ele>
+<accuracy>3.529</accuracy>
+<speed>1.5208225</speed>
+<bearing>272.4632</bearing>
+<bearingAccuracyDegrees>9.937335</bearingAccuracyDegrees>
+<time>1746103601361</time>
+</trkpt>
+<trkpt lat="55.9451758" lon="-4.3111519">
+<ele>130.8000030517578></ele>
+<accuracy>3.639</accuracy>
+<speed>1.4716691</speed>
+<bearing>271.53653</bearing>
+<bearingAccuracyDegrees>10.293255</bearingAccuracyDegrees>
+<time>1746103602445</time>
+</trkpt>
+<trkpt lat="55.9451762" lon="-4.3111765">
+<ele>130.8000030517578></ele>
+<accuracy>3.811</accuracy>
+<speed>1.46415</speed>
+<bearing>270.52234</bearing>
+<bearingAccuracyDegrees>12.050887</bearingAccuracyDegrees>
+<time>1746103603446</time>
+</trkpt>
+<trkpt lat="55.9451757" lon="-4.3112039">
+<ele>130.8000030517578></ele>
+<accuracy>4.082</accuracy>
+<speed>1.4690084</speed>
+<bearing>269.86786</bearing>
+<bearingAccuracyDegrees>12.573411</bearingAccuracyDegrees>
+<time>1746103604512</time>
+</trkpt>
+<trkpt lat="55.9451756" lon="-4.3112314">
+<ele>130.8000030517578></ele>
+<accuracy>4.442</accuracy>
+<speed>1.4670223</speed>
+<bearing>272.2352</bearing>
+<bearingAccuracyDegrees>12.058985</bearingAccuracyDegrees>
+<time>1746103605551</time>
+</trkpt>
+<trkpt lat="55.9451765" lon="-4.31126">
+<ele>130.8000030517578></ele>
+<accuracy>4.96</accuracy>
+<speed>1.4898643</speed>
+<bearing>274.48242</bearing>
+<bearingAccuracyDegrees>11.782643</bearingAccuracyDegrees>
+<time>1746103606584</time>
+</trkpt>
+<trkpt lat="55.9451772" lon="-4.3112868">
+<ele>130.8000030517578></ele>
+<accuracy>5.252</accuracy>
+<speed>1.5057093</speed>
+<bearing>271.8173</bearing>
+<bearingAccuracyDegrees>11.656419</bearingAccuracyDegrees>
+<time>1746103607607</time>
+</trkpt>
+<trkpt lat="55.9451806" lon="-4.3114069">
+<ele>130.8000030517578></ele>
+<accuracy>5.901</accuracy>
+<speed>1.5846452</speed>
+<bearing>269.9961</bearing>
+<bearingAccuracyDegrees>9.999324</bearingAccuracyDegrees>
+<time>1746103611593</time>
+</trkpt>
+<trkpt lat="55.9451812" lon="-4.3114383">
+<ele>130.8000030517578></ele>
+<accuracy>5.981</accuracy>
+<speed>1.5727729</speed>
+<bearing>267.58893</bearing>
+<bearingAccuracyDegrees>10.334735</bearingAccuracyDegrees>
+<time>1746103612596</time>
+</trkpt>
+<trkpt lat="55.9451817" lon="-4.3114697">
+<ele>130.8000030517578></ele>
+<accuracy>6.029</accuracy>
+<speed>1.5916864</speed>
+<bearing>272.5666</bearing>
+<bearingAccuracyDegrees>10.232731</bearingAccuracyDegrees>
+<time>1746103613598</time>
+</trkpt>
+<trkpt lat="55.945183" lon="-4.3115006">
+<ele>130.8000030517578></ele>
+<accuracy>6.074</accuracy>
+<speed>1.5797007</speed>
+<bearing>273.85925</bearing>
+<bearingAccuracyDegrees>11.708262</bearingAccuracyDegrees>
+<time>1746103614600</time>
+</trkpt>
+<trkpt lat="55.9451846" lon="-4.311531">
+<ele>130.8000030517578></ele>
+<accuracy>6.138</accuracy>
+<speed>1.5753027</speed>
+<bearing>274.3976</bearing>
+<bearingAccuracyDegrees>12.248301</bearingAccuracyDegrees>
+<time>1746103615603</time>
+</trkpt>
+<trkpt lat="55.9451865" lon="-4.3115622">
+<ele>130.8000030517578></ele>
+<accuracy>6.261</accuracy>
+<speed>1.5844094</speed>
+<bearing>277.5933</bearing>
+<bearingAccuracyDegrees>12.500858</bearingAccuracyDegrees>
+<time>1746103616605</time>
+</trkpt>
+<trkpt lat="55.9451894" lon="-4.3115918">
+<ele>130.8000030517578></ele>
+<accuracy>6.396</accuracy>
+<speed>1.5832576</speed>
+<bearing>280.32178</bearing>
+<bearingAccuracyDegrees>12.431461</bearingAccuracyDegrees>
+<time>1746103617608</time>
+</trkpt>
+<trkpt lat="55.9451914" lon="-4.311621">
+<ele>130.8000030517578></ele>
+<accuracy>6.525</accuracy>
+<speed>1.5493927</speed>
+<bearing>278.8607</bearing>
+<bearingAccuracyDegrees>12.479157</bearingAccuracyDegrees>
+<time>1746103618610</time>
+</trkpt>
+<trkpt lat="55.9451946" lon="-4.3116507">
+<ele>130.8000030517578></ele>
+<accuracy>6.321</accuracy>
+<speed>1.5420852</speed>
+<bearing>271.1638</bearing>
+<bearingAccuracyDegrees>12.103921</bearingAccuracyDegrees>
+<time>1746103619612</time>
+</trkpt>
+<trkpt lat="55.9451963" lon="-4.3116827">
+<ele>130.8000030517578></ele>
+<accuracy>5.941</accuracy>
+<speed>1.5513437</speed>
+<bearing>264.3453</bearing>
+<bearingAccuracyDegrees>12.023181</bearingAccuracyDegrees>
+<time>1746103620615</time>
+</trkpt>
+<trkpt lat="55.9451941" lon="-4.3117106">
+<ele>130.8000030517578></ele>
+<accuracy>5.464</accuracy>
+<speed>1.530923</speed>
+<bearing>261.60498</bearing>
+<bearingAccuracyDegrees>12.137314</bearingAccuracyDegrees>
+<time>1746103621617</time>
+</trkpt>
+<trkpt lat="55.9451926" lon="-4.3117376">
+<ele>130.8000030517578></ele>
+<accuracy>4.958</accuracy>
+<speed>1.5427599</speed>
+<bearing>266.29663</bearing>
+<bearingAccuracyDegrees>12.085288</bearingAccuracyDegrees>
+<time>1746103622619</time>
+</trkpt>
+<trkpt lat="55.9451915" lon="-4.3117619">
+<ele>130.8000030517578></ele>
+<accuracy>4.416</accuracy>
+<speed>1.5250336</speed>
+<bearing>268.30637</bearing>
+<bearingAccuracyDegrees>11.834235</bearingAccuracyDegrees>
+<time>1746103623622</time>
+</trkpt>
+<trkpt lat="55.9451897" lon="-4.3117888">
+<ele>130.8000030517578></ele>
+<accuracy>4.191</accuracy>
+<speed>1.4963455</speed>
+<bearing>267.42953</bearing>
+<bearingAccuracyDegrees>12.36303</bearingAccuracyDegrees>
+<time>1746103624623</time>
+</trkpt>
+<trkpt lat="55.945189" lon="-4.3118158">
+<ele>130.8000030517578></ele>
+<accuracy>4.109</accuracy>
+<speed>1.4747561</speed>
+<bearing>268.45282</bearing>
+<bearingAccuracyDegrees>12.075141</bearingAccuracyDegrees>
+<time>1746103625626</time>
+</trkpt>
+<trkpt lat="55.9451885" lon="-4.3118419">
+<ele>130.8000030517578></ele>
+<accuracy>4.052</accuracy>
+<speed>1.4343256</speed>
+<bearing>268.6284</bearing>
+<bearingAccuracyDegrees>11.763073</bearingAccuracyDegrees>
+<time>1746103626532</time>
+</trkpt>
+<trkpt lat="55.9451881" lon="-4.3118693">
+<ele>130.8000030517578></ele>
+<accuracy>3.986</accuracy>
+<speed>1.4263572</speed>
+<bearing>266.73087</bearing>
+<bearingAccuracyDegrees>11.690055</bearingAccuracyDegrees>
+<time>1746103627602</time>
+</trkpt>
+<trkpt lat="55.9451883" lon="-4.3118951">
+<ele>130.8000030517578></ele>
+<accuracy>3.938</accuracy>
+<speed>1.3956156</speed>
+<bearing>273.30203</bearing>
+<bearingAccuracyDegrees>11.765846</bearingAccuracyDegrees>
+<time>1746103628609</time>
+</trkpt>
+<trkpt lat="55.9451916" lon="-4.3119153">
+<ele>130.8000030517578></ele>
+<accuracy>3.91</accuracy>
+<speed>1.3704995</speed>
+<bearing>286.37137</bearing>
+<bearingAccuracyDegrees>10.109061</bearingAccuracyDegrees>
+<time>1746103629636</time>
+</trkpt>
+<trkpt lat="55.9452113" lon="-4.3120073">
+<ele>130.8000030517578></ele>
+<accuracy>3.778</accuracy>
+<speed>1.3728453</speed>
+<bearing>276.59497</bearing>
+<bearingAccuracyDegrees>10.190831</bearingAccuracyDegrees>
+<time>1746103633648</time>
+</trkpt>
+<trkpt lat="55.9452128" lon="-4.312029">
+<ele>130.8000030517578></ele>
+<accuracy>3.855</accuracy>
+<speed>1.3873814</speed>
+<bearing>277.54883</bearing>
+<bearingAccuracyDegrees>10.011216</bearingAccuracyDegrees>
+<time>1746103634548</time>
+</trkpt>
+<trkpt lat="55.945215" lon="-4.3120549">
+<ele>132.56526439513593></ele>
+<accuracy>4.027</accuracy>
+<speed>1.4049683</speed>
+<bearing>274.52734</bearing>
+<bearingAccuracyDegrees>12.520424</bearingAccuracyDegrees>
+<time>1746103635550</time>
+</trkpt>
+<trkpt lat="55.9452155" lon="-4.3120808">
+<ele>132.63091580459349></ele>
+<accuracy>4.285</accuracy>
+<speed>1.3841467</speed>
+<bearing>274.16714</bearing>
+<bearingAccuracyDegrees>11.837997</bearingAccuracyDegrees>
+<time>1746103636553</time>
+</trkpt>
+<trkpt lat="55.9452169" lon="-4.3121071">
+<ele>132.63091580459349></ele>
+<accuracy>4.626</accuracy>
+<speed>1.3772187</speed>
+<bearing>277.6189</bearing>
+<bearingAccuracyDegrees>12.142411</bearingAccuracyDegrees>
+<time>1746103637507</time>
+</trkpt>
+<trkpt lat="55.9452199" lon="-4.3121364">
+<ele>132.76222012705836></ele>
+<accuracy>4.977</accuracy>
+<speed>1.3704834</speed>
+<bearing>282.00665</bearing>
+<bearingAccuracyDegrees>12.277134</bearingAccuracyDegrees>
+<time>1746103638632</time>
+</trkpt>
+<trkpt lat="55.945222" lon="-4.3121595">
+<ele>133.22857509577562></ele>
+<accuracy>5.342</accuracy>
+<speed>1.3826616</speed>
+<bearing>278.78778</bearing>
+<bearingAccuracyDegrees>12.417763</bearingAccuracyDegrees>
+<time>1746103639560</time>
+</trkpt>
+<trkpt lat="55.9452225" lon="-4.3121847">
+<ele>133.41356088730345></ele>
+<accuracy>5.691</accuracy>
+<speed>1.3551967</speed>
+<bearing>273.91177</bearing>
+<bearingAccuracyDegrees>12.824895</bearingAccuracyDegrees>
+<time>1746103640562</time>
+</trkpt>
+<trkpt lat="55.9452223" lon="-4.3122089">
+<ele>133.5323707617389></ele>
+<accuracy>6.015</accuracy>
+<speed>1.3654222</speed>
+<bearing>270.62924</bearing>
+<bearingAccuracyDegrees>12.612127</bearingAccuracyDegrees>
+<time>1746103641563</time>
+</trkpt>
+<trkpt lat="55.9452211" lon="-4.3122316">
+<ele>133.69808201198202></ele>
+<accuracy>6.222</accuracy>
+<speed>1.3687497</speed>
+<bearing>269.3624</bearing>
+<bearingAccuracyDegrees>14.987968</bearingAccuracyDegrees>
+<time>1746103642467</time>
+</trkpt>
+<trkpt lat="55.9452208" lon="-4.3122537">
+<ele>133.72413753050662></ele>
+<accuracy>6.48</accuracy>
+<speed>1.367666</speed>
+<bearing>273.8778</bearing>
+<bearingAccuracyDegrees>12.937842</bearingAccuracyDegrees>
+<time>1746103643525</time>
+</trkpt>
+<trkpt lat="55.9452217" lon="-4.312279">
+<ele>134.01075344447756></ele>
+<accuracy>6.66</accuracy>
+<speed>1.3790169</speed>
+<bearing>275.39987</bearing>
+<bearingAccuracyDegrees>13.077566</bearingAccuracyDegrees>
+<time>1746103644625</time>
+</trkpt>
+<trkpt lat="55.9452229" lon="-4.3123007">
+<ele>134.45059716930794></ele>
+<accuracy>6.774</accuracy>
+<speed>1.3736385</speed>
+<bearing>277.43512</bearing>
+<bearingAccuracyDegrees>13.113406</bearingAccuracyDegrees>
+<time>1746103645574</time>
+</trkpt>
+<trkpt lat="55.9452246" lon="-4.3123242">
+<ele>134.71378456291342></ele>
+<accuracy>6.88</accuracy>
+<speed>1.364232</speed>
+<bearing>276.93317</bearing>
+<bearingAccuracyDegrees>13.058427</bearingAccuracyDegrees>
+<time>1746103646576</time>
+</trkpt>
+<trkpt lat="55.9452257" lon="-4.3123446">
+<ele>134.91026832357244></ele>
+<accuracy>6.935</accuracy>
+<speed>1.3062384</speed>
+<bearing>273.55978</bearing>
+<bearingAccuracyDegrees>13.49151</bearingAccuracyDegrees>
+<time>1746103647478</time>
+</trkpt>
+<trkpt lat="55.9452287" lon="-4.3123657">
+<ele>134.9133954223673></ele>
+<accuracy>6.973</accuracy>
+<speed>1.3106295</speed>
+<bearing>277.4609</bearing>
+<bearingAccuracyDegrees>13.024535</bearingAccuracyDegrees>
+<time>1746103648603</time>
+</trkpt>
+<trkpt lat="55.9452305" lon="-4.3123845">
+<ele>135.32618244473167></ele>
+<accuracy>6.994</accuracy>
+<speed>1.2933426</speed>
+<bearing>277.02444</bearing>
+<bearingAccuracyDegrees>14.64912</bearingAccuracyDegrees>
+<time>1746103649583</time>
+</trkpt>
+<trkpt lat="55.9452322" lon="-4.3124061">
+<ele>135.61493665937473></ele>
+<accuracy>6.977</accuracy>
+<speed>1.2943007</speed>
+<bearing>271.00705</bearing>
+<bearingAccuracyDegrees>13.161207</bearingAccuracyDegrees>
+<time>1746103650586</time>
+</trkpt>
+<trkpt lat="55.9452325" lon="-4.3124267">
+<ele>135.9005731106762></ele>
+<accuracy>7.007</accuracy>
+<speed>1.2898101</speed>
+<bearing>271.4507</bearing>
+<bearingAccuracyDegrees>12.977467</bearingAccuracyDegrees>
+<time>1746103651588</time>
+</trkpt>
+<trkpt lat="55.9452315" lon="-4.312447">
+<ele>135.9005731106762></ele>
+<accuracy>7.081</accuracy>
+<speed>1.2668015</speed>
+<bearing>271.15305</bearing>
+<bearingAccuracyDegrees>13.230251</bearingAccuracyDegrees>
+<time>1746103652544</time>
+</trkpt>
+<trkpt lat="55.9452333" lon="-4.3124699">
+<ele>136.36761957102382></ele>
+<accuracy>7.24</accuracy>
+<speed>1.2768657</speed>
+<bearing>274.85648</bearing>
+<bearingAccuracyDegrees>12.884899</bearingAccuracyDegrees>
+<time>1746103654313</time>
+</trkpt>
+<trkpt lat="55.945233" lon="-4.3124906">
+<ele>136.4025448233716></ele>
+<accuracy>7.367</accuracy>
+<speed>1.288124</speed>
+<bearing>271.67133</bearing>
+<bearingAccuracyDegrees>14.528745</bearingAccuracyDegrees>
+<time>1746103655392</time>
+</trkpt>
+<trkpt lat="55.9452317" lon="-4.3125134">
+<ele>136.94103718843212></ele>
+<accuracy>7.522</accuracy>
+<speed>1.2592944</speed>
+<bearing>270.77515</bearing>
+<bearingAccuracyDegrees>14.7550535</bearingAccuracyDegrees>
+<time>1746103656503</time>
+</trkpt>
+<trkpt lat="55.9452323" lon="-4.3125322">
+<ele>137.28614876586957></ele>
+<accuracy>7.577</accuracy>
+<speed>1.266604</speed>
+<bearing>275.25473</bearing>
+<bearingAccuracyDegrees>12.981182</bearingAccuracyDegrees>
+<time>1746103657502</time>
+</trkpt>
+<trkpt lat="55.9452315" lon="-4.3125494">
+<ele>137.4029268162214></ele>
+<accuracy>7.567</accuracy>
+<speed>1.2627628</speed>
+<bearing>270.7642</bearing>
+<bearingAccuracyDegrees>15.314228</bearingAccuracyDegrees>
+<time>1746103658605</time>
+</trkpt>
+<trkpt lat="55.945228" lon="-4.3125694">
+<ele>137.52491986589226></ele>
+<accuracy>7.497</accuracy>
+<speed>1.2860972</speed>
+<bearing>267.20215</bearing>
+<bearingAccuracyDegrees>15.146787</bearingAccuracyDegrees>
+<time>1746103659607</time>
+</trkpt>
+<trkpt lat="55.9452246" lon="-4.3125928">
+<ele>137.80644889296713></ele>
+<accuracy>7.433</accuracy>
+<speed>1.3257229</speed>
+<bearing>268.45236</bearing>
+<bearingAccuracyDegrees>15.4719095</bearingAccuracyDegrees>
+<time>1746103660610</time>
+</trkpt>
+<trkpt lat="55.9452226" lon="-4.3126175">
+<ele>138.03376423962652></ele>
+<accuracy>7.418</accuracy>
+<speed>1.2994555</speed>
+<bearing>274.1744</bearing>
+<bearingAccuracyDegrees>13.337821</bearingAccuracyDegrees>
+<time>1746103661612</time>
+</trkpt>
+<trkpt lat="55.9452224" lon="-4.3126415">
+<ele>138.03376423962652></ele>
+<accuracy>7.379</accuracy>
+<speed>1.3189672</speed>
+<bearing>276.9529</bearing>
+<bearingAccuracyDegrees>13.177369</bearingAccuracyDegrees>
+<time>1746103662566</time>
+</trkpt>
+<trkpt lat="55.9452194" lon="-4.3126632">
+<ele>138.17088626463186></ele>
+<accuracy>7.346</accuracy>
+<speed>1.3407414</speed>
+<bearing>265.7544</bearing>
+<bearingAccuracyDegrees>13.210425</bearingAccuracyDegrees>
+<time>1746103663634</time>
+</trkpt>
+<trkpt lat="55.9452163" lon="-4.3126837">
+<ele>138.27672719345549></ele>
+<accuracy>7.32</accuracy>
+<speed>1.3399804</speed>
+<bearing>262.62094</bearing>
+<bearingAccuracyDegrees>12.937367</bearingAccuracyDegrees>
+<time>1746103664619</time>
+</trkpt>
+<trkpt lat="55.9452143" lon="-4.3127082">
+<ele>138.32260938013926></ele>
+<accuracy>7.248</accuracy>
+<speed>1.3298122</speed>
+<bearing>263.9588</bearing>
+<bearingAccuracyDegrees>12.623948</bearingAccuracyDegrees>
+<time>1746103665621</time>
+</trkpt>
+<trkpt lat="55.9452139" lon="-4.3127327">
+<ele>138.40081821713864></ele>
+<accuracy>7.174</accuracy>
+<speed>1.3318391</speed>
+<bearing>267.52667</bearing>
+<bearingAccuracyDegrees>13.4464035</bearingAccuracyDegrees>
+<time>1746103666624</time>
+</trkpt>
+<trkpt lat="55.945215" lon="-4.3127572">
+<ele>138.4362731242095></ele>
+<accuracy>7.066</accuracy>
+<speed>1.3356214</speed>
+<bearing>265.49246</bearing>
+<bearingAccuracyDegrees>13.2782345</bearingAccuracyDegrees>
+<time>1746103667625</time>
+</trkpt>
+<trkpt lat="55.9452162" lon="-4.3127812">
+<ele>138.46651418986661></ele>
+<accuracy>7.008</accuracy>
+<speed>1.3099371</speed>
+<bearing>264.04974</bearing>
+<bearingAccuracyDegrees>13.3314</bearingAccuracyDegrees>
+<time>1746103668628</time>
+</trkpt>
+<trkpt lat="55.9452135" lon="-4.312884">
+<ele>138.8023014438823></ele>
+<accuracy>6.928</accuracy>
+<speed>1.4307213</speed>
+<bearing>267.3288</bearing>
+<bearingAccuracyDegrees>12.849285</bearingAccuracyDegrees>
+<time>1746103672638</time>
+</trkpt>
+<trkpt lat="55.945213" lon="-4.3129121">
+<ele>138.91023584568313></ele>
+<accuracy>6.839</accuracy>
+<speed>1.4412018</speed>
+<bearing>266.22986</bearing>
+<bearingAccuracyDegrees>12.667002</bearingAccuracyDegrees>
+<time>1746103673540</time>
+</trkpt>
+<trkpt lat="55.9452119" lon="-4.312942">
+<ele>138.93109289109458></ele>
+<accuracy>6.833</accuracy>
+<speed>1.4568425</speed>
+<bearing>264.9386</bearing>
+<bearingAccuracyDegrees>13.054882</bearingAccuracyDegrees>
+<time>1746103674642</time>
+</trkpt>
+<trkpt lat="55.9452109" lon="-4.3129698">
+<ele>138.9827142960143></ele>
+<accuracy>6.746</accuracy>
+<speed>1.4500182</speed>
+<bearing>265.66098</bearing>
+<bearingAccuracyDegrees>12.955593</bearingAccuracyDegrees>
+<time>1746103675544</time>
+</trkpt>
+<trkpt lat="55.9452094" lon="-4.3129979">
+<ele>139.0838722910571></ele>
+<accuracy>6.677</accuracy>
+<speed>1.4410676</speed>
+<bearing>265.58493</bearing>
+<bearingAccuracyDegrees>15.179697</bearingAccuracyDegrees>
+<time>1746103676547</time>
+</trkpt>
+<trkpt lat="55.9452073" lon="-4.3130259">
+<ele>139.1500949219402></ele>
+<accuracy>6.621</accuracy>
+<speed>1.4481541</speed>
+<bearing>264.2266</bearing>
+<bearingAccuracyDegrees>12.843138</bearingAccuracyDegrees>
+<time>1746103677650</time>
+</trkpt>
+<trkpt lat="55.9452054" lon="-4.3130527">
+<ele>139.16521669657038></ele>
+<accuracy>6.59</accuracy>
+<speed>1.4412633</speed>
+<bearing>263.7276</bearing>
+<bearingAccuracyDegrees>12.69373</bearingAccuracyDegrees>
+<time>1746103678552</time>
+</trkpt>
+<trkpt lat="55.9452046" lon="-4.3130802">
+<ele>139.3028782125691></ele>
+<accuracy>6.536</accuracy>
+<speed>1.4211966</speed>
+<bearing>261.33783</bearing>
+<bearingAccuracyDegrees>12.581591</bearingAccuracyDegrees>
+<time>1746103679553</time>
+</trkpt>
+<trkpt lat="55.9452055" lon="-4.3131076">
+<ele>139.3028782125691></ele>
+<accuracy>6.25</accuracy>
+<speed>1.4359971</speed>
+<bearing>263.89053</bearing>
+<bearingAccuracyDegrees>12.284524</bearingAccuracyDegrees>
+<time>1746103680490</time>
+</trkpt>
+<trkpt lat="55.9452055" lon="-4.3131337">
+<ele>139.243954642421></ele>
+<accuracy>5.73</accuracy>
+<speed>1.4412243</speed>
+<bearing>257.19717</bearing>
+<bearingAccuracyDegrees>12.049152</bearingAccuracyDegrees>
+<time>1746103681543</time>
+</trkpt>
+<trkpt lat="55.9452043" lon="-4.3131578">
+<ele>139.31747880563813></ele>
+<accuracy>5.142</accuracy>
+<speed>1.4446335</speed>
+<bearing>277.61823</bearing>
+<bearingAccuracyDegrees>11.813685</bearingAccuracyDegrees>
+<time>1746103682561</time>
+</trkpt>
+<trkpt lat="55.9452091" lon="-4.3131856">
+<ele>139.31747880563813></ele>
+<accuracy>4.531</accuracy>
+<speed>1.4883231</speed>
+<bearing>280.16446</bearing>
+<bearingAccuracyDegrees>12.409517</bearingAccuracyDegrees>
+<time>1746103683633</time>
+</trkpt>
+<trkpt lat="55.9452113" lon="-4.3132092">
+<ele>139.3226933091711></ele>
+<accuracy>3.937</accuracy>
+<speed>1.543493</speed>
+<bearing>283.49332</bearing>
+<bearingAccuracyDegrees>11.951538</bearingAccuracyDegrees>
+<time>1746103684589</time>
+</trkpt>
+<trkpt lat="55.9452173" lon="-4.3132347">
+<ele>139.25434524341193></ele>
+<accuracy>3.712</accuracy>
+<speed>1.567455</speed>
+<bearing>290.9867</bearing>
+<bearingAccuracyDegrees>11.86676</bearingAccuracyDegrees>
+<time>1746103685593</time>
+</trkpt>
+<trkpt lat="55.9452236" lon="-4.313261">
+<ele>139.23296585735943></ele>
+<accuracy>3.744</accuracy>
+<speed>1.5803001</speed>
+<bearing>293.0503</bearing>
+<bearingAccuracyDegrees>12.583193</bearingAccuracyDegrees>
+<time>1746103686624</time>
+</trkpt>
+<trkpt lat="55.9452298" lon="-4.3132836">
+<ele>139.25434524341193></ele>
+<accuracy>3.911</accuracy>
+<speed>1.5857173</speed>
+<bearing>295.19202</bearing>
+<bearingAccuracyDegrees>12.775569</bearingAccuracyDegrees>
+<time>1746103687573</time>
+</trkpt>
+<trkpt lat="55.9452375" lon="-4.3133092">
+<ele>139.2668600306428></ele>
+<accuracy>4.267</accuracy>
+<speed>1.5672393</speed>
+<bearing>304.38208</bearing>
+<bearingAccuracyDegrees>12.43516</bearingAccuracyDegrees>
+<time>1746103688575</time>
+</trkpt>
+<trkpt lat="55.9452464" lon="-4.3133312">
+<ele>139.3153550031718></ele>
+<accuracy>4.644</accuracy>
+<speed>1.5457338</speed>
+<bearing>318.49362</bearing>
+<bearingAccuracyDegrees>12.475055</bearingAccuracyDegrees>
+<time>1746103689578</time>
+</trkpt>
+<trkpt lat="55.9452576" lon="-4.3133476">
+<ele>139.44206896410435></ele>
+<accuracy>5.109</accuracy>
+<speed>1.5361774</speed>
+<bearing>336.65274</bearing>
+<bearingAccuracyDegrees>12.610118</bearingAccuracyDegrees>
+<time>1746103690579</time>
+</trkpt>
+<trkpt lat="55.94527" lon="-4.3133566">
+<ele>139.6079314690682></ele>
+<accuracy>5.417</accuracy>
+<speed>1.4918242</speed>
+<bearing>344.84283</bearing>
+<bearingAccuracyDegrees>12.646525</bearingAccuracyDegrees>
+<time>1746103691583</time>
+</trkpt>
+<trkpt lat="55.9452824" lon="-4.3133634">
+<ele>139.7826249585746></ele>
+<accuracy>5.659</accuracy>
+<speed>1.483901</speed>
+<bearing>347.40933</bearing>
+<bearingAccuracyDegrees>12.219935</bearingAccuracyDegrees>
+<time>1746103692585</time>
+</trkpt>
+<trkpt lat="55.9452949" lon="-4.3133698">
+<ele>139.88379236311195></ele>
+<accuracy>5.823</accuracy>
+<speed>1.4444609</speed>
+<bearing>346.9416</bearing>
+<bearingAccuracyDegrees>11.991858</bearingAccuracyDegrees>
+<time>1746103693588</time>
+</trkpt>
+<trkpt lat="55.9453077" lon="-4.3133791">
+<ele>139.99325110825708></ele>
+<accuracy>5.923</accuracy>
+<speed>1.4323673</speed>
+<bearing>341.21396</bearing>
+<bearingAccuracyDegrees>12.031512</bearingAccuracyDegrees>
+<time>1746103694590</time>
+</trkpt>
+<trkpt lat="55.9453204" lon="-4.3133901">
+<ele>139.99325110825708></ele>
+<accuracy>5.974</accuracy>
+<speed>1.4155893</speed>
+<bearing>340.58072</bearing>
+<bearingAccuracyDegrees>12.142075</bearingAccuracyDegrees>
+<time>1746103695545</time>
+</trkpt>
+<trkpt lat="55.9453335" lon="-4.3134009">
+<ele>140.1079808641895></ele>
+<accuracy>6.061</accuracy>
+<speed>1.404822</speed>
+<bearing>337.00043</bearing>
+<bearingAccuracyDegrees>12.185995</bearingAccuracyDegrees>
+<time>1746103696568</time>
+</trkpt>
+<trkpt lat="55.9453469" lon="-4.3134144">
+<ele>140.2034163272831></ele>
+<accuracy>6.186</accuracy>
+<speed>1.431561</speed>
+<bearing>333.02783</bearing>
+<bearingAccuracyDegrees>12.856906</bearingAccuracyDegrees>
+<time>1746103697612</time>
+</trkpt>
+<trkpt lat="55.945359" lon="-4.313423">
+<ele>140.31867040214593></ele>
+<accuracy>6.067</accuracy>
+<speed>1.4755732</speed>
+<bearing>333.02853</bearing>
+<bearingAccuracyDegrees>12.263407</bearingAccuracyDegrees>
+<time>1746103698621</time>
+</trkpt>
+<trkpt lat="55.9453721" lon="-4.3134283">
+<ele>140.4584375968931></ele>
+<accuracy>5.792</accuracy>
+<speed>1.5007287</speed>
+<bearing>330.83218</bearing>
+<bearingAccuracyDegrees>11.925652</bearingAccuracyDegrees>
+<time>1746103699665</time>
+</trkpt>
+<trkpt lat="55.9453832" lon="-4.3134295">
+<ele>140.6190683723681></ele>
+<accuracy>5.467</accuracy>
+<speed>1.516852</speed>
+<bearing>324.70566</bearing>
+<bearingAccuracyDegrees>12.016904</bearingAccuracyDegrees>
+<time>1746103700603</time>
+</trkpt>
+<trkpt lat="55.9453967" lon="-4.3134315">
+<ele>140.71816028210503></ele>
+<accuracy>5.055</accuracy>
+<speed>1.5181288</speed>
+<bearing>323.3742</bearing>
+<bearingAccuracyDegrees>12.282927</bearingAccuracyDegrees>
+<time>1746103701606</time>
+</trkpt>
+<trkpt lat="55.9454477" lon="-4.3134685">
+<ele>140.9575501855211></ele>
+<accuracy>4.128</accuracy>
+<speed>1.5122755</speed>
+<bearing>323.7732</bearing>
+<bearingAccuracyDegrees>10.1478</bearingAccuracyDegrees>
+<time>1746103705616</time>
+</trkpt>
+<trkpt lat="55.9454615" lon="-4.3134831">
+<ele>141.07177124583427></ele>
+<accuracy>4.089</accuracy>
+<speed>1.5453069</speed>
+<bearing>324.6589</bearing>
+<bearingAccuracyDegrees>10.130901</bearingAccuracyDegrees>
+<time>1746103706618</time>
+</trkpt>
+<trkpt lat="55.9454759" lon="-4.3134975">
+<ele>141.20216243845593></ele>
+<accuracy>4.083</accuracy>
+<speed>1.5664171</speed>
+<bearing>329.27362</bearing>
+<bearingAccuracyDegrees>10.09574</bearingAccuracyDegrees>
+<time>1746103707620</time>
+</trkpt>
+<trkpt lat="55.9454909" lon="-4.3135118">
+<ele>141.2584920451731></ele>
+<accuracy>4.096</accuracy>
+<speed>1.5716223</speed>
+<bearing>328.6507</bearing>
+<bearingAccuracyDegrees>10.17715</bearingAccuracyDegrees>
+<time>1746103708623</time>
+</trkpt>
+<trkpt lat="55.945505" lon="-4.3135272">
+<ele>141.31638674766143></ele>
+<accuracy>4.057</accuracy>
+<speed>1.5664501</speed>
+<bearing>330.4681</bearing>
+<bearingAccuracyDegrees>10.187482</bearingAccuracyDegrees>
+<time>1746103709625</time>
+</trkpt>
+<trkpt lat="55.9455192" lon="-4.313542">
+<ele>141.429047826408></ele>
+<accuracy>4.027</accuracy>
+<speed>1.579005</speed>
+<bearing>330.14392</bearing>
+<bearingAccuracyDegrees>10.084121</bearingAccuracyDegrees>
+<time>1746103710628</time>
+</trkpt>
+<trkpt lat="55.9455328" lon="-4.3135582">
+<ele>141.45773491091026></ele>
+<accuracy>3.991</accuracy>
+<speed>1.5695349</speed>
+<bearing>323.4401</bearing>
+<bearingAccuracyDegrees>9.657743</bearingAccuracyDegrees>
+<time>1746103711629</time>
+</trkpt>
+<trkpt lat="55.9455454" lon="-4.3135758">
+<ele>141.53701607847194></ele>
+<accuracy>3.983</accuracy>
+<speed>1.5476769</speed>
+<bearing>327.9197</bearing>
+<bearingAccuracyDegrees>9.649714</bearingAccuracyDegrees>
+<time>1746103712632</time>
+</trkpt>
+<trkpt lat="55.9455598" lon="-4.3135901">
+<ele>141.58343762768644></ele>
+<accuracy>3.917</accuracy>
+<speed>1.5440675</speed>
+<bearing>338.26105</bearing>
+<bearingAccuracyDegrees>9.774698</bearingAccuracyDegrees>
+<time>1746103713635</time>
+</trkpt>
+<trkpt lat="55.9455748" lon="-4.3136019">
+<ele>141.65802558545317></ele>
+<accuracy>3.885</accuracy>
+<speed>1.5283172</speed>
+<bearing>343.3261</bearing>
+<bearingAccuracyDegrees>9.599655</bearingAccuracyDegrees>
+<time>1746103714637</time>
+</trkpt>
+<trkpt lat="55.9455904" lon="-4.3136106">
+<ele>141.74930543499954></ele>
+<accuracy>3.821</accuracy>
+<speed>1.5273155</speed>
+<bearing>345.69714</bearing>
+<bearingAccuracyDegrees>9.666714</bearingAccuracyDegrees>
+<time>1746103715640</time>
+</trkpt>
+<trkpt lat="55.9456063" lon="-4.3136196">
+<ele>141.74093475114165></ele>
+<accuracy>3.75</accuracy>
+<speed>1.5167801</speed>
+<bearing>346.9183</bearing>
+<bearingAccuracyDegrees>9.963817</bearingAccuracyDegrees>
+<time>1746103716642</time>
+</trkpt>
+<trkpt lat="55.9456226" lon="-4.3136278">
+<ele>141.74093475114165></ele>
+<accuracy>3.689</accuracy>
+<speed>1.5233891</speed>
+<bearing>344.97623</bearing>
+<bearingAccuracyDegrees>9.818083</bearingAccuracyDegrees>
+<time>1746103717606</time>
+</trkpt>
+<trkpt lat="55.9456387" lon="-4.3136385">
+<ele>141.86507742087267></ele>
+<accuracy>3.604</accuracy>
+<speed>1.5362777</speed>
+<bearing>341.95114</bearing>
+<bearingAccuracyDegrees>9.088802</bearingAccuracyDegrees>
+<time>1746103718629</time>
+</trkpt>
+<trkpt lat="55.945656" lon="-4.3136488">
+<ele>141.87550965961503></ele>
+<accuracy>3.524</accuracy>
+<speed>1.5507356</speed>
+<bearing>342.79465</bearing>
+<bearingAccuracyDegrees>9.01311</bearingAccuracyDegrees>
+<time>1746103719675</time>
+</trkpt>
+<trkpt lat="55.9456725" lon="-4.3136603">
+<ele>142.07476784880885></ele>
+<accuracy>3.46</accuracy>
+<speed>1.5619956</speed>
+<bearing>341.478</bearing>
+<bearingAccuracyDegrees>9.121146</bearingAccuracyDegrees>
+<time>1746103720766</time>
+</trkpt>
+<trkpt lat="55.945687" lon="-4.3136699">
+<ele>142.1582281480581></ele>
+<accuracy>3.404</accuracy>
+<speed>1.5261887</speed>
+<bearing>346.95462</bearing>
+<bearingAccuracyDegrees>10.009221</bearingAccuracyDegrees>
+<time>1746103721827</time>
+</trkpt>
+<trkpt lat="55.9456997" lon="-4.3136845">
+<ele>142.19995860141864></ele>
+<accuracy>3.348</accuracy>
+<speed>1.4826955</speed>
+<bearing>315.32065</bearing>
+<bearingAccuracyDegrees>9.404043</bearingAccuracyDegrees>
+<time>1746103722929</time>
+</trkpt>
+<trkpt lat="55.9457037" lon="-4.3137106">
+<ele>142.2354296459854></ele>
+<accuracy>3.291</accuracy>
+<speed>1.4297554</speed>
+<bearing>280.44604</bearing>
+<bearingAccuracyDegrees>9.462825</bearingAccuracyDegrees>
+<time>1746103723964</time>
+</trkpt>
+<trkpt lat="55.945702" lon="-4.3137409">
+<ele>142.19369902050653></ele>
+<accuracy>3.256</accuracy>
+<speed>1.4134467</speed>
+<bearing>267.572</bearing>
+<bearingAccuracyDegrees>10.133121</bearingAccuracyDegrees>
+<time>1746103725125</time>
+</trkpt>
+<trkpt lat="55.9456997" lon="-4.3137664">
+<ele>141.93810335782712></ele>
+<accuracy>3.223</accuracy>
+<speed>1.4565449</speed>
+<bearing>266.8965</bearing>
+<bearingAccuracyDegrees>10.575857</bearingAccuracyDegrees>
+<time>1746103726108</time>
+</trkpt>
+<trkpt lat="55.9456975" lon="-4.313795">
+<ele>141.84997519252536></ele>
+<accuracy>3.207</accuracy>
+<speed>1.5225663</speed>
+<bearing>267.46558</bearing>
+<bearingAccuracyDegrees>10.106284</bearingAccuracyDegrees>
+<time>1746103727129</time>
+</trkpt>
+<trkpt lat="55.9456961" lon="-4.3138204">
+<ele>141.6152547892937></ele>
+<accuracy>3.195</accuracy>
+<speed>1.5429903</speed>
+<bearing>271.84497</bearing>
+<bearingAccuracyDegrees>11.86778</bearingAccuracyDegrees>
+<time>1746103728091</time>
+</trkpt>
+<trkpt lat="55.9456973" lon="-4.3138488">
+<ele>141.29708847019307></ele>
+<accuracy>3.214</accuracy>
+<speed>1.5729188</speed>
+<bearing>278.9118</bearing>
+<bearingAccuracyDegrees>9.784694</bearingAccuracyDegrees>
+<time>1746103729087</time>
+</trkpt>
+<trkpt lat="55.9456993" lon="-4.31388">
+<ele>141.22302521273917></ele>
+<accuracy>3.246</accuracy>
+<speed>1.5934856</speed>
+<bearing>278.49026</bearing>
+<bearingAccuracyDegrees>9.852211</bearingAccuracyDegrees>
+<time>1746103730066</time>
+</trkpt>
+<trkpt lat="55.9457011" lon="-4.3139115">
+<ele>140.84854611342496></ele>
+<accuracy>3.314</accuracy>
+<speed>1.6057525</speed>
+<bearing>278.67465</bearing>
+<bearingAccuracyDegrees>9.803766</bearingAccuracyDegrees>
+<time>1746103731068</time>
+</trkpt>
+<trkpt lat="55.9457026" lon="-4.3139449">
+<ele>140.68686797673345></ele>
+<accuracy>3.399</accuracy>
+<speed>1.6175989</speed>
+<bearing>276.41397</bearing>
+<bearingAccuracyDegrees>9.545689</bearingAccuracyDegrees>
+<time>1746103732071</time>
+</trkpt>
+<trkpt lat="55.9457035" lon="-4.3139775">
+<ele>140.4334044995044></ele>
+<accuracy>3.48</accuracy>
+<speed>1.6283357</speed>
+<bearing>274.27087</bearing>
+<bearingAccuracyDegrees>9.648453</bearingAccuracyDegrees>
+<time>1746103733063</time>
+</trkpt>
+<trkpt lat="55.9457041" lon="-4.3140238">
+<ele>140.21697555003928></ele>
+<accuracy>3.573</accuracy>
+<speed>1.6316466</speed>
+<bearing>276.129</bearing>
+<bearingAccuracyDegrees>9.432418</bearingAccuracyDegrees>
+<time>1746103734488</time>
+</trkpt>
+<trkpt lat="55.9457068" lon="-4.3140569">
+<ele>139.90876926645987></ele>
+<accuracy>3.608</accuracy>
+<speed>1.6468459</speed>
+<bearing>280.38617</bearing>
+<bearingAccuracyDegrees>9.509352</bearingAccuracyDegrees>
+<time>1746103735449</time>
+</trkpt>
+<trkpt lat="55.9457089" lon="-4.314089">
+<ele>139.58910166040076></ele>
+<accuracy>3.624</accuracy>
+<speed>1.6783699</speed>
+<bearing>276.6561</bearing>
+<bearingAccuracyDegrees>9.5257845</bearingAccuracyDegrees>
+<time>1746103736392</time>
+</trkpt>
+<trkpt lat="55.9457075" lon="-4.3141207">
+<ele>139.3012545378914></ele>
+<accuracy>3.616</accuracy>
+<speed>1.6842839</speed>
+<bearing>268.47656</bearing>
+<bearingAccuracyDegrees>9.471564</bearingAccuracyDegrees>
+<time>1746103737363</time>
+</trkpt>
+<trkpt lat="55.9457065" lon="-4.3141509">
+<ele>139.03688170145966></ele>
+<accuracy>3.622</accuracy>
+<speed>1.6740224</speed>
+<bearing>274.92163</bearing>
+<bearingAccuracyDegrees>9.658418</bearingAccuracyDegrees>
+<time>1746103738339</time>
+</trkpt>
+<trkpt lat="55.9457084" lon="-4.3141792">
+<ele>138.7813811601284></ele>
+<accuracy>3.642</accuracy>
+<speed>1.6616107</speed>
+<bearing>280.19333</bearing>
+<bearingAccuracyDegrees>9.88469</bearingAccuracyDegrees>
+<time>1746103739351</time>
+</trkpt>
+<trkpt lat="55.9457105" lon="-4.3142067">
+<ele>138.4523702155151></ele>
+<accuracy>3.685</accuracy>
+<speed>1.6667789</speed>
+<bearing>281.7955</bearing>
+<bearingAccuracyDegrees>10.03025</bearingAccuracyDegrees>
+<time>1746103740272</time>
+</trkpt>
+<trkpt lat="55.945713" lon="-4.314336">
+<ele>137.44664460011248></ele>
+<accuracy>3.915</accuracy>
+<speed>1.6519659</speed>
+<bearing>279.84442</bearing>
+<bearingAccuracyDegrees>9.332521</bearingAccuracyDegrees>
+<time>1746103744552</time>
+</trkpt>
+<trkpt lat="55.9457162" lon="-4.3143646">
+<ele>137.1990111851204></ele>
+<accuracy>3.946</accuracy>
+<speed>1.640929</speed>
+<bearing>279.27335</bearing>
+<bearingAccuracyDegrees>9.582482</bearingAccuracyDegrees>
+<time>1746103745542</time>
+</trkpt>
+<trkpt lat="55.9457197" lon="-4.3143927">
+<ele>136.91697844399533></ele>
+<accuracy>3.967</accuracy>
+<speed>1.6294764</speed>
+<bearing>280.9581</bearing>
+<bearingAccuracyDegrees>9.327254</bearingAccuracyDegrees>
+<time>1746103746613</time>
+</trkpt>
+<trkpt lat="55.9457238" lon="-4.3144181">
+<ele>136.91697844399533></ele>
+<accuracy>3.92</accuracy>
+<speed>1.6113399</speed>
+<bearing>284.2488</bearing>
+<bearingAccuracyDegrees>9.752109</bearingAccuracyDegrees>
+<time>1746103747547</time>
+</trkpt>
+<trkpt lat="55.9457287" lon="-4.3144454">
+<ele>136.8294784018209></ele>
+<accuracy>3.901</accuracy>
+<speed>1.5889199</speed>
+<bearing>286.5405</bearing>
+<bearingAccuracyDegrees>9.300543</bearingAccuracyDegrees>
+<time>1746103748550</time>
+</trkpt>
+<trkpt lat="55.9457339" lon="-4.3144706">
+<ele>136.75128385330737></ele>
+<accuracy>3.906</accuracy>
+<speed>1.5804443</speed>
+<bearing>285.86276</bearing>
+<bearingAccuracyDegrees>9.827056</bearingAccuracyDegrees>
+<time>1746103749524</time>
+</trkpt>
+<trkpt lat="55.9457381" lon="-4.3144973">
+<ele>136.6465042729521></ele>
+<accuracy>3.864</accuracy>
+<speed>1.5728569</speed>
+<bearing>281.75018</bearing>
+<bearingAccuracyDegrees>9.416633</bearingAccuracyDegrees>
+<time>1746103750567</time>
+</trkpt>
+<trkpt lat="55.945741" lon="-4.3145205">
+<ele>136.5010660757104></ele>
+<accuracy>3.851</accuracy>
+<speed>1.5598793</speed>
+<bearing>281.5685</bearing>
+<bearingAccuracyDegrees>9.444427</bearingAccuracyDegrees>
+<time>1746103751547</time>
+</trkpt>
+<trkpt lat="55.9457439" lon="-4.3145431">
+<ele>136.33999223307484></ele>
+<accuracy>3.878</accuracy>
+<speed>1.5665083</speed>
+<bearing>277.0556</bearing>
+<bearingAccuracyDegrees>9.934185</bearingAccuracyDegrees>
+<time>1746103752627</time>
+</trkpt>
+<trkpt lat="55.9457456" lon="-4.3145636">
+<ele>136.33999223307484></ele>
+<accuracy>3.865</accuracy>
+<speed>1.5438788</speed>
+<bearing>274.84244</bearing>
+<bearingAccuracyDegrees>10.120611</bearingAccuracyDegrees>
+<time>1746103753561</time>
+</trkpt>
+<trkpt lat="55.9457482" lon="-4.314586">
+<ele>136.24460040884418></ele>
+<accuracy>3.887</accuracy>
+<speed>1.5392339</speed>
+<bearing>274.91458</bearing>
+<bearingAccuracyDegrees>10.023349</bearingAccuracyDegrees>
+<time>1746103754592</time>
+</trkpt>
+<trkpt lat="55.9457516" lon="-4.3146102">
+<ele>136.18830409102932></ele>
+<accuracy>3.886</accuracy>
+<speed>1.562689</speed>
+<bearing>276.2055</bearing>
+<bearingAccuracyDegrees>9.714769</bearingAccuracyDegrees>
+<time>1746103755609</time>
+</trkpt>
+<trkpt lat="55.9457545" lon="-4.3146317">
+<ele>136.1330506559617></ele>
+<accuracy>3.891</accuracy>
+<speed>1.5534129</speed>
+<bearing>279.13602</bearing>
+<bearingAccuracyDegrees>9.963099</bearingAccuracyDegrees>
+<time>1746103756611</time>
+</trkpt>
+<trkpt lat="55.9457576" lon="-4.3146537">
+<ele>135.90682802962687></ele>
+<accuracy>3.911</accuracy>
+<speed>1.5650917</speed>
+<bearing>272.0253</bearing>
+<bearingAccuracyDegrees>10.073982</bearingAccuracyDegrees>
+<time>1746103757639</time>
+</trkpt>
+<trkpt lat="55.945758" lon="-4.3146782">
+<ele>135.90682802962687></ele>
+<accuracy>3.891</accuracy>
+<speed>1.5839509</speed>
+<bearing>261.34137</bearing>
+<bearingAccuracyDegrees>9.76495</bearingAccuracyDegrees>
+<time>1746103758570</time>
+</trkpt>
+<trkpt lat="55.945753" lon="-4.3147021">
+<ele>135.65246499484385></ele>
+<accuracy>3.896</accuracy>
+<speed>1.5795164</speed>
+<bearing>248.94444</bearing>
+<bearingAccuracyDegrees>10.09086</bearingAccuracyDegrees>
+<time>1746103759525</time>
+</trkpt>
+<trkpt lat="55.9457422" lon="-4.3147272">
+<ele>135.38455796616148></ele>
+<accuracy>3.893</accuracy>
+<speed>1.6150532</speed>
+<bearing>236.49005</bearing>
+<bearingAccuracyDegrees>11.991903</bearingAccuracyDegrees>
+<time>1746103760508</time>
+</trkpt>
+<trkpt lat="55.9457322" lon="-4.3147486">
+<ele>135.32461882014292></ele>
+<accuracy>3.896</accuracy>
+<speed>1.6276565</speed>
+<bearing>232.28674</bearing>
+<bearingAccuracyDegrees>10.315998</bearingAccuracyDegrees>
+<time>1746103761511</time>
+</trkpt>
+<trkpt lat="55.9457214" lon="-4.3147697">
+<ele>135.14636748047775></ele>
+<accuracy>3.885</accuracy>
+<speed>1.621792</speed>
+<bearing>228.93642</bearing>
+<bearingAccuracyDegrees>12.074314</bearingAccuracyDegrees>
+<time>1746103762509</time>
+</trkpt>
+<trkpt lat="55.9457088" lon="-4.31479">
+<ele>134.98271307094086></ele>
+<accuracy>3.899</accuracy>
+<speed>1.6081299</speed>
+<bearing>223.86246</bearing>
+<bearingAccuracyDegrees>10.319794</bearingAccuracyDegrees>
+<time>1746103763508</time>
+</trkpt>
+<trkpt lat="55.9456925" lon="-4.3148102">
+<ele>133.3000030517578></ele>
+<accuracy>3.899</accuracy>
+<speed>1.6045505</speed>
+<bearing>215.29514</bearing>
+<bearingAccuracyDegrees>10.454732</bearingAccuracyDegrees>
+<time>1746103764670</time>
+</trkpt>
+<trkpt lat="55.9456721" lon="-4.314829">
+<ele>133.3000030517578></ele>
+<accuracy>3.927</accuracy>
+<speed>1.6030006</speed>
+<bearing>214.77942</bearing>
+<bearingAccuracyDegrees>10.124585</bearingAccuracyDegrees>
+<time>1746103766090</time>
+</trkpt>
+<trkpt lat="55.9456581" lon="-4.3148437">
+<ele>133.3000030517578></ele>
+<accuracy>3.946</accuracy>
+<speed>1.5954801</speed>
+<bearing>216.14693</bearing>
+<bearingAccuracyDegrees>10.120933</bearingAccuracyDegrees>
+<time>1746103767143</time>
+</trkpt>
+<trkpt lat="55.9456453" lon="-4.314859">
+<ele>133.3000030517578></ele>
+<accuracy>3.987</accuracy>
+<speed>1.6222342</speed>
+<bearing>218.13771</bearing>
+<bearingAccuracyDegrees>10.197416</bearingAccuracyDegrees>
+<time>1746103768107</time>
+</trkpt>
+<trkpt lat="55.9456333" lon="-4.3148774">
+<ele>133.3000030517578></ele>
+<accuracy>4.058</accuracy>
+<speed>1.6153408</speed>
+<bearing>225.72919</bearing>
+<bearingAccuracyDegrees>10.27476</bearingAccuracyDegrees>
+<time>1746103769091</time>
+</trkpt>
+<trkpt lat="55.9456242" lon="-4.3148949">
+<ele>133.3000030517578></ele>
+<accuracy>4.088</accuracy>
+<speed>1.603669</speed>
+<bearing>227.11247</bearing>
+<bearingAccuracyDegrees>10.311562</bearingAccuracyDegrees>
+<time>1746103770072</time>
+</trkpt>
+<trkpt lat="55.9456144" lon="-4.3149158">
+<ele>133.3000030517578></ele>
+<accuracy>4.154</accuracy>
+<speed>1.6128759</speed>
+<bearing>227.18217</bearing>
+<bearingAccuracyDegrees>9.898963</bearingAccuracyDegrees>
+<time>1746103771049</time>
+</trkpt>
+<trkpt lat="55.9456045" lon="-4.3149358">
+<ele>133.3000030517578></ele>
+<accuracy>4.246</accuracy>
+<speed>1.587885</speed>
+<bearing>228.90408</bearing>
+<bearingAccuracyDegrees>11.90324</bearingAccuracyDegrees>
+<time>1746103772049</time>
+</trkpt>
+<trkpt lat="55.945592" lon="-4.3149636">
+<ele>133.3000030517578></ele>
+<accuracy>4.338</accuracy>
+<speed>1.6140438</speed>
+<bearing>232.26376</bearing>
+<bearingAccuracyDegrees>10.316978</bearingAccuracyDegrees>
+<time>1746103773358</time>
+</trkpt>
+<trkpt lat="55.9455838" lon="-4.314985">
+<ele>133.3000030517578></ele>
+<accuracy>4.378</accuracy>
+<speed>1.6353344</speed>
+<bearing>233.9067</bearing>
+<bearingAccuracyDegrees>11.97699</bearingAccuracyDegrees>
+<time>1746103774329</time>
+</trkpt>
+<trkpt lat="55.9455751" lon="-4.3150068">
+<ele>133.3000030517578></ele>
+<accuracy>4.404</accuracy>
+<speed>1.6530867</speed>
+<bearing>235.52641</bearing>
+<bearingAccuracyDegrees>11.606064</bearingAccuracyDegrees>
+<time>1746103775305</time>
+</trkpt>
+<trkpt lat="55.9455662" lon="-4.3150294">
+<ele>133.3000030517578></ele>
+<accuracy>4.443</accuracy>
+<speed>1.6499668</speed>
+<bearing>233.53293</bearing>
+<bearingAccuracyDegrees>12.334658</bearingAccuracyDegrees>
+<time>1746103776310</time>
+</trkpt>
+<trkpt lat="55.9455562" lon="-4.3150481">
+<ele>133.3000030517578></ele>
+<accuracy>4.483</accuracy>
+<speed>1.6253448</speed>
+<bearing>232.5954</bearing>
+<bearingAccuracyDegrees>10.408321</bearingAccuracyDegrees>
+<time>1746103777309</time>
+</trkpt>
+<trkpt lat="55.9455462" lon="-4.3150661">
+<ele>133.3000030517578></ele>
+<accuracy>4.527</accuracy>
+<speed>1.599844</speed>
+<bearing>231.57054</bearing>
+<bearingAccuracyDegrees>10.316357</bearingAccuracyDegrees>
+<time>1746103778316</time>
+</trkpt>
+<trkpt lat="55.9455375" lon="-4.3150851">
+<ele>133.3000030517578></ele>
+<accuracy>4.539</accuracy>
+<speed>1.5854198</speed>
+<bearing>232.3571</bearing>
+<bearingAccuracyDegrees>9.542907</bearingAccuracyDegrees>
+<time>1746103779322</time>
+</trkpt>
+<trkpt lat="55.9455295" lon="-4.3151045">
+<ele>133.3000030517578></ele>
+<accuracy>4.549</accuracy>
+<speed>1.592503</speed>
+<bearing>235.07806</bearing>
+<bearingAccuracyDegrees>9.589092</bearingAccuracyDegrees>
+<time>1746103780312</time>
+</trkpt>
+<trkpt lat="55.9455229" lon="-4.315128">
+<ele>133.3000030517578></ele>
+<accuracy>4.559</accuracy>
+<speed>1.576271</speed>
+<bearing>235.29839</bearing>
+<bearingAccuracyDegrees>9.360232</bearingAccuracyDegrees>
+<time>1746103781307</time>
+</trkpt>
+<trkpt lat="55.945517" lon="-4.3151536">
+<ele>133.3000030517578></ele>
+<accuracy>4.528</accuracy>
+<speed>1.5987339</speed>
+<bearing>238.19019</bearing>
+<bearingAccuracyDegrees>9.160104</bearingAccuracyDegrees>
+<time>1746103782313</time>
+</trkpt>
+<trkpt lat="55.9455106" lon="-4.3151772">
+<ele>133.3000030517578></ele>
+<accuracy>4.476</accuracy>
+<speed>1.5881716</speed>
+<bearing>238.03581</bearing>
+<bearingAccuracyDegrees>9.314617</bearingAccuracyDegrees>
+<time>1746103783311</time>
+</trkpt>
+<trkpt lat="55.9455029" lon="-4.3151982">
+<ele>133.8000030517578></ele>
+<accuracy>4.417</accuracy>
+<speed>1.5585726</speed>
+<bearing>237.38628</bearing>
+<bearingAccuracyDegrees>9.677039</bearingAccuracyDegrees>
+<time>1746103784322</time>
+</trkpt>
+<trkpt lat="55.9454949" lon="-4.3152177">
+<ele>133.8000030517578></ele>
+<accuracy>4.371</accuracy>
+<speed>1.5256686</speed>
+<bearing>236.09721</bearing>
+<bearingAccuracyDegrees>9.656915</bearingAccuracyDegrees>
+<time>1746103785347</time>
+</trkpt>
+<trkpt lat="55.9454873" lon="-4.3152365">
+<ele>133.8000030517578></ele>
+<accuracy>4.284</accuracy>
+<speed>1.5214156</speed>
+<bearing>236.98311</bearing>
+<bearingAccuracyDegrees>10.179424</bearingAccuracyDegrees>
+<time>1746103786349</time>
+</trkpt>
+<trkpt lat="55.9454794" lon="-4.3152564">
+<ele>133.8000030517578></ele>
+<accuracy>4.19</accuracy>
+<speed>1.523061</speed>
+<bearing>232.65161</bearing>
+<bearingAccuracyDegrees>9.865758</bearingAccuracyDegrees>
+<time>1746103787354</time>
+</trkpt>
+<trkpt lat="55.9454697" lon="-4.3152748">
+<ele>133.8000030517578></ele>
+<accuracy>4.139</accuracy>
+<speed>1.512014</speed>
+<bearing>229.2181</bearing>
+<bearingAccuracyDegrees>9.506399</bearingAccuracyDegrees>
+<time>1746103788385</time>
+</trkpt>
+<trkpt lat="55.9454605" lon="-4.315291">
+<ele>133.8000030517578></ele>
+<accuracy>4.114</accuracy>
+<speed>1.5072901</speed>
+<bearing>232.02054</bearing>
+<bearingAccuracyDegrees>9.638068</bearingAccuracyDegrees>
+<time>1746103789367</time>
+</trkpt>
+<trkpt lat="55.9454521" lon="-4.3153143">
+<ele>133.8000030517578></ele>
+<accuracy>4.092</accuracy>
+<speed>1.51734</speed>
+<bearing>240.64479</bearing>
+<bearingAccuracyDegrees>9.693627</bearingAccuracyDegrees>
+<time>1746103790445</time>
+</trkpt>
+<trkpt lat="55.9454465" lon="-4.3153369">
+<ele>133.8000030517578></ele>
+<accuracy>4.119</accuracy>
+<speed>1.5214355</speed>
+<bearing>241.16664</bearing>
+<bearingAccuracyDegrees>9.971062</bearingAccuracyDegrees>
+<time>1746103791390</time>
+</trkpt>
+<trkpt lat="55.9454406" lon="-4.315361">
+<ele>133.8000030517578></ele>
+<accuracy>4.19</accuracy>
+<speed>1.5347182</speed>
+<bearing>238.59332</bearing>
+<bearingAccuracyDegrees>9.481071</bearingAccuracyDegrees>
+<time>1746103792368</time>
+</trkpt>
+<trkpt lat="55.9454347" lon="-4.3153883">
+<ele>133.8000030517578></ele>
+<accuracy>4.28</accuracy>
+<speed>1.5412867</speed>
+<bearing>236.17178</bearing>
+<bearingAccuracyDegrees>9.675563</bearingAccuracyDegrees>
+<time>1746103793406</time>
+</trkpt>
+<trkpt lat="55.9454293" lon="-4.3154143">
+<ele>133.8000030517578></ele>
+<accuracy>4.345</accuracy>
+<speed>1.5496444</speed>
+<bearing>235.92964</bearing>
+<bearingAccuracyDegrees>9.79699</bearingAccuracyDegrees>
+<time>1746103794408</time>
+</trkpt>
+<trkpt lat="55.9454229" lon="-4.3154365">
+<ele>133.8000030517578></ele>
+<accuracy>4.4</accuracy>
+<speed>1.5077274</speed>
+<bearing>228.65198</bearing>
+<bearingAccuracyDegrees>9.498883</bearingAccuracyDegrees>
+<time>1746103795410</time>
+</trkpt>
+<trkpt lat="55.945415" lon="-4.3154573">
+<ele>133.8000030517578></ele>
+<accuracy>4.437</accuracy>
+<speed>1.5235131</speed>
+<bearing>229.08649</bearing>
+<bearingAccuracyDegrees>9.431687</bearingAccuracyDegrees>
+<time>1746103796381</time>
+</trkpt>
+<trkpt lat="55.9454082" lon="-4.3154772">
+<ele>131.3000030517578></ele>
+<accuracy>4.411</accuracy>
+<speed>1.5258497</speed>
+<bearing>231.20352</bearing>
+<bearingAccuracyDegrees>9.120569</bearingAccuracyDegrees>
+<time>1746103797332</time>
+</trkpt>
+<trkpt lat="55.9453993" lon="-4.3155088">
+<ele>131.3000030517578></ele>
+<accuracy>4.315</accuracy>
+<speed>1.5344734</speed>
+<bearing>235.36752</bearing>
+<bearingAccuracyDegrees>9.663092</bearingAccuracyDegrees>
+<time>1746103798468</time>
+</trkpt>
+<trkpt lat="55.9453925" lon="-4.3155436">
+<ele>131.3000030517578></ele>
+<accuracy>4.238</accuracy>
+<speed>1.5379877</speed>
+<bearing>237.1687</bearing>
+<bearingAccuracyDegrees>9.6032715</bearingAccuracyDegrees>
+<time>1746103799466</time>
+</trkpt>
+<trkpt lat="55.9453844" lon="-4.3155778">
+<ele>131.3000030517578></ele>
+<accuracy>4.207</accuracy>
+<speed>1.5711507</speed>
+<bearing>238.93333</bearing>
+<bearingAccuracyDegrees>9.408471</bearingAccuracyDegrees>
+<time>1746103800402</time>
+</trkpt>
+<trkpt lat="55.9453746" lon="-4.3156202">
+<ele>131.3000030517578></ele>
+<accuracy>4.062</accuracy>
+<speed>1.5847169</speed>
+<bearing>241.43178</bearing>
+<bearingAccuracyDegrees>9.651669</bearingAccuracyDegrees>
+<time>1746103801473</time>
+</trkpt>
+<trkpt lat="55.9453656" lon="-4.3156544">
+<ele>131.3000030517578></ele>
+<accuracy>3.949</accuracy>
+<speed>1.5830511</speed>
+<bearing>241.62828</bearing>
+<bearingAccuracyDegrees>9.4928465</bearingAccuracyDegrees>
+<time>1746103802478</time>
+</trkpt>
+<trkpt lat="55.9453564" lon="-4.3156836">
+<ele>131.3000030517578></ele>
+<accuracy>3.866</accuracy>
+<speed>1.5948325</speed>
+<bearing>241.3754</bearing>
+<bearingAccuracyDegrees>9.818449</bearingAccuracyDegrees>
+<time>1746103803481</time>
+</trkpt>
+<trkpt lat="55.9453469" lon="-4.3157106">
+<ele>131.3000030517578></ele>
+<accuracy>3.809</accuracy>
+<speed>1.5931346</speed>
+<bearing>238.90079</bearing>
+<bearingAccuracyDegrees>9.640687</bearingAccuracyDegrees>
+<time>1746103804478</time>
+</trkpt>
+<trkpt lat="55.9453386" lon="-4.3157359">
+<ele>131.3000030517578></ele>
+<accuracy>3.765</accuracy>
+<speed>1.5757573</speed>
+<bearing>239.39195</bearing>
+<bearingAccuracyDegrees>9.473398</bearingAccuracyDegrees>
+<time>1746103805468</time>
+</trkpt>
+<trkpt lat="55.9453307" lon="-4.3157593">
+<ele>131.3000030517578></ele>
+<accuracy>3.744</accuracy>
+<speed>1.5785861</speed>
+<bearing>238.53922</bearing>
+<bearingAccuracyDegrees>9.564716</bearingAccuracyDegrees>
+<time>1746103806465</time>
+</trkpt>
+<trkpt lat="55.9453222" lon="-4.3157797">
+<ele>131.3000030517578></ele>
+<accuracy>3.767</accuracy>
+<speed>1.5947908</speed>
+<bearing>234.30505</bearing>
+<bearingAccuracyDegrees>9.743519</bearingAccuracyDegrees>
+<time>1746103807449</time>
+</trkpt>
+<trkpt lat="55.9453137" lon="-4.3157998">
+<ele>131.3000030517578></ele>
+<accuracy>3.792</accuracy>
+<speed>1.5702164</speed>
+<bearing>238.11668</bearing>
+<bearingAccuracyDegrees>9.851416</bearingAccuracyDegrees>
+<time>1746103808453</time>
+</trkpt>
+<trkpt lat="55.9453059" lon="-4.3158253">
+<ele>131.3000030517578></ele>
+<accuracy>3.808</accuracy>
+<speed>1.5623202</speed>
+<bearing>240.96912</bearing>
+<bearingAccuracyDegrees>9.767532</bearingAccuracyDegrees>
+<time>1746103809649</time>
+</trkpt>
+<trkpt lat="55.9453" lon="-4.3158485">
+<ele>131.3000030517578></ele>
+<accuracy>3.82</accuracy>
+<speed>1.5934011</speed>
+<bearing>240.94144</bearing>
+<bearingAccuracyDegrees>9.532672</bearingAccuracyDegrees>
+<time>1746103810625</time>
+</trkpt>
+<trkpt lat="55.9452925" lon="-4.3158698">
+<ele>131.3000030517578></ele>
+<accuracy>3.816</accuracy>
+<speed>1.5991166</speed>
+<bearing>236.57675</bearing>
+<bearingAccuracyDegrees>9.934673</bearingAccuracyDegrees>
+<time>1746103811590</time>
+</trkpt>
+<trkpt lat="55.9452838" lon="-4.3158902">
+<ele>131.3000030517578></ele>
+<accuracy>3.797</accuracy>
+<speed>1.6337531</speed>
+<bearing>236.10643</bearing>
+<bearingAccuracyDegrees>9.743495</bearingAccuracyDegrees>
+<time>1746103812533</time>
+</trkpt>
+<trkpt lat="55.9452747" lon="-4.3159105">
+<ele>131.3000030517578></ele>
+<accuracy>3.829</accuracy>
+<speed>1.652411</speed>
+<bearing>233.69511</bearing>
+<bearingAccuracyDegrees>9.847932</bearingAccuracyDegrees>
+<time>1746103813462</time>
+</trkpt>
+<trkpt lat="55.9452667" lon="-4.3159335">
+<ele>131.3000030517578></ele>
+<accuracy>3.868</accuracy>
+<speed>1.6736957</speed>
+<bearing>233.62886</bearing>
+<bearingAccuracyDegrees>10.01204</bearingAccuracyDegrees>
+<time>1746103814457</time>
+</trkpt>
+<trkpt lat="55.9452607" lon="-4.3159557">
+<ele>129.56656402295647></ele>
+<accuracy>3.895</accuracy>
+<speed>1.6680449</speed>
+<bearing>236.84912</bearing>
+<bearingAccuracyDegrees>10.017987</bearingAccuracyDegrees>
+<time>1746103815369</time>
+</trkpt>
+<trkpt lat="55.9452553" lon="-4.3159765">
+<ele>129.3915559334479></ele>
+<accuracy>3.925</accuracy>
+<speed>1.6533761</speed>
+<bearing>240.4417</bearing>
+<bearingAccuracyDegrees>11.989315</bearingAccuracyDegrees>
+<time>1746103816290</time>
+</trkpt>
+<trkpt lat="55.9452492" lon="-4.3159931">
+<ele>129.0457170865081></ele>
+<accuracy>3.966</accuracy>
+<speed>1.6263304</speed>
+<bearing>240.78896</bearing>
+<bearingAccuracyDegrees>12.207797</bearingAccuracyDegrees>
+<time>1746103817199</time>
+</trkpt>
+<trkpt lat="55.9452437" lon="-4.3160091">
+<ele>128.44263996161303></ele>
+<accuracy>4.01</accuracy>
+<speed>1.635417</speed>
+<bearing>246.43533</bearing>
+<bearingAccuracyDegrees>12.1122055</bearingAccuracyDegrees>
+<time>1746103818105</time>
+</trkpt>
+<trkpt lat="55.9452384" lon="-4.3160372">
+<ele>128.14370943135538></ele>
+<accuracy>4.114</accuracy>
+<speed>1.6732562</speed>
+<bearing>253.67192</bearing>
+<bearingAccuracyDegrees>12.254918</bearingAccuracyDegrees>
+<time>1746103819546</time>
+</trkpt>
+<trkpt lat="55.9452376" lon="-4.3160583">
+<ele>127.52504998041225></ele>
+<accuracy>4.204</accuracy>
+<speed>1.6672686</speed>
+<bearing>255.481</bearing>
+<bearingAccuracyDegrees>12.42135</bearingAccuracyDegrees>
+<time>1746103820586</time>
+</trkpt>
+<trkpt lat="55.9452346" lon="-4.3160858">
+<ele>127.29342165800003></ele>
+<accuracy>4.278</accuracy>
+<speed>1.6576115</speed>
+<bearing>256.43912</bearing>
+<bearingAccuracyDegrees>9.890786</bearingAccuracyDegrees>
+<time>1746103821589</time>
+</trkpt>
+<trkpt lat="55.9452303" lon="-4.3161136">
+<ele>127.16740792131866></ele>
+<accuracy>4.304</accuracy>
+<speed>1.6500033</speed>
+<bearing>258.18</bearing>
+<bearingAccuracyDegrees>9.416529</bearingAccuracyDegrees>
+<time>1746103822591</time>
+</trkpt>
+<trkpt lat="55.945225" lon="-4.3161402">
+<ele>127.04139603106074></ele>
+<accuracy>4.29</accuracy>
+<speed>1.6126901</speed>
+<bearing>258.12265</bearing>
+<bearingAccuracyDegrees>9.510543</bearingAccuracyDegrees>
+<time>1746103823593</time>
+</trkpt>
+<trkpt lat="55.9452228" lon="-4.3161656">
+<ele>127.05402332402923></ele>
+<accuracy>4.274</accuracy>
+<speed>1.5858512</speed>
+<bearing>262.03168</bearing>
+<bearingAccuracyDegrees>9.080684</bearingAccuracyDegrees>
+<time>1746103824596</time>
+</trkpt>
+<trkpt lat="55.9452217" lon="-4.3161926">
+<ele>127.04569206783827></ele>
+<accuracy>4.217</accuracy>
+<speed>1.5795119</speed>
+<bearing>257.74207</bearing>
+<bearingAccuracyDegrees>9.176896</bearingAccuracyDegrees>
+<time>1746103825598</time>
+</trkpt>
+<trkpt lat="55.9452193" lon="-4.3162217">
+<ele>127.0868277237339></ele>
+<accuracy>4.174</accuracy>
+<speed>1.5688281</speed>
+<bearing>255.31216</bearing>
+<bearingAccuracyDegrees>9.582797</bearingAccuracyDegrees>
+<time>1746103826599</time>
+</trkpt>
+<trkpt lat="55.9452144" lon="-4.3162521">
+<ele>127.12787741268414></ele>
+<accuracy>4.124</accuracy>
+<speed>1.5970666</speed>
+<bearing>247.65372</bearing>
+<bearingAccuracyDegrees>9.384828</bearingAccuracyDegrees>
+<time>1746103827603</time>
+</trkpt>
+<trkpt lat="55.9452076" lon="-4.3162775">
+<ele>127.20636869704978></ele>
+<accuracy>4.075</accuracy>
+<speed>1.5865289</speed>
+<bearing>245.78667</bearing>
+<bearingAccuracyDegrees>9.417159</bearingAccuracyDegrees>
+<time>1746103828604</time>
+</trkpt>
+<trkpt lat="55.9452005" lon="-4.3162991">
+<ele>127.22823892120564></ele>
+<accuracy>4.042</accuracy>
+<speed>1.5576755</speed>
+<bearing>238.76135</bearing>
+<bearingAccuracyDegrees>9.734596</bearingAccuracyDegrees>
+<time>1746103829607</time>
+</trkpt>
+<trkpt lat="55.9451916" lon="-4.316317">
+<ele>127.10951551575992></ele>
+<accuracy>3.998</accuracy>
+<speed>1.5602846</speed>
+<bearing>234.1975</bearing>
+<bearingAccuracyDegrees>9.945887</bearingAccuracyDegrees>
+<time>1746103830610</time>
+</trkpt>
+<trkpt lat="55.9451826" lon="-4.3163339">
+<ele>127.04914619165686></ele>
+<accuracy>3.98</accuracy>
+<speed>1.564246</speed>
+<bearing>232.63213</bearing>
+<bearingAccuracyDegrees>11.764459</bearingAccuracyDegrees>
+<time>1746103831612</time>
+</trkpt>
+<trkpt lat="55.9451733" lon="-4.316349">
+<ele>126.93926427877707></ele>
+<accuracy>3.993</accuracy>
+<speed>1.5528939</speed>
+<bearing>228.83954</bearing>
+<bearingAccuracyDegrees>12.102478</bearingAccuracyDegrees>
+<time>1746103832614</time>
+</trkpt>
+<trkpt lat="55.945164" lon="-4.3163619">
+<ele>126.82835541451391></ele>
+<accuracy>3.991</accuracy>
+<speed>1.543792</speed>
+<bearing>221.71544</bearing>
+<bearingAccuracyDegrees>12.017469</bearingAccuracyDegrees>
+<time>1746103833617</time>
+</trkpt>
+<trkpt lat="55.9451538" lon="-4.3163753">
+<ele>126.75754111320958></ele>
+<accuracy>4.048</accuracy>
+<speed>1.5383121</speed>
+<bearing>213.52094</bearing>
+<bearingAccuracyDegrees>12.126809</bearingAccuracyDegrees>
+<time>1746103834619</time>
+</trkpt>
+<trkpt lat="55.9451426" lon="-4.3163939">
+<ele>126.60904602425268></ele>
+<accuracy>4.143</accuracy>
+<speed>1.5425106</speed>
+<bearing>212.85161</bearing>
+<bearingAccuracyDegrees>11.862088</bearingAccuracyDegrees>
+<time>1746103835620</time>
+</trkpt>
+<trkpt lat="55.9451311" lon="-4.3164158">
+<ele>126.60904602425268></ele>
+<accuracy>4.197</accuracy>
+<speed>1.5430918</speed>
+<bearing>209.54266</bearing>
+<bearingAccuracyDegrees>11.858366</bearingAccuracyDegrees>
+<time>1746103836533</time>
+</trkpt>
+<trkpt lat="55.9451202" lon="-4.3164384">
+<ele>126.49766770999445></ele>
+<accuracy>4.269</accuracy>
+<speed>1.5414317</speed>
+<bearing>209.61678</bearing>
+<bearingAccuracyDegrees>10.041855</bearingAccuracyDegrees>
+<time>1746103837499</time>
+</trkpt>
+<trkpt lat="55.9451105" lon="-4.3164589">
+<ele>126.49922974075534></ele>
+<accuracy>4.307</accuracy>
+<speed>1.5400633</speed>
+<bearing>213.94629</bearing>
+<bearingAccuracyDegrees>11.493454</bearingAccuracyDegrees>
+<time>1746103838506</time>
+</trkpt>
+<trkpt lat="55.9451" lon="-4.316482">
+<ele>126.4627824302608></ele>
+<accuracy>4.279</accuracy>
+<speed>1.5432714</speed>
+<bearing>217.0787</bearing>
+<bearingAccuracyDegrees>10.080269</bearingAccuracyDegrees>
+<time>1746103839507</time>
+</trkpt>
+<trkpt lat="55.9450865" lon="-4.3165046">
+<ele>126.49922974075534></ele>
+<accuracy>4.221</accuracy>
+<speed>1.5613235</speed>
+<bearing>214.47247</bearing>
+<bearingAccuracyDegrees>9.835537</bearingAccuracyDegrees>
+<time>1746103840511</time>
+</trkpt>
+<trkpt lat="55.9450711" lon="-4.316527">
+<ele>126.51380870820222></ele>
+<accuracy>4.161</accuracy>
+<speed>1.5754172</speed>
+<bearing>215.16145</bearing>
+<bearingAccuracyDegrees>9.787606</bearingAccuracyDegrees>
+<time>1746103841509</time>
+</trkpt>
+<trkpt lat="55.9450554" lon="-4.3165482">
+<ele>126.43674873162234></ele>
+<accuracy>4.065</accuracy>
+<speed>1.5674973</speed>
+<bearing>214.46034</bearing>
+<bearingAccuracyDegrees>9.538015</bearingAccuracyDegrees>
+<time>1746103842521</time>
+</trkpt>
+<trkpt lat="55.9450403" lon="-4.3165665">
+<ele>126.37322683768501></ele>
+<accuracy>4.009</accuracy>
+<speed>1.5527202</speed>
+<bearing>210.24048</bearing>
+<bearingAccuracyDegrees>9.128097</bearingAccuracyDegrees>
+<time>1746103843524</time>
+</trkpt>
+<trkpt lat="55.945025" lon="-4.3165817">
+<ele>126.27849263895232></ele>
+<accuracy>3.963</accuracy>
+<speed>1.5586668</speed>
+<bearing>211.79396</bearing>
+<bearingAccuracyDegrees>9.816847</bearingAccuracyDegrees>
+<time>1746103844545</time>
+</trkpt>
+<trkpt lat="55.9450097" lon="-4.3165973">
+<ele>126.12646041356777></ele>
+<accuracy>3.917</accuracy>
+<speed>1.5514014</speed>
+<bearing>215.2145</bearing>
+<bearingAccuracyDegrees>9.809735</bearingAccuracyDegrees>
+<time>1746103845547</time>
+</trkpt>
+<trkpt lat="55.9449944" lon="-4.3166144">
+<ele>125.97703409868299></ele>
+<accuracy>3.869</accuracy>
+<speed>1.5618762</speed>
+<bearing>221.12358</bearing>
+<bearingAccuracyDegrees>9.606398</bearingAccuracyDegrees>
+<time>1746103846531</time>
+</trkpt>
+<trkpt lat="55.9449789" lon="-4.3166304">
+<ele>125.9452147400039></ele>
+<accuracy>3.808</accuracy>
+<speed>1.5734049</speed>
+<bearing>219.84575</bearing>
+<bearingAccuracyDegrees>9.721746</bearingAccuracyDegrees>
+<time>1746103847524</time>
+</trkpt>
+<trkpt lat="55.9449636" lon="-4.316646">
+<ele>125.99415543855889></ele>
+<accuracy>3.77</accuracy>
+<speed>1.580311</speed>
+<bearing>220.5923</bearing>
+<bearingAccuracyDegrees>9.952438</bearingAccuracyDegrees>
+<time>1746103848524</time>
+</trkpt>
+<trkpt lat="55.9449493" lon="-4.3166622">
+<ele>125.99519673304289></ele>
+<accuracy>3.767</accuracy>
+<speed>1.5779548</speed>
+<bearing>219.04057</bearing>
+<bearingAccuracyDegrees>9.931231</bearingAccuracyDegrees>
+<time>1746103849529</time>
+</trkpt>
+<trkpt lat="55.9449357" lon="-4.3166774">
+<ele>126.03076414691341></ele>
+<accuracy>3.759</accuracy>
+<speed>1.5682728</speed>
+<bearing>219.42918</bearing>
+<bearingAccuracyDegrees>10.203633</bearingAccuracyDegrees>
+<time>1746103850513</time>
+</trkpt>
+<trkpt lat="55.9449231" lon="-4.3166939">
+<ele>126.04183477438403></ele>
+<accuracy>3.778</accuracy>
+<speed>1.5591264</speed>
+<bearing>219.7604</bearing>
+<bearingAccuracyDegrees>9.824389</bearingAccuracyDegrees>
+<time>1746103851531</time>
+</trkpt>
+<trkpt lat="55.9449114" lon="-4.3167091">
+<ele>126.03662835113238></ele>
+<accuracy>3.838</accuracy>
+<speed>1.5399168</speed>
+<bearing>220.92883</bearing>
+<bearingAccuracyDegrees>9.790228</bearingAccuracyDegrees>
+<time>1746103852545</time>
+</trkpt>
+<trkpt lat="55.9448736" lon="-4.3167802">
+<ele>125.83021859412707></ele>
+<accuracy>4.07</accuracy>
+<speed>1.5387653</speed>
+<bearing>227.1981</bearing>
+<bearingAccuracyDegrees>9.768477</bearingAccuracyDegrees>
+<time>1746103856544</time>
+</trkpt>
+<trkpt lat="55.9448637" lon="-4.316801">
+<ele>125.84483162901049></ele>
+<accuracy>4.1</accuracy>
+<speed>1.5585595</speed>
+<bearing>228.93274</bearing>
+<bearingAccuracyDegrees>9.454264</bearingAccuracyDegrees>
+<time>1746103857566</time>
+</trkpt>
+<trkpt lat="55.9448532" lon="-4.3168237">
+<ele>125.82660940080586></ele>
+<accuracy>4.12</accuracy>
+<speed>1.5568255</speed>
+<bearing>230.02144</bearing>
+<bearingAccuracyDegrees>9.338848</bearingAccuracyDegrees>
+<time>1746103858589</time>
+</trkpt>
+<trkpt lat="55.9448435" lon="-4.3168453">
+<ele>125.83700825451878></ele>
+<accuracy>4.127</accuracy>
+<speed>1.563839</speed>
+<bearing>232.75237</bearing>
+<bearingAccuracyDegrees>8.741111</bearingAccuracyDegrees>
+<time>1746103859552</time>
+</trkpt>
+<trkpt lat="55.9448345" lon="-4.3168686">
+<ele>125.83700825451878></ele>
+<accuracy>4.114</accuracy>
+<speed>1.5551218</speed>
+<bearing>236.95924</bearing>
+<bearingAccuracyDegrees>9.054929</bearingAccuracyDegrees>
+<time>1746103860522</time>
+</trkpt>
+<trkpt lat="55.9448258" lon="-4.3168938">
+<ele>125.78327950047617></ele>
+<accuracy>4.086</accuracy>
+<speed>1.5373555</speed>
+<bearing>237.80342</bearing>
+<bearingAccuracyDegrees>9.15606</bearingAccuracyDegrees>
+<time>1746103861564</time>
+</trkpt>
+<trkpt lat="55.9448169" lon="-4.3169178">
+<ele>125.7510002000376></ele>
+<accuracy>4.059</accuracy>
+<speed>1.5195887</speed>
+<bearing>235.22343</bearing>
+<bearingAccuracyDegrees>9.02103</bearingAccuracyDegrees>
+<time>1746103862567</time>
+</trkpt>
+<trkpt lat="55.9448071" lon="-4.3169413">
+<ele>125.59538202339269></ele>
+<accuracy>4.003</accuracy>
+<speed>1.5147595</speed>
+<bearing>231.04684</bearing>
+<bearingAccuracyDegrees>9.30089</bearingAccuracyDegrees>
+<time>1746103863592</time>
+</trkpt>
+<trkpt lat="55.9447978" lon="-4.3169619">
+<ele>125.56083356730565></ele>
+<accuracy>3.928</accuracy>
+<speed>1.5277842</speed>
+<bearing>234.95995</bearing>
+<bearingAccuracyDegrees>9.253867</bearingAccuracyDegrees>
+<time>1746103864583</time>
+</trkpt>
+<trkpt lat="55.9447879" lon="-4.3169861">
+<ele>125.69742458937702></ele>
+<accuracy>3.865</accuracy>
+<speed>1.531326</speed>
+<bearing>233.27858</bearing>
+<bearingAccuracyDegrees>9.238466</bearingAccuracyDegrees>
+<time>1746103865608</time>
+</trkpt>
+<trkpt lat="55.9447781" lon="-4.31701">
+<ele>125.92129772617739></ele>
+<accuracy>3.807</accuracy>
+<speed>1.503171</speed>
+<bearing>235.16055</bearing>
+<bearingAccuracyDegrees>9.832424</bearingAccuracyDegrees>
+<time>1746103866628</time>
+</trkpt>
+<trkpt lat="55.94477" lon="-4.3170317">
+<ele>126.32844939111392></ele>
+<accuracy>3.807</accuracy>
+<speed>1.4952253</speed>
+<bearing>236.96318</bearing>
+<bearingAccuracyDegrees>10.2176285</bearingAccuracyDegrees>
+<time>1746103867596</time>
+</trkpt>
+<trkpt lat="55.9447606" lon="-4.3170556">
+<ele>126.6585583687151></ele>
+<accuracy>3.749</accuracy>
+<speed>1.4834365</speed>
+<bearing>239.99786</bearing>
+<bearingAccuracyDegrees>10.336467</bearingAccuracyDegrees>
+<time>1746103868599</time>
+</trkpt>
+<trkpt lat="55.9447515" lon="-4.3170814">
+<ele>126.78667465162673></ele>
+<accuracy>3.723</accuracy>
+<speed>1.4615352</speed>
+<bearing>241.90697</bearing>
+<bearingAccuracyDegrees>10.042769</bearingAccuracyDegrees>
+<time>1746103869601</time>
+</trkpt>
+<trkpt lat="55.9447438" lon="-4.317108">
+<ele>126.93559433222754></ele>
+<accuracy>3.702</accuracy>
+<speed>1.4382741</speed>
+<bearing>245.10971</bearing>
+<bearingAccuracyDegrees>10.382446</bearingAccuracyDegrees>
+<time>1746103870603</time>
+</trkpt>
+<trkpt lat="55.944739" lon="-4.3171347">
+<ele>126.9611088019927></ele>
+<accuracy>3.687</accuracy>
+<speed>1.382682</speed>
+<bearing>260.31464</bearing>
+<bearingAccuracyDegrees>10.29236</bearingAccuracyDegrees>
+<time>1746103871605</time>
+</trkpt>
+<trkpt lat="55.9447384" lon="-4.3171632">
+<ele>126.9611088019927></ele>
+<accuracy>3.623</accuracy>
+<speed>1.3377018</speed>
+<bearing>269.40927</bearing>
+<bearingAccuracyDegrees>9.162343</bearingAccuracyDegrees>
+<time>1746103872612</time>
+</trkpt>
+<trkpt lat="55.9447398" lon="-4.3171906">
+<ele>126.9126834442871></ele>
+<accuracy>3.625</accuracy>
+<speed>1.3840647</speed>
+<bearing>269.94174</bearing>
+<bearingAccuracyDegrees>9.690114</bearingAccuracyDegrees>
+<time>1746103873583</time>
+</trkpt>
+<trkpt lat="55.9447404" lon="-4.31722">
+<ele>126.9126834442871></ele>
+<accuracy>3.629</accuracy>
+<speed>1.4277862</speed>
+<bearing>267.29593</bearing>
+<bearingAccuracyDegrees>11.414102</bearingAccuracyDegrees>
+<time>1746103874591</time>
+</trkpt>
+<trkpt lat="55.9447405" lon="-4.3172509">
+<ele>126.89497961813964></ele>
+<accuracy>3.638</accuracy>
+<speed>1.4728646</speed>
+<bearing>269.7198</bearing>
+<bearingAccuracyDegrees>10.047276</bearingAccuracyDegrees>
+<time>1746103875610</time>
+</trkpt>
+<trkpt lat="55.9447426" lon="-4.3172837">
+<ele>126.89497961813964></ele>
+<accuracy>3.677</accuracy>
+<speed>1.5212893</speed>
+<bearing>273.41193</bearing>
+<bearingAccuracyDegrees>10.336735</bearingAccuracyDegrees>
+<time>1746103876610</time>
+</trkpt>
+<trkpt lat="55.9447463" lon="-4.3173215">
+<ele>127.03631941427136></ele>
+<accuracy>3.737</accuracy>
+<speed>1.5538083</speed>
+<bearing>275.56873</bearing>
+<bearingAccuracyDegrees>9.874288</bearingAccuracyDegrees>
+<time>1746103877623</time>
+</trkpt>
+<trkpt lat="55.9447478" lon="-4.3173576">
+<ele>126.98320790366634></ele>
+<accuracy>3.752</accuracy>
+<speed>1.5906109</speed>
+<bearing>263.48715</bearing>
+<bearingAccuracyDegrees>9.067282</bearingAccuracyDegrees>
+<time>1746103878592</time>
+</trkpt>
+<trkpt lat="55.9447439" lon="-4.3173963">
+<ele>126.96862833068377></ele>
+<accuracy>3.775</accuracy>
+<speed>1.5909513</speed>
+<bearing>251.01982</bearing>
+<bearingAccuracyDegrees>9.235262</bearingAccuracyDegrees>
+<time>1746103879607</time>
+</trkpt>
+<trkpt lat="55.9447389" lon="-4.3174302">
+<ele>126.79410843185214></ele>
+<accuracy>3.747</accuracy>
+<speed>1.5971898</speed>
+<bearing>252.86458</bearing>
+<bearingAccuracyDegrees>9.626321</bearingAccuracyDegrees>
+<time>1746103880610</time>
+</trkpt>
+<trkpt lat="55.9447343" lon="-4.3174634">
+<ele>126.64817608673734></ele>
+<accuracy>3.68</accuracy>
+<speed>1.6235183</speed>
+<bearing>252.3459</bearing>
+<bearingAccuracyDegrees>9.59166</bearingAccuracyDegrees>
+<time>1746103881601</time>
+</trkpt>
+<trkpt lat="55.9447303" lon="-4.3174935">
+<ele>126.56330482381982></ele>
+<accuracy>3.592</accuracy>
+<speed>1.5895662</speed>
+<bearing>257.65213</bearing>
+<bearingAccuracyDegrees>9.685861</bearingAccuracyDegrees>
+<time>1746103882625</time>
+</trkpt>
+<trkpt lat="55.9447285" lon="-4.3175228">
+<ele>126.5685456233544></ele>
+<accuracy>3.505</accuracy>
+<speed>1.5683961</speed>
+<bearing>263.11914</bearing>
+<bearingAccuracyDegrees>9.621521</bearingAccuracyDegrees>
+<time>1746103883627</time>
+</trkpt>
+<trkpt lat="55.9447315" lon="-4.3176304">
+<ele>126.01639233376568></ele>
+<accuracy>3.22</accuracy>
+<speed>1.5640124</speed>
+<bearing>273.81943</bearing>
+<bearingAccuracyDegrees>9.115152</bearingAccuracyDegrees>
+<time>1746103887745</time>
+</trkpt>
+<trkpt lat="55.944733" lon="-4.3176553">
+<ele>126.01639233376568></ele>
+<accuracy>3.19</accuracy>
+<speed>1.5871508</speed>
+<bearing>275.07358</bearing>
+<bearingAccuracyDegrees>9.0261</bearingAccuracyDegrees>
+<time>1746103888649</time>
+</trkpt>
+<trkpt lat="55.9447382" lon="-4.3177889">
+<ele>125.76510655100614></ele>
+<accuracy>3.143</accuracy>
+<speed>1.5355287</speed>
+<bearing>273.64664</bearing>
+<bearingAccuracyDegrees>9.455317</bearingAccuracyDegrees>
+<time>1746103893649</time>
+</trkpt>
+<trkpt lat="55.9447413" lon="-4.3178368">
+<ele>125.48553143065799></ele>
+<accuracy>3.13</accuracy>
+<speed>1.5314053</speed>
+<bearing>276.71564</bearing>
+<bearingAccuracyDegrees>9.651868</bearingAccuracyDegrees>
+<time>1746103895690</time>
+</trkpt>
+<trkpt lat="55.9447429" lon="-4.317861">
+<ele>125.48553143065799></ele>
+<accuracy>3.155</accuracy>
+<speed>1.5536846</speed>
+<bearing>276.90707</bearing>
+<bearingAccuracyDegrees>10.025822</bearingAccuracyDegrees>
+<time>1746103896647</time>
+</trkpt>
+<trkpt lat="55.9447446" lon="-4.3178826">
+<ele>125.41071851172102></ele>
+<accuracy>3.19</accuracy>
+<speed>1.5229003</speed>
+<bearing>280.5716</bearing>
+<bearingAccuracyDegrees>10.302721</bearingAccuracyDegrees>
+<time>1746103897566</time>
+</trkpt>
+<trkpt lat="55.9447474" lon="-4.3179086">
+<ele>125.24568759812921></ele>
+<accuracy>3.218</accuracy>
+<speed>1.5337924</speed>
+<bearing>279.1002</bearing>
+<bearingAccuracyDegrees>9.980656</bearingAccuracyDegrees>
+<time>1746103898569</time>
+</trkpt>
+<trkpt lat="55.9447499" lon="-4.3179354">
+<ele>125.0119216718416></ele>
+<accuracy>3.249</accuracy>
+<speed>1.5393302</speed>
+<bearing>278.70258</bearing>
+<bearingAccuracyDegrees>9.956807</bearingAccuracyDegrees>
+<time>1746103899570</time>
+</trkpt>
+<trkpt lat="55.9447521" lon="-4.3179613">
+<ele>124.96558985528998></ele>
+<accuracy>3.258</accuracy>
+<speed>1.543486</speed>
+<bearing>279.73953</bearing>
+<bearingAccuracyDegrees>9.551977</bearingAccuracyDegrees>
+<time>1746103900573</time>
+</trkpt>
+<trkpt lat="55.9447551" lon="-4.3179919">
+<ele>124.96558985528998></ele>
+<accuracy>3.278</accuracy>
+<speed>1.5400398</speed>
+<bearing>281.13474</bearing>
+<bearingAccuracyDegrees>10.0326185</bearingAccuracyDegrees>
+<time>1746103901649</time>
+</trkpt>
+<trkpt lat="55.9447574" lon="-4.3180146">
+<ele>124.87969445123042></ele>
+<accuracy>3.276</accuracy>
+<speed>1.5165406</speed>
+<bearing>276.63885</bearing>
+<bearingAccuracyDegrees>10.211772</bearingAccuracyDegrees>
+<time>1746103902650</time>
+</trkpt>
+<trkpt lat="55.9447592" lon="-4.3180349">
+<ele>124.88035983056326></ele>
+<accuracy>3.3</accuracy>
+<speed>1.5204502</speed>
+<bearing>275.77325</bearing>
+<bearingAccuracyDegrees>10.090236</bearingAccuracyDegrees>
+<time>1746103903624</time>
+</trkpt>
+<trkpt lat="55.944761" lon="-4.3180551">
+<ele>124.79238358349323></ele>
+<accuracy>3.335</accuracy>
+<speed>1.5220726</speed>
+<bearing>275.99374</bearing>
+<bearingAccuracyDegrees>11.8352585</bearingAccuracyDegrees>
+<time>1746103904625</time>
+</trkpt>
+<trkpt lat="55.9447639" lon="-4.3181555">
+<ele>124.67864965458493></ele>
+<accuracy>4.068</accuracy>
+<speed>1.549097</speed>
+<bearing>275.179</bearing>
+<bearingAccuracyDegrees>12.729236</bearingAccuracyDegrees>
+<time>1746103908611</time>
+</trkpt>
+<trkpt lat="55.944764" lon="-4.3181834">
+<ele>124.72033216057685></ele>
+<accuracy>4.393</accuracy>
+<speed>1.5491185</speed>
+<bearing>275.1447</bearing>
+<bearingAccuracyDegrees>12.478983</bearingAccuracyDegrees>
+<time>1746103909588</time>
+</trkpt>
+<trkpt lat="55.9447636" lon="-4.318213">
+<ele>124.72189386343331></ele>
+<accuracy>4.779</accuracy>
+<speed>1.5664039</speed>
+<bearing>276.6194</bearing>
+<bearingAccuracyDegrees>12.050176</bearingAccuracyDegrees>
+<time>1746103910589</time>
+</trkpt>
+<trkpt lat="55.9447634" lon="-4.3182432">
+<ele>124.68596015964084></ele>
+<accuracy>5.108</accuracy>
+<speed>1.5704019</speed>
+<bearing>276.08432</bearing>
+<bearingAccuracyDegrees>12.985143</bearingAccuracyDegrees>
+<time>1746103911592</time>
+</trkpt>
+<trkpt lat="55.9447629" lon="-4.3182725">
+<ele>124.56154582422683></ele>
+<accuracy>5.414</accuracy>
+<speed>1.5562412</speed>
+<bearing>275.93103</bearing>
+<bearingAccuracyDegrees>12.387987</bearingAccuracyDegrees>
+<time>1746103912587</time>
+</trkpt>
+<trkpt lat="55.944763" lon="-4.3183014">
+<ele>124.46305085057098></ele>
+<accuracy>5.687</accuracy>
+<speed>1.5353315</speed>
+<bearing>268.66565</bearing>
+<bearingAccuracyDegrees>12.257581</bearingAccuracyDegrees>
+<time>1746103913568</time>
+</trkpt>
+<trkpt lat="55.9447575" lon="-4.3183283">
+<ele>124.36766990251348></ele>
+<accuracy>5.951</accuracy>
+<speed>1.5119672</speed>
+<bearing>225.79335</bearing>
+<bearingAccuracyDegrees>12.908685</bearingAccuracyDegrees>
+<time>1746103914590</time>
+</trkpt>
+<trkpt lat="55.9447445" lon="-4.3183499">
+<ele>124.34893005186217></ele>
+<accuracy>6.197</accuracy>
+<speed>1.5283098</speed>
+<bearing>242.76128</bearing>
+<bearingAccuracyDegrees>13.031775</bearingAccuracyDegrees>
+<time>1746103915612</time>
+</trkpt>
+<trkpt lat="55.9447369" lon="-4.3183742">
+<ele>124.32758749391152></ele>
+<accuracy>6.318</accuracy>
+<speed>1.5471267</speed>
+<bearing>238.0488</bearing>
+<bearingAccuracyDegrees>13.251764</bearingAccuracyDegrees>
+<time>1746103916544</time>
+</trkpt>
+<trkpt lat="55.9447267" lon="-4.3183997">
+<ele>124.22556038771785></ele>
+<accuracy>6.426</accuracy>
+<speed>1.5430483</speed>
+<bearing>236.88171</bearing>
+<bearingAccuracyDegrees>12.421028</bearingAccuracyDegrees>
+<time>1746103917545</time>
+</trkpt>
+<trkpt lat="55.9447154" lon="-4.3184278">
+<ele>124.2156700693292></ele>
+<accuracy>6.224</accuracy>
+<speed>1.5562398</speed>
+<bearing>238.06093</bearing>
+<bearingAccuracyDegrees>11.841941</bearingAccuracyDegrees>
+<time>1746103918547</time>
+</trkpt>
+<trkpt lat="55.9447051" lon="-4.3184565">
+<ele>124.23250097502962></ele>
+<accuracy>5.813</accuracy>
+<speed>1.5799772</speed>
+<bearing>237.70776</bearing>
+<bearingAccuracyDegrees>11.752372</bearingAccuracyDegrees>
+<time>1746103919531</time>
+</trkpt>
+<trkpt lat="55.9446953" lon="-4.3184845">
+<ele>124.23250097502962></ele>
+<accuracy>5.365</accuracy>
+<speed>1.6066289</speed>
+<bearing>236.97801</bearing>
+<bearingAccuracyDegrees>9.893918</bearingAccuracyDegrees>
+<time>1746103920503</time>
+</trkpt>
+<trkpt lat="55.9446868" lon="-4.3185158">
+<ele>124.26165125037963></ele>
+<accuracy>4.786</accuracy>
+<speed>1.6333838</speed>
+<bearing>251.76416</bearing>
+<bearingAccuracyDegrees>9.4774885</bearingAccuracyDegrees>
+<time>1746103921526</time>
+</trkpt>
+<trkpt lat="55.9446827" lon="-4.3185477">
+<ele>124.37295086311252></ele>
+<accuracy>4.196</accuracy>
+<speed>1.6236883</speed>
+<bearing>265.42307</bearing>
+<bearingAccuracyDegrees>10.1148815</bearingAccuracyDegrees>
+<time>1746103922512</time>
+</trkpt>
+<trkpt lat="55.9446811" lon="-4.3185792">
+<ele>124.5416108869642></ele>
+<accuracy>3.796</accuracy>
+<speed>1.6340473</speed>
+<bearing>268.7108</bearing>
+<bearingAccuracyDegrees>10.121863</bearingAccuracyDegrees>
+<time>1746103923524</time>
+</trkpt>
+<trkpt lat="55.9446788" lon="-4.3186125">
+<ele>124.90496995512547></ele>
+<accuracy>3.551</accuracy>
+<speed>1.6342777</speed>
+<bearing>262.4969</bearing>
+<bearingAccuracyDegrees>9.558063</bearingAccuracyDegrees>
+<time>1746103924512</time>
+</trkpt>
+<trkpt lat="55.9446761" lon="-4.3186448">
+<ele>125.30137103035463></ele>
+<accuracy>3.361</accuracy>
+<speed>1.6315566</speed>
+<bearing>260.0271</bearing>
+<bearingAccuracyDegrees>10.032558</bearingAccuracyDegrees>
+<time>1746103925506</time>
+</trkpt>
+<trkpt lat="55.9446753" lon="-4.3186748">
+<ele>125.43568717136628></ele>
+<accuracy>3.308</accuracy>
+<speed>1.592845</speed>
+<bearing>266.26007</bearing>
+<bearingAccuracyDegrees>9.740036</bearingAccuracyDegrees>
+<time>1746103926509</time>
+</trkpt>
+<trkpt lat="55.9446771" lon="-4.318702">
+<ele>125.53252103948188></ele>
+<accuracy>3.255</accuracy>
+<speed>1.587542</speed>
+<bearing>269.45773</bearing>
+<bearingAccuracyDegrees>9.6842</bearingAccuracyDegrees>
+<time>1746103927489</time>
+</trkpt>
+<trkpt lat="55.9446792" lon="-4.3187272">
+<ele>125.698217600553></ele>
+<accuracy>3.223</accuracy>
+<speed>1.5652549</speed>
+<bearing>268.86758</bearing>
+<bearingAccuracyDegrees>9.888904</bearingAccuracyDegrees>
+<time>1746103928511</time>
+</trkpt>
+<trkpt lat="55.9446811" lon="-4.3187507">
+<ele>125.69925884397665></ele>
+<accuracy>3.216</accuracy>
+<speed>1.5486121</speed>
+<bearing>267.38446</bearing>
+<bearingAccuracyDegrees>10.452901</bearingAccuracyDegrees>
+<time>1746103929512</time>
+</trkpt>
+<trkpt lat="55.9446832" lon="-4.3187693">
+<ele>125.68832579431054></ele>
+<accuracy>3.228</accuracy>
+<speed>1.5147457</speed>
+<bearing>273.57294</bearing>
+<bearingAccuracyDegrees>10.1910095</bearingAccuracyDegrees>
+<time>1746103930447</time>
+</trkpt>
+<trkpt lat="55.9446866" lon="-4.3187888">
+<ele>125.5649394830518></ele>
+<accuracy>3.219</accuracy>
+<speed>1.5064113</speed>
+<bearing>280.2887</bearing>
+<bearingAccuracyDegrees>9.913956</bearingAccuracyDegrees>
+<time>1746103931447</time>
+</trkpt>
+<trkpt lat="55.944692" lon="-4.3188091">
+<ele>125.4903986580907></ele>
+<accuracy>3.19</accuracy>
+<speed>1.494838</speed>
+<bearing>286.3774</bearing>
+<bearingAccuracyDegrees>9.788917</bearingAccuracyDegrees>
+<time>1746103932451</time>
+</trkpt>
+<trkpt lat="55.9446953" lon="-4.3188264">
+<ele>125.53315018951548></ele>
+<accuracy>3.196</accuracy>
+<speed>1.4892446</speed>
+<bearing>277.32123</bearing>
+<bearingAccuracyDegrees>10.133006</bearingAccuracyDegrees>
+<time>1746103933442</time>
+</trkpt>
+<trkpt lat="55.9446962" lon="-4.3188509">
+<ele>125.53621258387184></ele>
+<accuracy>3.25</accuracy>
+<speed>1.4828372</speed>
+<bearing>275.30878</bearing>
+<bearingAccuracyDegrees>10.133638</bearingAccuracyDegrees>
+<time>1746103934446</time>
+</trkpt>
+<trkpt lat="55.9446977" lon="-4.3188773">
+<ele>125.54443010958346></ele>
+<accuracy>3.421</accuracy>
+<speed>1.4914386</speed>
+<bearing>274.30328</bearing>
+<bearingAccuracyDegrees>11.648025</bearingAccuracyDegrees>
+<time>1746103935495</time>
+</trkpt>
+<trkpt lat="55.944699" lon="-4.3189028">
+<ele>125.560048647488></ele>
+<accuracy>3.718</accuracy>
+<speed>1.4767455</speed>
+<bearing>275.4862</bearing>
+<bearingAccuracyDegrees>12.335968</bearingAccuracyDegrees>
+<time>1746103936506</time>
+</trkpt>
+<trkpt lat="55.9447017" lon="-4.3189257">
+<ele>125.58658621687198></ele>
+<accuracy>3.976</accuracy>
+<speed>1.4667617</speed>
+<bearing>280.66818</bearing>
+<bearingAccuracyDegrees>12.332796</bearingAccuracyDegrees>
+<time>1746103937444</time>
+</trkpt>
+<trkpt lat="55.9447051" lon="-4.3189515">
+<ele>125.62302971907278></ele>
+<accuracy>4.585</accuracy>
+<speed>1.4922209</speed>
+<bearing>283.39917</bearing>
+<bearingAccuracyDegrees>12.481014</bearingAccuracyDegrees>
+<time>1746103938465</time>
+</trkpt>
+<trkpt lat="55.9447056" lon="-4.3189802">
+<ele>125.66810705090683></ele>
+<accuracy>5.023</accuracy>
+<speed>1.5061567</speed>
+<bearing>279.54956</bearing>
+<bearingAccuracyDegrees>12.880356</bearingAccuracyDegrees>
+<time>1746103939518</time>
+</trkpt>
+<trkpt lat="55.9447079" lon="-4.3190063">
+<ele>125.78160529129002></ele>
+<accuracy>5.438</accuracy>
+<speed>1.4890466</speed>
+<bearing>278.1148</bearing>
+<bearingAccuracyDegrees>12.68118</bearingAccuracyDegrees>
+<time>1746103940516</time>
+</trkpt>
+<trkpt lat="55.9447107" lon="-4.3190328">
+<ele>125.98569763877114></ele>
+<accuracy>5.84</accuracy>
+<speed>1.4870094</speed>
+<bearing>279.2955</bearing>
+<bearingAccuracyDegrees>12.485622</bearingAccuracyDegrees>
+<time>1746103941511</time>
+</trkpt>
+<trkpt lat="55.9447141" lon="-4.3190608">
+<ele>126.04921716377063></ele>
+<accuracy>6.232</accuracy>
+<speed>1.4839668</speed>
+<bearing>280.04858</bearing>
+<bearingAccuracyDegrees>12.7006035</bearingAccuracyDegrees>
+<time>1746103942543</time>
+</trkpt>
+<trkpt lat="55.9447179" lon="-4.3190879">
+<ele>126.12991887631044></ele>
+<accuracy>6.585</accuracy>
+<speed>1.4669594</speed>
+<bearing>278.05798</bearing>
+<bearingAccuracyDegrees>12.865474</bearingAccuracyDegrees>
+<time>1746103943567</time>
+</trkpt>
+<trkpt lat="55.9447203" lon="-4.3191148">
+<ele>126.1450179904966></ele>
+<accuracy>6.889</accuracy>
+<speed>1.4584911</speed>
+<bearing>276.14474</bearing>
+<bearingAccuracyDegrees>12.419916</bearingAccuracyDegrees>
+<time>1746103944608</time>
+</trkpt>
+<trkpt lat="55.944721" lon="-4.3191408">
+<ele>126.24443616449109></ele>
+<accuracy>7.12</accuracy>
+<speed>1.4766773</speed>
+<bearing>276.13953</bearing>
+<bearingAccuracyDegrees>12.994142</bearingAccuracyDegrees>
+<time>1746103945594</time>
+</trkpt>
+<trkpt lat="55.9447224" lon="-4.3191699">
+<ele>126.36366957664038></ele>
+<accuracy>7.302</accuracy>
+<speed>1.477658</speed>
+<bearing>283.9007</bearing>
+<bearingAccuracyDegrees>12.987886</bearingAccuracyDegrees>
+<time>1746103946625</time>
+</trkpt>
+<trkpt lat="55.9447259" lon="-4.3192008">
+<ele>126.42979536935673></ele>
+<accuracy>7.417</accuracy>
+<speed>1.4954399</speed>
+<bearing>288.12045</bearing>
+<bearingAccuracyDegrees>12.970607</bearingAccuracyDegrees>
+<time>1746103947651</time>
+</trkpt>
+<trkpt lat="55.9447289" lon="-4.31923">
+<ele>126.49393522460778></ele>
+<accuracy>7.503</accuracy>
+<speed>1.506876</speed>
+<bearing>284.97986</bearing>
+<bearingAccuracyDegrees>12.60335</bearingAccuracyDegrees>
+<time>1746103948627</time>
+</trkpt>
+<trkpt lat="55.9447319" lon="-4.3192606">
+<ele>126.51382331842736></ele>
+<accuracy>7.506</accuracy>
+<speed>1.5133245</speed>
+<bearing>282.4402</bearing>
+<bearingAccuracyDegrees>12.373762</bearingAccuracyDegrees>
+<time>1746103949653</time>
+</trkpt>
+<trkpt lat="55.9447347" lon="-4.3192901">
+<ele>126.52018464370639></ele>
+<accuracy>7.445</accuracy>
+<speed>1.5293779</speed>
+<bearing>278.31012</bearing>
+<bearingAccuracyDegrees>12.365187</bearingAccuracyDegrees>
+<time>1746103950662</time>
+</trkpt>
+<trkpt lat="55.944735" lon="-4.3193223">
+<ele>126.47072066870076></ele>
+<accuracy>7.052</accuracy>
+<speed>1.5289853</speed>
+<bearing>275.75784</bearing>
+<bearingAccuracyDegrees>10.120654</bearingAccuracyDegrees>
+<time>1746103951591</time>
+</trkpt>
+<trkpt lat="55.9447361" lon="-4.3193565">
+<ele>126.44094588831544></ele>
+<accuracy>6.311</accuracy>
+<speed>1.5184324</speed>
+<bearing>276.36526</bearing>
+<bearingAccuracyDegrees>9.821638</bearingAccuracyDegrees>
+<time>1746103952594</time>
+</trkpt>
+<trkpt lat="55.9447381" lon="-4.3193854">
+<ele>126.43730118076795></ele>
+<accuracy>5.584</accuracy>
+<speed>1.514413</speed>
+<bearing>277.75443</bearing>
+<bearingAccuracyDegrees>10.304559</bearingAccuracyDegrees>
+<time>1746103953597</time>
+</trkpt>
+<trkpt lat="55.9447403" lon="-4.319414">
+<ele>126.53593868437378></ele>
+<accuracy>4.913</accuracy>
+<speed>1.5065625</speed>
+<bearing>277.0299</bearing>
+<bearingAccuracyDegrees>12.158448</bearingAccuracyDegrees>
+<time>1746103954599</time>
+</trkpt>
+<trkpt lat="55.9447416" lon="-4.3194394">
+<ele>126.54687281165391></ele>
+<accuracy>4.33</accuracy>
+<speed>1.5074733</speed>
+<bearing>274.24008</bearing>
+<bearingAccuracyDegrees>12.18365</bearingAccuracyDegrees>
+<time>1746103955600</time>
+</trkpt>
+<trkpt lat="55.9447428" lon="-4.3194635">
+<ele>126.56978245674662></ele>
+<accuracy>3.841</accuracy>
+<speed>1.5009453</speed>
+<bearing>274.16467</bearing>
+<bearingAccuracyDegrees>12.648824</bearingAccuracyDegrees>
+<time>1746103956604</time>
+</trkpt>
+<trkpt lat="55.9447437" lon="-4.3194862">
+<ele>126.56292503091842></ele>
+<accuracy>3.732</accuracy>
+<speed>1.5201769</speed>
+<bearing>274.23468</bearing>
+<bearingAccuracyDegrees>12.524001</bearingAccuracyDegrees>
+<time>1746103957605</time>
+</trkpt>
+<trkpt lat="55.944746" lon="-4.3195071">
+<ele>126.5785453352162></ele>
+<accuracy>3.637</accuracy>
+<speed>1.5204694</speed>
+<bearing>277.15048</bearing>
+<bearingAccuracyDegrees>12.244073</bearingAccuracyDegrees>
+<time>1746103958608</time>
+</trkpt>
+<trkpt lat="55.9447497" lon="-4.319528">
+<ele>126.57958668984435></ele>
+<accuracy>3.579</accuracy>
+<speed>1.509142</speed>
+<bearing>279.42136</bearing>
+<bearingAccuracyDegrees>12.141685</bearingAccuracyDegrees>
+<time>1746103959611</time>
+</trkpt>
+<trkpt lat="55.9447527" lon="-4.3195468">
+<ele>126.596141678898></ele>
+<accuracy>3.583</accuracy>
+<speed>1.5080913</speed>
+<bearing>278.4015</bearing>
+<bearingAccuracyDegrees>12.146477</bearingAccuracyDegrees>
+<time>1746103960613</time>
+</trkpt>
+<trkpt lat="55.9447523" lon="-4.3195702">
+<ele>126.71694054914698></ele>
+<accuracy>3.589</accuracy>
+<speed>1.5058389</speed>
+<bearing>276.7624</bearing>
+<bearingAccuracyDegrees>12.079292</bearingAccuracyDegrees>
+<time>1746103961615</time>
+</trkpt>
+<trkpt lat="55.9447532" lon="-4.3195965">
+<ele>126.71694054914698></ele>
+<accuracy>3.666</accuracy>
+<speed>1.4972625</speed>
+<bearing>276.55072</bearing>
+<bearingAccuracyDegrees>12.123036</bearingAccuracyDegrees>
+<time>1746103962515</time>
+</trkpt>
+<trkpt lat="55.9447546" lon="-4.3196206">
+<ele>126.79138611093933></ele>
+<accuracy>3.866</accuracy>
+<speed>1.4884353</speed>
+<bearing>277.29715</bearing>
+<bearingAccuracyDegrees>12.369577</bearingAccuracyDegrees>
+<time>1746103963443</time>
+</trkpt>
+<trkpt lat="55.9447577" lon="-4.3196467">
+<ele>126.85282813951154></ele>
+<accuracy>4.177</accuracy>
+<speed>1.5095631</speed>
+<bearing>278.75528</bearing>
+<bearingAccuracyDegrees>12.105668</bearingAccuracyDegrees>
+<time>1746103964519</time>
+</trkpt>
+<trkpt lat="55.9447594" lon="-4.3196709">
+<ele>126.85259592061422></ele>
+<accuracy>4.57</accuracy>
+<speed>1.497127</speed>
+<bearing>275.03534</bearing>
+<bearingAccuracyDegrees>12.459343</bearingAccuracyDegrees>
+<time>1746103965508</time>
+</trkpt>
+<trkpt lat="55.9447602" lon="-4.3196959">
+<ele>126.88071393579396></ele>
+<accuracy>5.142</accuracy>
+<speed>1.4827765</speed>
+<bearing>274.72046</bearing>
+<bearingAccuracyDegrees>12.619177</bearingAccuracyDegrees>
+<time>1746103966531</time>
+</trkpt>
+<trkpt lat="55.9447446" lon="-4.3197385">
+<ele>126.88071393579396></ele>
+<accuracy>5.68</accuracy>
+<speed>1.4725573</speed>
+<bearing>271.56024</bearing>
+<bearingAccuracyDegrees>13.156421</bearingAccuracyDegrees>
+<time>1746103967545</time>
+</trkpt>
+<trkpt lat="55.9447439" lon="-4.3197653">
+<ele>126.90050074232677></ele>
+<accuracy>6.224</accuracy>
+<speed>1.4712347</speed>
+<bearing>277.38785</bearing>
+<bearingAccuracyDegrees>14.899967</bearingAccuracyDegrees>
+<time>1746103968543</time>
+</trkpt>
+<trkpt lat="55.944747" lon="-4.3197922">
+<ele>126.93486740924294></ele>
+<accuracy>6.707</accuracy>
+<speed>1.4818039</speed>
+<bearing>274.57388</bearing>
+<bearingAccuracyDegrees>13.329116</bearingAccuracyDegrees>
+<time>1746103969565</time>
+</trkpt>
+<trkpt lat="55.9447497" lon="-4.3198212">
+<ele>126.90050074232677></ele>
+<accuracy>7.113</accuracy>
+<speed>1.4933109</speed>
+<bearing>275.2405</bearing>
+<bearingAccuracyDegrees>13.132573</bearingAccuracyDegrees>
+<time>1746103970569</time>
+</trkpt>
+<trkpt lat="55.9447522" lon="-4.3198534">
+<ele>126.96155689130106></ele>
+<accuracy>7.319</accuracy>
+<speed>1.5134152</speed>
+<bearing>275.8443</bearing>
+<bearingAccuracyDegrees>12.285618</bearingAccuracyDegrees>
+<time>1746103971571</time>
+</trkpt>
+<trkpt lat="55.9447543" lon="-4.3198833">
+<ele>126.92237042356466></ele>
+<accuracy>7.301</accuracy>
+<speed>1.5206043</speed>
+<bearing>278.52225</bearing>
+<bearingAccuracyDegrees>12.091942</bearingAccuracyDegrees>
+<time>1746103972583</time>
+</trkpt>
+<trkpt lat="55.9447576" lon="-4.3199158">
+<ele>127.04392962431692></ele>
+<accuracy>7.166</accuracy>
+<speed>1.5292109</speed>
+<bearing>286.7436</bearing>
+<bearingAccuracyDegrees>11.863447</bearingAccuracyDegrees>
+<time>1746103973607</time>
+</trkpt>
+<trkpt lat="55.9447645" lon="-4.319945">
+<ele>127.17358701651379></ele>
+<accuracy>7.008</accuracy>
+<speed>1.5249344</speed>
+<bearing>301.0493</bearing>
+<bearingAccuracyDegrees>12.011412</bearingAccuracyDegrees>
+<time>1746103974611</time>
+</trkpt>
+<trkpt lat="55.944777" lon="-4.3199697">
+<ele>127.23867680579895></ele>
+<accuracy>6.846</accuracy>
+<speed>1.5322961</speed>
+<bearing>316.23895</bearing>
+<bearingAccuracyDegrees>12.1925745</bearingAccuracyDegrees>
+<time>1746103975632</time>
+</trkpt>
+<trkpt lat="55.9447915" lon="-4.3199885">
+<ele>127.34549398916403></ele>
+<accuracy>6.764</accuracy>
+<speed>1.5379788</speed>
+<bearing>321.2094</bearing>
+<bearingAccuracyDegrees>12.652323</bearingAccuracyDegrees>
+<time>1746103976624</time>
+</trkpt>
+<trkpt lat="55.9448048" lon="-4.3200054">
+<ele>127.3694473673759></ele>
+<accuracy>6.713</accuracy>
+<speed>1.5429623</speed>
+<bearing>320.49457</bearing>
+<bearingAccuracyDegrees>12.455282</bearingAccuracyDegrees>
+<time>1746103977587</time>
+</trkpt>
+<trkpt lat="55.9448182" lon="-4.3200229">
+<ele>127.34184891571891></ele>
+<accuracy>6.647</accuracy>
+<speed>1.5188797</speed>
+<bearing>323.31763</bearing>
+<bearingAccuracyDegrees>12.786465</bearingAccuracyDegrees>
+<time>1746103978648</time>
+</trkpt>
+<trkpt lat="55.9448317" lon="-4.3200404">
+<ele>127.38207295213329></ele>
+<accuracy>6.602</accuracy>
+<speed>1.5249397</speed>
+<bearing>320.05374</bearing>
+<bearingAccuracyDegrees>11.955496</bearingAccuracyDegrees>
+<time>1746103979650</time>
+</trkpt>
+<trkpt lat="55.9448434" lon="-4.3200587">
+<ele>127.37113776292114></ele>
+<accuracy>6.575</accuracy>
+<speed>1.5151808</speed>
+<bearing>315.23132</bearing>
+<bearingAccuracyDegrees>12.183146</bearingAccuracyDegrees>
+<time>1746103980644</time>
+</trkpt>
+<trkpt lat="55.9448527" lon="-4.3200777">
+<ele>127.3872801899789></ele>
+<accuracy>6.561</accuracy>
+<speed>1.5053668</speed>
+<bearing>310.29788</bearing>
+<bearingAccuracyDegrees>12.317811</bearingAccuracyDegrees>
+<time>1746103981649</time>
+</trkpt>
+<trkpt lat="55.9448631" lon="-4.3200985">
+<ele>127.4022962467954></ele>
+<accuracy>6.545</accuracy>
+<speed>1.5543064</speed>
+<bearing>311.72107</bearing>
+<bearingAccuracyDegrees>12.434719</bearingAccuracyDegrees>
+<time>1746103982645</time>
+</trkpt>
+<trkpt lat="55.9448719" lon="-4.3201155">
+<ele>127.51633625056189></ele>
+<accuracy>6.527</accuracy>
+<speed>1.5699196</speed>
+<bearing>314.39157</bearing>
+<bearingAccuracyDegrees>12.031266</bearingAccuracyDegrees>
+<time>1746103983565</time>
+</trkpt>
+<trkpt lat="55.9448802" lon="-4.320132">
+<ele>127.60382001817656></ele>
+<accuracy>6.116</accuracy>
+<speed>1.54973</speed>
+<bearing>318.54147</bearing>
+<bearingAccuracyDegrees>12.029277</bearingAccuracyDegrees>
+<time>1746103984569</time>
+</trkpt>
+<trkpt lat="55.9448893" lon="-4.3201489">
+<ele>127.72150791892723></ele>
+<accuracy>5.676</accuracy>
+<speed>1.5422229</speed>
+<bearing>321.0839</bearing>
+<bearingAccuracyDegrees>11.802183</bearingAccuracyDegrees>
+<time>1746103985570</time>
+</trkpt>
+<trkpt lat="55.9448974" lon="-4.3201631">
+<ele>127.77921057474228></ele>
+<accuracy>5.117</accuracy>
+<speed>1.5088104</speed>
+<bearing>326.21878</bearing>
+<bearingAccuracyDegrees>11.656247</bearingAccuracyDegrees>
+<time>1746103986572</time>
+</trkpt>
+<trkpt lat="55.9449047" lon="-4.3201747">
+<ele>127.94481154737869></ele>
+<accuracy>4.615</accuracy>
+<speed>1.4846351</speed>
+<bearing>326.4731</bearing>
+<bearingAccuracyDegrees>11.6791115</bearingAccuracyDegrees>
+<time>1746103987575</time>
+</trkpt>
+<trkpt lat="55.9449121" lon="-4.320187">
+<ele>128.08384398923636></ele>
+<accuracy>4.099</accuracy>
+<speed>1.4698669</speed>
+<bearing>323.92908</bearing>
+<bearingAccuracyDegrees>9.831805</bearingAccuracyDegrees>
+<time>1746103988578</time>
+</trkpt>
+<trkpt lat="55.9449217" lon="-4.3201988">
+<ele>128.06068057558525></ele>
+<accuracy>3.953</accuracy>
+<speed>1.4491974</speed>
+<bearing>328.73682</bearing>
+<bearingAccuracyDegrees>10.327506</bearingAccuracyDegrees>
+<time>1746103989580</time>
+</trkpt>
+<trkpt lat="55.9449327" lon="-4.3202084">
+<ele>128.06068057558525></ele>
+<accuracy>3.799</accuracy>
+<speed>1.4312593</speed>
+<bearing>329.42294</bearing>
+<bearingAccuracyDegrees>11.505741</bearingAccuracyDegrees>
+<time>1746103990504</time>
+</trkpt>
+<trkpt lat="55.9450048" lon="-4.3202765">
+<ele>129.4295376240667></ele>
+<accuracy>3.644</accuracy>
+<speed>1.2816588</speed>
+<bearing>342.32404</bearing>
+<bearingAccuracyDegrees>9.504677</bearingAccuracyDegrees>
+<time>1746103996496</time>
+</trkpt>
+<trkpt lat="55.9450178" lon="-4.3202847">
+<ele>129.48150711080083></ele>
+<accuracy>3.626</accuracy>
+<speed>1.2636001</speed>
+<bearing>345.7058</bearing>
+<bearingAccuracyDegrees>9.62764</bearingAccuracyDegrees>
+<time>1746103997599</time>
+</trkpt>
+<trkpt lat="55.9450298" lon="-4.3202894">
+<ele>129.48359056037492></ele>
+<accuracy>3.604</accuracy>
+<speed>1.245349</speed>
+<bearing>346.6907</bearing>
+<bearingAccuracyDegrees>9.66416</bearingAccuracyDegrees>
+<time>1746103998601</time>
+</trkpt>
+<trkpt lat="55.9450429" lon="-4.320293">
+<ele>129.50879611994432></ele>
+<accuracy>3.558</accuracy>
+<speed>1.2892481</speed>
+<bearing>350.72604</bearing>
+<bearingAccuracyDegrees>9.94514</bearingAccuracyDegrees>
+<time>1746103999603</time>
+</trkpt>
+<trkpt lat="55.9450582" lon="-4.3202959">
+<ele>129.20722476666543></ele>
+<accuracy>3.523</accuracy>
+<speed>1.3388591</speed>
+<bearing>353.28555</bearing>
+<bearingAccuracyDegrees>10.098925</bearingAccuracyDegrees>
+<time>1746104000606</time>
+</trkpt>
+<trkpt lat="55.9450733" lon="-4.3203002">
+<ele>128.97597514137442></ele>
+<accuracy>3.48</accuracy>
+<speed>1.3757775</speed>
+<bearing>349.5702</bearing>
+<bearingAccuracyDegrees>9.746198</bearingAccuracyDegrees>
+<time>1746104001607</time>
+</trkpt>
+<trkpt lat="55.9450883" lon="-4.3203061">
+<ele>128.64838214951428></ele>
+<accuracy>3.45</accuracy>
+<speed>1.4379752</speed>
+<bearing>343.6482</bearing>
+<bearingAccuracyDegrees>9.779879</bearingAccuracyDegrees>
+<time>1746104002610</time>
+</trkpt>
+<trkpt lat="55.9451029" lon="-4.3203138">
+<ele>128.44787431247693></ele>
+<accuracy>3.476</accuracy>
+<speed>1.4516894</speed>
+<bearing>333.28217</bearing>
+<bearingAccuracyDegrees>10.20301</bearingAccuracyDegrees>
+<time>1746104003613</time>
+</trkpt>
+<trkpt lat="55.9451136" lon="-4.3203251">
+<ele>128.44787431247693></ele>
+<accuracy>3.521</accuracy>
+<speed>1.4536375</speed>
+<bearing>318.27063</bearing>
+<bearingAccuracyDegrees>12.006162</bearingAccuracyDegrees>
+<time>1746104004517</time>
+</trkpt>
+<trkpt lat="55.9451222" lon="-4.3203397">
+<ele>128.09582510854597></ele>
+<accuracy>3.602</accuracy>
+<speed>1.4426576</speed>
+<bearing>311.7729</bearing>
+<bearingAccuracyDegrees>9.959958</bearingAccuracyDegrees>
+<time>1746104005512</time>
+</trkpt>
+<trkpt lat="55.9451309" lon="-4.3203493">
+<ele>127.67141542862849></ele>
+<accuracy>3.737</accuracy>
+<speed>1.421827</speed>
+<bearing>315.24304</bearing>
+<bearingAccuracyDegrees>11.723704</bearingAccuracyDegrees>
+<time>1746104006620</time>
+</trkpt>
+<trkpt lat="55.94514" lon="-4.3203536">
+<ele>127.26055646399686></ele>
+<accuracy>3.793</accuracy>
+<speed>1.4319483</speed>
+<bearing>318.64645</bearing>
+<bearingAccuracyDegrees>11.663241</bearingAccuracyDegrees>
+<time>1746104007622</time>
+</trkpt>
+<trkpt lat="55.9451517" lon="-4.3203623">
+<ele>127.06652022344753></ele>
+<accuracy>3.815</accuracy>
+<speed>1.4984282</speed>
+<bearing>317.36688</bearing>
+<bearingAccuracyDegrees>11.973441</bearingAccuracyDegrees>
+<time>1746104008668</time>
+</trkpt>
+<trkpt lat="55.9451611" lon="-4.3203726">
+<ele>126.90614472642375></ele>
+<accuracy>3.806</accuracy>
+<speed>1.5088882</speed>
+<bearing>319.23538</bearing>
+<bearingAccuracyDegrees>12.140482</bearingAccuracyDegrees>
+<time>1746104009611</time>
+</trkpt>
+<trkpt lat="55.9451709" lon="-4.320385">
+<ele>126.67808342335881></ele>
+<accuracy>3.783</accuracy>
+<speed>1.5283601</speed>
+<bearing>321.81885</bearing>
+<bearingAccuracyDegrees>12.874399</bearingAccuracyDegrees>
+<time>1746104010532</time>
+</trkpt>
+<trkpt lat="55.9451813" lon="-4.3203946">
+<ele>126.18897867489119></ele>
+<accuracy>3.766</accuracy>
+<speed>1.490512</speed>
+<bearing>326.3851</bearing>
+<bearingAccuracyDegrees>14.73826</bearingAccuracyDegrees>
+<time>1746104011523</time>
+</trkpt>
+<trkpt lat="55.9451898" lon="-4.3204028">
+<ele>125.93281950279976></ele>
+<accuracy>3.856</accuracy>
+<speed>1.4480357</speed>
+<bearing>325.87302</bearing>
+<bearingAccuracyDegrees>14.6818495</bearingAccuracyDegrees>
+<time>1746104012445</time>
+</trkpt>
+<trkpt lat="55.9451958" lon="-4.3204233">
+<ele>125.6376211393704></ele>
+<accuracy>3.935</accuracy>
+<speed>1.4568695</speed>
+<bearing>313.08737</bearing>
+<bearingAccuracyDegrees>13.024767</bearingAccuracyDegrees>
+<time>1746104013410</time>
+</trkpt>
+<trkpt lat="55.9451991" lon="-4.32045">
+<ele>125.3528450192895></ele>
+<accuracy>3.967</accuracy>
+<speed>1.4470612</speed>
+<bearing>305.41907</bearing>
+<bearingAccuracyDegrees>12.720914</bearingAccuracyDegrees>
+<time>1746104014329</time>
+</trkpt>
+<trkpt lat="55.9452008" lon="-4.3204763">
+<ele>124.95145283518453></ele>
+<accuracy>3.98</accuracy>
+<speed>1.4387784</speed>
+<bearing>299.31082</bearing>
+<bearingAccuracyDegrees>12.460568</bearingAccuracyDegrees>
+<time>1746104015263</time>
+</trkpt>
+<trkpt lat="55.9452009" lon="-4.3205002">
+<ele>123.30000305175781></ele>
+<accuracy>3.948</accuracy>
+<speed>1.3907001</speed>
+<bearing>290.4777</bearing>
+<bearingAccuracyDegrees>12.222991</bearingAccuracyDegrees>
+<time>1746104016244</time>
+</trkpt>
+<trkpt lat="55.9452017" lon="-4.3205215">
+<ele>123.30000305175781></ele>
+<accuracy>3.875</accuracy>
+<speed>1.3633127</speed>
+<bearing>290.23734</bearing>
+<bearingAccuracyDegrees>12.253147</bearingAccuracyDegrees>
+<time>1746104017267</time>
+</trkpt>
+<trkpt lat="55.9452035" lon="-4.3205407">
+<ele>123.30000305175781></ele>
+<accuracy>3.798</accuracy>
+<speed>1.346495</speed>
+<bearing>292.86172</bearing>
+<bearingAccuracyDegrees>11.60689</bearingAccuracyDegrees>
+<time>1746104018289</time>
+</trkpt>
+<trkpt lat="55.9452065" lon="-4.3205606">
+<ele>123.30000305175781></ele>
+<accuracy>3.671</accuracy>
+<speed>1.3138165</speed>
+<bearing>288.80957</bearing>
+<bearingAccuracyDegrees>12.766177</bearingAccuracyDegrees>
+<time>1746104019650</time>
+</trkpt>
+<trkpt lat="55.9452108" lon="-4.3205784">
+<ele>123.30000305175781></ele>
+<accuracy>3.645</accuracy>
+<speed>1.1899143</speed>
+<bearing>294.6392</bearing>
+<bearingAccuracyDegrees>12.47852</bearingAccuracyDegrees>
+<time>1746104021272</time>
+</trkpt>
+<trkpt lat="55.9452181" lon="-4.3205883">
+<ele>123.30000305175781></ele>
+<accuracy>3.664</accuracy>
+<speed>1.1180367</speed>
+<bearing>292.90866</bearing>
+<bearingAccuracyDegrees>12.374691</bearingAccuracyDegrees>
+<time>1746104022831</time>
+</trkpt>
+<trkpt lat="55.9452192" lon="-4.3206736">
+<ele>123.30000305175781></ele>
+<accuracy>3.883</accuracy>
+<speed>1.3769411</speed>
+<bearing>241.9829</bearing>
+<bearingAccuracyDegrees>12.585689</bearingAccuracyDegrees>
+<time>1746104028564</time>
+</trkpt>
+<trkpt lat="55.9452075" lon="-4.3206895">
+<ele>121.46374534527163></ele>
+<accuracy>4.008</accuracy>
+<speed>1.4175123</speed>
+<bearing>208.75195</bearing>
+<bearingAccuracyDegrees>12.508996</bearingAccuracyDegrees>
+<time>1746104029573</time>
+</trkpt>
+<trkpt lat="55.9451934" lon="-4.3206976">
+<ele>121.28473967494492></ele>
+<accuracy>4.044</accuracy>
+<speed>1.4432583</speed>
+<bearing>184.52211</bearing>
+<bearingAccuracyDegrees>12.245103</bearingAccuracyDegrees>
+<time>1746104030575</time>
+</trkpt>
+<trkpt lat="55.945179" lon="-4.320699">
+<ele>121.28473967494492></ele>
+<accuracy>4.02</accuracy>
+<speed>1.4733877</speed>
+<bearing>176.81927</bearing>
+<bearingAccuracyDegrees>12.595341</bearingAccuracyDegrees>
+<time>1746104031539</time>
+</trkpt>
+<trkpt lat="55.9451661" lon="-4.3206968">
+<ele>121.14849745325846></ele>
+<accuracy>3.949</accuracy>
+<speed>1.4696755</speed>
+<bearing>169.6244</bearing>
+<bearingAccuracyDegrees>12.553226</bearingAccuracyDegrees>
+<time>1746104032542</time>
+</trkpt>
+<trkpt lat="55.9451509" lon="-4.3206903">
+<ele>121.13236662463282></ele>
+<accuracy>3.834</accuracy>
+<speed>1.4533682</speed>
+<bearing>164.73605</bearing>
+<bearingAccuracyDegrees>11.829983</bearingAccuracyDegrees>
+<time>1746104033625</time>
+</trkpt>
+<trkpt lat="55.945139" lon="-4.3206829">
+<ele>121.08137259121173></ele>
+<accuracy>3.75</accuracy>
+<speed>1.4283384</speed>
+<bearing>161.97447</bearing>
+<bearingAccuracyDegrees>12.145545</bearingAccuracyDegrees>
+<time>1746104034585</time>
+</trkpt>
+<trkpt lat="55.9451251" lon="-4.3206736">
+<ele>121.0391456978157></ele>
+<accuracy>3.675</accuracy>
+<speed>1.4342641</speed>
+<bearing>162.97578</bearing>
+<bearingAccuracyDegrees>11.6601715</bearingAccuracyDegrees>
+<time>1746104035586</time>
+</trkpt>
+<trkpt lat="55.9451111" lon="-4.3206654">
+<ele>121.0391456978157></ele>
+<accuracy>3.656</accuracy>
+<speed>1.4466456</speed>
+<bearing>163.5252</bearing>
+<bearingAccuracyDegrees>11.611084</bearingAccuracyDegrees>
+<time>1746104036589</time>
+</trkpt>
+<trkpt lat="55.9450977" lon="-4.3206581">
+<ele>121.17235499638252></ele>
+<accuracy>3.64</accuracy>
+<speed>1.4608827</speed>
+<bearing>160.32823</bearing>
+<bearingAccuracyDegrees>11.731146</bearingAccuracyDegrees>
+<time>1746104037592</time>
+</trkpt>
+<trkpt lat="55.9450837" lon="-4.3206493">
+<ele>121.13020651861422></ele>
+<accuracy>3.631</accuracy>
+<speed>1.4930723</speed>
+<bearing>161.18875</bearing>
+<bearingAccuracyDegrees>9.889051</bearingAccuracyDegrees>
+<time>1746104038594</time>
+</trkpt>
+<trkpt lat="55.9450684" lon="-4.3206388">
+<ele>121.00860443622028></ele>
+<accuracy>3.611</accuracy>
+<speed>1.5294622</speed>
+<bearing>161.71144</bearing>
+<bearingAccuracyDegrees>10.090197</bearingAccuracyDegrees>
+<time>1746104039596</time>
+</trkpt>
+<trkpt lat="55.9450517" lon="-4.3206278">
+<ele>120.9539678280376></ele>
+<accuracy>3.654</accuracy>
+<speed>1.5353318</speed>
+<bearing>160.01646</bearing>
+<bearingAccuracyDegrees>10.234467</bearingAccuracyDegrees>
+<time>1746104040597</time>
+</trkpt>
+<trkpt lat="55.9450344" lon="-4.3206165">
+<ele>120.93731674027013></ele>
+<accuracy>3.713</accuracy>
+<speed>1.5453931</speed>
+<bearing>158.11607</bearing>
+<bearingAccuracyDegrees>10.079575</bearingAccuracyDegrees>
+<time>1746104041600</time>
+</trkpt>
+<trkpt lat="55.945015" lon="-4.3206049">
+<ele>120.91446512734984></ele>
+<accuracy>3.743</accuracy>
+<speed>1.5637158</speed>
+<bearing>157.65442</bearing>
+<bearingAccuracyDegrees>9.614542</bearingAccuracyDegrees>
+<time>1746104042602</time>
+</trkpt>
+<trkpt lat="55.9449934" lon="-4.3205941">
+<ele>120.86919534267312></ele>
+<accuracy>3.762</accuracy>
+<speed>1.5780119</speed>
+<bearing>160.07329</bearing>
+<bearingAccuracyDegrees>9.78427</bearingAccuracyDegrees>
+<time>1746104043605</time>
+</trkpt>
+<trkpt lat="55.9449703" lon="-4.3205843">
+<ele>120.88532592827664></ele>
+<accuracy>3.757</accuracy>
+<speed>1.5972831</speed>
+<bearing>158.78584</bearing>
+<bearingAccuracyDegrees>10.28139</bearingAccuracyDegrees>
+<time>1746104044608</time>
+</trkpt>
+<trkpt lat="55.9449488" lon="-4.3205755">
+<ele>120.85774784866365></ele>
+<accuracy>3.718</accuracy>
+<speed>1.5859205</speed>
+<bearing>159.01863</bearing>
+<bearingAccuracyDegrees>9.401183</bearingAccuracyDegrees>
+<time>1746104045610</time>
+</trkpt>
+<trkpt lat="55.9449283" lon="-4.3205659">
+<ele>120.8613902314668></ele>
+<accuracy>3.612</accuracy>
+<speed>1.5855732</speed>
+<bearing>161.03003</bearing>
+<bearingAccuracyDegrees>9.483777</bearingAccuracyDegrees>
+<time>1746104046612</time>
+</trkpt>
+<trkpt lat="55.9449095" lon="-4.3205583">
+<ele>120.91394391553577></ele>
+<accuracy>3.545</accuracy>
+<speed>1.5648416</speed>
+<bearing>164.48413</bearing>
+<bearingAccuracyDegrees>10.004596</bearingAccuracyDegrees>
+<time>1746104047615</time>
+</trkpt>
+<trkpt lat="55.9448929" lon="-4.3205521">
+<ele>120.9004150941789></ele>
+<accuracy>3.486</accuracy>
+<speed>1.5501829</speed>
+<bearing>165.05344</bearing>
+<bearingAccuracyDegrees>9.5982895</bearingAccuracyDegrees>
+<time>1746104048617</time>
+</trkpt>
+<trkpt lat="55.9448787" lon="-4.3205473">
+<ele>120.87960156441605></ele>
+<accuracy>3.462</accuracy>
+<speed>1.5359305</speed>
+<bearing>163.33235</bearing>
+<bearingAccuracyDegrees>9.269178</bearingAccuracyDegrees>
+<time>1746104049618</time>
+</trkpt>
+<trkpt lat="55.9448662" lon="-4.3205419">
+<ele>120.85493313380988></ele>
+<accuracy>3.476</accuracy>
+<speed>1.5239639</speed>
+<bearing>160.73526</bearing>
+<bearingAccuracyDegrees>9.90231</bearingAccuracyDegrees>
+<time>1746104050621</time>
+</trkpt>
+<trkpt lat="55.9448543" lon="-4.3205348">
+<ele>120.83724179942391></ele>
+<accuracy>3.533</accuracy>
+<speed>1.523089</speed>
+<bearing>157.06851</bearing>
+<bearingAccuracyDegrees>10.227647</bearingAccuracyDegrees>
+<time>1746104051623</time>
+</trkpt>
+<trkpt lat="55.9448439" lon="-4.3205284">
+<ele>120.79509494354579></ele>
+<accuracy>3.599</accuracy>
+<speed>1.5132352</speed>
+<bearing>159.31358</bearing>
+<bearingAccuracyDegrees>11.900732</bearingAccuracyDegrees>
+<time>1746104052626</time>
+</trkpt>
+<trkpt lat="55.944832" lon="-4.3205228">
+<ele>120.69311081354951></ele>
+<accuracy>3.676</accuracy>
+<speed>1.5109754</speed>
+<bearing>161.76959</bearing>
+<bearingAccuracyDegrees>12.366768</bearingAccuracyDegrees>
+<time>1746104053629</time>
+</trkpt>
+<trkpt lat="55.9448172" lon="-4.3205156">
+<ele>120.66033045717711></ele>
+<accuracy>3.737</accuracy>
+<speed>1.5203588</speed>
+<bearing>162.38914</bearing>
+<bearingAccuracyDegrees>12.341209</bearingAccuracyDegrees>
+<time>1746104054630</time>
+</trkpt>
+<trkpt lat="55.9448023" lon="-4.3205066">
+<ele>120.63847695567615></ele>
+<accuracy>3.845</accuracy>
+<speed>1.5036218</speed>
+<bearing>160.16658</bearing>
+<bearingAccuracyDegrees>12.16881</bearingAccuracyDegrees>
+<time>1746104055633</time>
+</trkpt>
+<trkpt lat="55.9447893" lon="-4.3204972">
+<ele>120.61454223203614></ele>
+<accuracy>3.968</accuracy>
+<speed>1.490775</speed>
+<bearing>160.04733</bearing>
+<bearingAccuracyDegrees>11.952765</bearingAccuracyDegrees>
+<time>1746104056534</time>
+</trkpt>
+<trkpt lat="55.9447764" lon="-4.3204877">
+<ele>120.61454223203614></ele>
+<accuracy>4.105</accuracy>
+<speed>1.4873774</speed>
+<bearing>157.28745</bearing>
+<bearingAccuracyDegrees>12.243151</bearingAccuracyDegrees>
+<time>1746104057459</time>
+</trkpt>
+<trkpt lat="55.944763" lon="-4.3204759">
+<ele>120.59166081842429></ele>
+<accuracy>4.353</accuracy>
+<speed>1.4609461</speed>
+<bearing>158.2255</bearing>
+<bearingAccuracyDegrees>12.024183</bearingAccuracyDegrees>
+<time>1746104058462</time>
+</trkpt>
+<trkpt lat="55.9447461" lon="-4.320467">
+<ele>120.63646446295519></ele>
+<accuracy>4.755</accuracy>
+<speed>1.5112613</speed>
+<bearing>162.7518</bearing>
+<bearingAccuracyDegrees>10.183683</bearingAccuracyDegrees>
+<time>1746104059483</time>
+</trkpt>
+<trkpt lat="55.9447281" lon="-4.320461">
+<ele>120.63594414761347></ele>
+<accuracy>5.075</accuracy>
+<speed>1.5225433</speed>
+<bearing>162.20308</bearing>
+<bearingAccuracyDegrees>9.908171</bearingAccuracyDegrees>
+<time>1746104060516</time>
+</trkpt>
+<trkpt lat="55.9447138" lon="-4.3204499">
+<ele>120.54483235129027></ele>
+<accuracy>5.381</accuracy>
+<speed>1.5123789</speed>
+<bearing>158.80844</bearing>
+<bearingAccuracyDegrees>10.172074</bearingAccuracyDegrees>
+<time>1746104061519</time>
+</trkpt>
+<trkpt lat="55.9446995" lon="-4.320437">
+<ele>120.45142238549056></ele>
+<accuracy>5.69</accuracy>
+<speed>1.498321</speed>
+<bearing>156.25493</bearing>
+<bearingAccuracyDegrees>10.068598</bearingAccuracyDegrees>
+<time>1746104062542</time>
+</trkpt>
+<trkpt lat="55.9446857" lon="-4.3204231">
+<ele>120.51177910202563></ele>
+<accuracy>5.979</accuracy>
+<speed>1.4757011</speed>
+<bearing>157.10567</bearing>
+<bearingAccuracyDegrees>9.830025</bearingAccuracyDegrees>
+<time>1746104063571</time>
+</trkpt>
+<trkpt lat="55.9446718" lon="-4.3204106">
+<ele>120.6416114644241></ele>
+<accuracy>6.248</accuracy>
+<speed>1.47035</speed>
+<bearing>155.64612</bearing>
+<bearingAccuracyDegrees>9.819255</bearingAccuracyDegrees>
+<time>1746104064588</time>
+</trkpt>
+<trkpt lat="55.9446566" lon="-4.320399">
+<ele>120.52365162798148></ele>
+<accuracy>6.434</accuracy>
+<speed>1.4799272</speed>
+<bearing>156.10545</bearing>
+<bearingAccuracyDegrees>9.449963</bearingAccuracyDegrees>
+<time>1746104065599</time>
+</trkpt>
+<trkpt lat="55.9446412" lon="-4.3203877">
+<ele>120.5933749193367></ele>
+<accuracy>6.557</accuracy>
+<speed>1.4748974</speed>
+<bearing>154.29723</bearing>
+<bearingAccuracyDegrees>9.727129</bearingAccuracyDegrees>
+<time>1746104066640</time>
+</trkpt>
+<trkpt lat="55.9446264" lon="-4.3203766">
+<ele>120.65637851380784></ele>
+<accuracy>6.628</accuracy>
+<speed>1.4486154</speed>
+<bearing>156.95358</bearing>
+<bearingAccuracyDegrees>9.606064</bearingAccuracyDegrees>
+<time>1746104067668</time>
+</trkpt>
+<trkpt lat="55.9446135" lon="-4.3203701">
+<ele>120.65269219431353></ele>
+<accuracy>6.627</accuracy>
+<speed>1.4569582</speed>
+<bearing>154.45787</bearing>
+<bearingAccuracyDegrees>10.133175</bearingAccuracyDegrees>
+<time>1746104068664</time>
+</trkpt>
+<trkpt lat="55.9445994" lon="-4.320359">
+<ele>120.628236776993></ele>
+<accuracy>6.581</accuracy>
+<speed>1.4383769</speed>
+<bearing>152.0081</bearing>
+<bearingAccuracyDegrees>11.248299</bearingAccuracyDegrees>
+<time>1746104069566</time>
+</trkpt>
+<trkpt lat="55.9445846" lon="-4.320347">
+<ele>120.62043187121037></ele>
+<accuracy>6.53</accuracy>
+<speed>1.4630028</speed>
+<bearing>154.92445</bearing>
+<bearingAccuracyDegrees>11.71893</bearingAccuracyDegrees>
+<time>1746104070568</time>
+</trkpt>
+<trkpt lat="55.9445691" lon="-4.320335">
+<ele>120.60117980056339></ele>
+<accuracy>6.512</accuracy>
+<speed>1.499883</speed>
+<bearing>151.84601</bearing>
+<bearingAccuracyDegrees>11.873641</bearingAccuracyDegrees>
+<time>1746104071569</time>
+</trkpt>
+<trkpt lat="55.9445475" lon="-4.3203307">
+<ele>120.5585132030013></ele>
+<accuracy>6.199</accuracy>
+<speed>1.524207</speed>
+<bearing>152.5468</bearing>
+<bearingAccuracyDegrees>9.369559</bearingAccuracyDegrees>
+<time>1746104072573</time>
+</trkpt>
+<trkpt lat="55.9445306" lon="-4.3203208">
+<ele>120.63088378130166></ele>
+<accuracy>5.839</accuracy>
+<speed>1.5291939</speed>
+<bearing>154.61145</bearing>
+<bearingAccuracyDegrees>9.641455</bearingAccuracyDegrees>
+<time>1746104073575</time>
+</trkpt>
+<trkpt lat="55.9445135" lon="-4.3203099">
+<ele>120.55803893055719></ele>
+<accuracy>5.31</accuracy>
+<speed>1.5515022</speed>
+<bearing>154.50414</bearing>
+<bearingAccuracyDegrees>9.934377</bearingAccuracyDegrees>
+<time>1746104074577</time>
+</trkpt>
+<trkpt lat="55.9444973" lon="-4.3202979">
+<ele>120.48363375571341></ele>
+<accuracy>4.717</accuracy>
+<speed>1.5346175</speed>
+<bearing>155.61078</bearing>
+<bearingAccuracyDegrees>9.619557</bearingAccuracyDegrees>
+<time>1746104075580</time>
+</trkpt>
+<trkpt lat="55.9444824" lon="-4.3202868">
+<ele>120.43732596490001></ele>
+<accuracy>4.118</accuracy>
+<speed>1.5245368</speed>
+<bearing>150.66739</bearing>
+<bearingAccuracyDegrees>9.177054</bearingAccuracyDegrees>
+<time>1746104076582</time>
+</trkpt>
+<trkpt lat="55.9444685" lon="-4.320276">
+<ele>120.52163153742413></ele>
+<accuracy>3.813</accuracy>
+<speed>1.5387868</speed>
+<bearing>153.99353</bearing>
+<bearingAccuracyDegrees>9.753028</bearingAccuracyDegrees>
+<time>1746104077584</time>
+</trkpt>
+<trkpt lat="55.9444536" lon="-4.3202651">
+<ele>120.47896628733507></ele>
+<accuracy>3.736</accuracy>
+<speed>1.5351508</speed>
+<bearing>158.22223</bearing>
+<bearingAccuracyDegrees>9.720496</bearingAccuracyDegrees>
+<time>1746104078586</time>
+</trkpt>
+<trkpt lat="55.9444383" lon="-4.3202562">
+<ele>120.31186673328304></ele>
+<accuracy>3.691</accuracy>
+<speed>1.5423619</speed>
+<bearing>160.32791</bearing>
+<bearingAccuracyDegrees>9.337388</bearingAccuracyDegrees>
+<time>1746104079589</time>
+</trkpt>
+<trkpt lat="55.9444225" lon="-4.3202474">
+<ele>120.26608022012417></ele>
+<accuracy>3.704</accuracy>
+<speed>1.5390145</speed>
+<bearing>155.68866</bearing>
+<bearingAccuracyDegrees>9.184834</bearingAccuracyDegrees>
+<time>1746104080590</time>
+</trkpt>
+<trkpt lat="55.944408" lon="-4.3202365">
+<ele>120.18959647480177></ele>
+<accuracy>3.713</accuracy>
+<speed>1.52898</speed>
+<bearing>155.11636</bearing>
+<bearingAccuracyDegrees>9.030753</bearingAccuracyDegrees>
+<time>1746104081592</time>
+</trkpt>
+<trkpt lat="55.9443934" lon="-4.3202293">
+<ele>120.13600622859404></ele>
+<accuracy>3.704</accuracy>
+<speed>1.5184109</speed>
+<bearing>157.44063</bearing>
+<bearingAccuracyDegrees>10.297463</bearingAccuracyDegrees>
+<time>1746104082596</time>
+</trkpt>
+<trkpt lat="55.9443788" lon="-4.3202231">
+<ele>120.13600622859404></ele>
+<accuracy>3.674</accuracy>
+<speed>1.5104638</speed>
+<bearing>163.11644</bearing>
+<bearingAccuracyDegrees>9.943615</bearingAccuracyDegrees>
+<time>1746104083598</time>
+</trkpt>
+<trkpt lat="55.9443629" lon="-4.3202183">
+<ele>120.35185667207753></ele>
+<accuracy>3.638</accuracy>
+<speed>1.5071224</speed>
+<bearing>163.19379</bearing>
+<bearingAccuracyDegrees>9.7613535</bearingAccuracyDegrees>
+<time>1746104084600</time>
+</trkpt>
+<trkpt lat="55.9443463" lon="-4.3202124">
+<ele>120.4596178904633></ele>
+<accuracy>3.576</accuracy>
+<speed>1.5176222</speed>
+<bearing>162.24124</bearing>
+<bearingAccuracyDegrees>10.019897</bearingAccuracyDegrees>
+<time>1746104085603</time>
+</trkpt>
+<trkpt lat="55.9443312" lon="-4.3202051">
+<ele>120.4596178904633></ele>
+<accuracy>3.516</accuracy>
+<speed>1.5315095</speed>
+<bearing>158.93869</bearing>
+<bearingAccuracyDegrees>10.146935</bearingAccuracyDegrees>
+<time>1746104086508</time>
+</trkpt>
+<trkpt lat="55.9443173" lon="-4.3201965">
+<ele>120.52673730251334></ele>
+<accuracy>3.483</accuracy>
+<speed>1.509471</speed>
+<bearing>154.95155</bearing>
+<bearingAccuracyDegrees>11.551929</bearingAccuracyDegrees>
+<time>1746104087519</time>
+</trkpt>
+<trkpt lat="55.9443032" lon="-4.3201865">
+<ele>120.39002547052374></ele>
+<accuracy>3.46</accuracy>
+<speed>1.4952252</speed>
+<bearing>152.68124</bearing>
+<bearingAccuracyDegrees>10.562896</bearingAccuracyDegrees>
+<time>1746104088574</time>
+</trkpt>
+<trkpt lat="55.9442908" lon="-4.3201755">
+<ele>120.38482236228347></ele>
+<accuracy>3.439</accuracy>
+<speed>1.480346</speed>
+<bearing>154.74416</bearing>
+<bearingAccuracyDegrees>9.988252</bearingAccuracyDegrees>
+<time>1746104089584</time>
+</trkpt>
+<trkpt lat="55.9442783" lon="-4.3201659">
+<ele>120.29012634232078></ele>
+<accuracy>3.449</accuracy>
+<speed>1.4650995</speed>
+<bearing>158.01385</bearing>
+<bearingAccuracyDegrees>9.972114</bearingAccuracyDegrees>
+<time>1746104090627</time>
+</trkpt>
+<trkpt lat="55.9442667" lon="-4.3201572">
+<ele>120.17348275057196></ele>
+<accuracy>3.443</accuracy>
+<speed>1.4640009</speed>
+<bearing>158.80063</bearing>
+<bearingAccuracyDegrees>9.763238</bearingAccuracyDegrees>
+<time>1746104091639</time>
+</trkpt>
+<trkpt lat="55.9442564" lon="-4.3201515">
+<ele>120.0346040743301></ele>
+<accuracy>3.407</accuracy>
+<speed>1.4570621</speed>
+<bearing>161.32112</bearing>
+<bearingAccuracyDegrees>9.428021</bearingAccuracyDegrees>
+<time>1746104092619</time>
+</trkpt>
+<trkpt lat="55.9442431" lon="-4.3201447">
+<ele>120.00442727343372></ele>
+<accuracy>3.432</accuracy>
+<speed>1.477261</speed>
+<bearing>160.82811</bearing>
+<bearingAccuracyDegrees>9.272347</bearingAccuracyDegrees>
+<time>1746104093621</time>
+</trkpt>
+<trkpt lat="55.9441884" lon="-4.3201052">
+<ele>119.79007097666675></ele>
+<accuracy>4.337</accuracy>
+<speed>1.4902897</speed>
+<bearing>154.2066</bearing>
+<bearingAccuracyDegrees>10.263735</bearingAccuracyDegrees>
+<time>1746104097631</time>
+</trkpt>
+<trkpt lat="55.9441465" lon="-4.3200775">
+<ele>119.69643522153697></ele>
+<accuracy>5.228</accuracy>
+<speed>1.4888368</speed>
+<bearing>152.57402</bearing>
+<bearingAccuracyDegrees>11.737403</bearingAccuracyDegrees>
+<time>1746104100638</time>
+</trkpt>
+<trkpt lat="55.9441329" lon="-4.3200684">
+<ele>119.67042195925112></ele>
+<accuracy>5.405</accuracy>
+<speed>1.4774047</speed>
+<bearing>152.56123</bearing>
+<bearingAccuracyDegrees>11.875577</bearingAccuracyDegrees>
+<time>1746104101640</time>
+</trkpt>
+<trkpt lat="55.9441215" lon="-4.3200536">
+<ele>119.70105308959555></ele>
+<accuracy>5.646</accuracy>
+<speed>1.4806004</speed>
+<bearing>150.78809</bearing>
+<bearingAccuracyDegrees>12.500078</bearingAccuracyDegrees>
+<time>1746104102542</time>
+</trkpt>
+<trkpt lat="55.9441109" lon="-4.3200377">
+<ele>119.70105308959555></ele>
+<accuracy>5.762</accuracy>
+<speed>1.4778526</speed>
+<bearing>151.42122</bearing>
+<bearingAccuracyDegrees>12.172663</bearingAccuracyDegrees>
+<time>1746104103469</time>
+</trkpt>
+<trkpt lat="55.9440989" lon="-4.3200259">
+<ele>119.7817836536982></ele>
+<accuracy>5.849</accuracy>
+<speed>1.4650624</speed>
+<bearing>151.50186</bearing>
+<bearingAccuracyDegrees>12.206551</bearingAccuracyDegrees>
+<time>1746104104500</time>
+</trkpt>
+<trkpt lat="55.9440871" lon="-4.3200156">
+<ele>119.75724197067842></ele>
+<accuracy>5.904</accuracy>
+<speed>1.466643</speed>
+<bearing>152.87039</bearing>
+<bearingAccuracyDegrees>10.153891</bearingAccuracyDegrees>
+<time>1746104105502</time>
+</trkpt>
+<trkpt lat="55.9440749" lon="-4.3200052">
+<ele>119.76624807219832></ele>
+<accuracy>5.937</accuracy>
+<speed>1.4381024</speed>
+<bearing>152.61981</bearing>
+<bearingAccuracyDegrees>11.818268</bearingAccuracyDegrees>
+<time>1746104106561</time>
+</trkpt>
+<trkpt lat="55.9440639" lon="-4.3199878">
+<ele>119.66745930538659></ele>
+<accuracy>5.935</accuracy>
+<speed>1.4482149</speed>
+<bearing>146.29951</bearing>
+<bearingAccuracyDegrees>11.82066</bearingAccuracyDegrees>
+<time>1746104107561</time>
+</trkpt>
+<trkpt lat="55.944054" lon="-4.319971">
+<ele>119.61468941408577></ele>
+<accuracy>5.952</accuracy>
+<speed>1.4431576</speed>
+<bearing>146.33093</bearing>
+<bearingAccuracyDegrees>12.044137</bearingAccuracyDegrees>
+<time>1746104108556</time>
+</trkpt>
+<trkpt lat="55.9440415" lon="-4.3199624">
+<ele>119.56316593650234></ele>
+<accuracy>5.936</accuracy>
+<speed>1.4067062</speed>
+<bearing>151.38754</bearing>
+<bearingAccuracyDegrees>12.052346</bearingAccuracyDegrees>
+<time>1746104109558</time>
+</trkpt>
+<trkpt lat="55.9440281" lon="-4.3199548">
+<ele>119.56316593650234></ele>
+<accuracy>5.908</accuracy>
+<speed>1.4063947</speed>
+<bearing>150.93555</bearing>
+<bearingAccuracyDegrees>12.306052</bearingAccuracyDegrees>
+<time>1746104110509</time>
+</trkpt>
+<trkpt lat="55.9440149" lon="-4.3199429">
+<ele>119.68902238840491></ele>
+<accuracy>5.877</accuracy>
+<speed>1.3990291</speed>
+<bearing>151.06516</bearing>
+<bearingAccuracyDegrees>11.711157</bearingAccuracyDegrees>
+<time>1746104111562</time>
+</trkpt>
+<trkpt lat="55.9440022" lon="-4.3199316">
+<ele>119.72758203741671></ele>
+<accuracy>5.821</accuracy>
+<speed>1.4039738</speed>
+<bearing>148.64464</bearing>
+<bearingAccuracyDegrees>12.212392</bearingAccuracyDegrees>
+<time>1746104112565</time>
+</trkpt>
+<trkpt lat="55.9439875" lon="-4.3199151">
+<ele>119.55744308336887></ele>
+<accuracy>5.77</accuracy>
+<speed>1.4156934</speed>
+<bearing>146.12878</bearing>
+<bearingAccuracyDegrees>12.0403185</bearingAccuracyDegrees>
+<time>1746104113567</time>
+</trkpt>
+<trkpt lat="55.9439748" lon="-4.3199033">
+<ele>119.55652767027205></ele>
+<accuracy>5.685</accuracy>
+<speed>1.43116</speed>
+<bearing>149.96672</bearing>
+<bearingAccuracyDegrees>12.21287</bearingAccuracyDegrees>
+<time>1746104114569</time>
+</trkpt>
+<trkpt lat="55.943961" lon="-4.3198936">
+<ele>119.52010950845387></ele>
+<accuracy>5.639</accuracy>
+<speed>1.4167345</speed>
+<bearing>153.71219</bearing>
+<bearingAccuracyDegrees>12.304193</bearingAccuracyDegrees>
+<time>1746104115572</time>
+</trkpt>
+<trkpt lat="55.9439452" lon="-4.3198846">
+<ele>119.49097509003633></ele>
+<accuracy>5.61</accuracy>
+<speed>1.4308999</speed>
+<bearing>154.29088</bearing>
+<bearingAccuracyDegrees>11.938605</bearingAccuracyDegrees>
+<time>1746104116574</time>
+</trkpt>
+<trkpt lat="55.9439299" lon="-4.3198744">
+<ele>119.3853059377158></ele>
+<accuracy>5.543</accuracy>
+<speed>1.4143642</speed>
+<bearing>151.63142</bearing>
+<bearingAccuracyDegrees>12.062352</bearingAccuracyDegrees>
+<time>1746104117577</time>
+</trkpt>
+<trkpt lat="55.9439138" lon="-4.3198646">
+<ele>119.22018262880195></ele>
+<accuracy>5.48</accuracy>
+<speed>1.3745854</speed>
+<bearing>151.9861</bearing>
+<bearingAccuracyDegrees>11.922628</bearingAccuracyDegrees>
+<time>1746104118501</time>
+</trkpt>
+<trkpt lat="55.9438994" lon="-4.3198527">
+<ele>119.1879271084996></ele>
+<accuracy>5.415</accuracy>
+<speed>1.4179885</speed>
+<bearing>150.85686</bearing>
+<bearingAccuracyDegrees>12.102994</bearingAccuracyDegrees>
+<time>1746104119577</time>
+</trkpt>
+<trkpt lat="55.9438871" lon="-4.3198404">
+<ele>119.17091402238093></ele>
+<accuracy>5.383</accuracy>
+<speed>1.4130063</speed>
+<bearing>152.46155</bearing>
+<bearingAccuracyDegrees>11.908573</bearingAccuracyDegrees>
+<time>1746104120583</time>
+</trkpt>
+<trkpt lat="55.9438767" lon="-4.3198287">
+<ele>119.05958223032418></ele>
+<accuracy>5.398</accuracy>
+<speed>1.3862919</speed>
+<bearing>152.94067</bearing>
+<bearingAccuracyDegrees>12.355998</bearingAccuracyDegrees>
+<time>1746104121604</time>
+</trkpt>
+<trkpt lat="55.9438684" lon="-4.3198172">
+<ele>118.98414795668168></ele>
+<accuracy>5.485</accuracy>
+<speed>1.3658184</speed>
+<bearing>153.29636</bearing>
+<bearingAccuracyDegrees>12.393012</bearingAccuracyDegrees>
+<time>1746104122588</time>
+</trkpt>
+<trkpt lat="55.9438607" lon="-4.3198042">
+<ele>119.05131108682438></ele>
+<accuracy>5.627</accuracy>
+<speed>1.3689971</speed>
+<bearing>150.88148</bearing>
+<bearingAccuracyDegrees>12.240652</bearingAccuracyDegrees>
+<time>1746104123591</time>
+</trkpt>
+<trkpt lat="55.943853" lon="-4.3197914">
+<ele>119.10751423757767></ele>
+<accuracy>5.864</accuracy>
+<speed>1.3589509</speed>
+<bearing>147.36412</bearing>
+<bearingAccuracyDegrees>12.804539</bearingAccuracyDegrees>
+<time>1746104124593</time>
+</trkpt>
+<trkpt lat="55.943845" lon="-4.3197789">
+<ele>119.09762986553744></ele>
+<accuracy>6.01</accuracy>
+<speed>1.3858166</speed>
+<bearing>147.15138</bearing>
+<bearingAccuracyDegrees>11.838779</bearingAccuracyDegrees>
+<time>1746104125509</time>
+</trkpt>
+<trkpt lat="55.9438346" lon="-4.3197661">
+<ele>119.03728341948717></ele>
+<accuracy>6.143</accuracy>
+<speed>1.4008064</speed>
+<bearing>145.9685</bearing>
+<bearingAccuracyDegrees>12.877205</bearingAccuracyDegrees>
+<time>1746104126509</time>
+</trkpt>
+<trkpt lat="55.9438233" lon="-4.3197524">
+<ele>119.03728341948717></ele>
+<accuracy>6.26</accuracy>
+<speed>1.4241784</speed>
+<bearing>143.9284</bearing>
+<bearingAccuracyDegrees>12.922652</bearingAccuracyDegrees>
+<time>1746104127509</time>
+</trkpt>
+<trkpt lat="55.9438105" lon="-4.3197316">
+<ele>119.0122488643459></ele>
+<accuracy>6.34</accuracy>
+<speed>1.4316933</speed>
+<bearing>148.14148</bearing>
+<bearingAccuracyDegrees>12.184607</bearingAccuracyDegrees>
+<time>1746104128602</time>
+</trkpt>
+<trkpt lat="55.9437991" lon="-4.3197171">
+<ele>118.99976349622126></ele>
+<accuracy>6.358</accuracy>
+<speed>1.455866</speed>
+<bearing>147.04887</bearing>
+<bearingAccuracyDegrees>12.355149</bearingAccuracyDegrees>
+<time>1746104129509</time>
+</trkpt>
+<trkpt lat="55.9437869" lon="-4.3197022">
+<ele>118.93109429553141></ele>
+<accuracy>6.369</accuracy>
+<speed>1.4718137</speed>
+<bearing>148.12213</bearing>
+<bearingAccuracyDegrees>12.620527</bearingAccuracyDegrees>
+<time>1746104130508</time>
+</trkpt>
+<trkpt lat="55.9437748" lon="-4.3196874">
+<ele>118.93213473387398></ele>
+<accuracy>6.348</accuracy>
+<speed>1.4814279</speed>
+<bearing>150.90863</bearing>
+<bearingAccuracyDegrees>12.5326605</bearingAccuracyDegrees>
+<time>1746104131509</time>
+</trkpt>
+<trkpt lat="55.9437623" lon="-4.3196761">
+<ele>118.93213473387398></ele>
+<accuracy>6.328</accuracy>
+<speed>1.4256842</speed>
+<bearing>150.23267</bearing>
+<bearingAccuracyDegrees>12.77429</bearingAccuracyDegrees>
+<time>1746104132511</time>
+</trkpt>
+<trkpt lat="55.9437485" lon="-4.3196648">
+<ele>118.88947686499455></ele>
+<accuracy>6.287</accuracy>
+<speed>1.4038393</speed>
+<bearing>150.3946</bearing>
+<bearingAccuracyDegrees>12.388018</bearingAccuracyDegrees>
+<time>1746104133514</time>
+</trkpt>
+<trkpt lat="55.9437347" lon="-4.3196527">
+<ele>118.87282994917214></ele>
+<accuracy>6.258</accuracy>
+<speed>1.3875175</speed>
+<bearing>151.90607</bearing>
+<bearingAccuracyDegrees>12.5991</bearingAccuracyDegrees>
+<time>1746104134516</time>
+</trkpt>
+<trkpt lat="55.9437208" lon="-4.3196393">
+<ele>118.75640415693105></ele>
+<accuracy>6.229</accuracy>
+<speed>1.3358651</speed>
+<bearing>149.41588</bearing>
+<bearingAccuracyDegrees>12.688228</bearingAccuracyDegrees>
+<time>1746104135462</time>
+</trkpt>
+<trkpt lat="55.9437065" lon="-4.3196257">
+<ele>118.71114581857628></ele>
+<accuracy>6.207</accuracy>
+<speed>1.3632426</speed>
+<bearing>149.06006</bearing>
+<bearingAccuracyDegrees>12.543856</bearingAccuracyDegrees>
+<time>1746104136484</time>
+</trkpt>
+<trkpt lat="55.9436921" lon="-4.3196166">
+<ele>118.6402750174788></ele>
+<accuracy>6.184</accuracy>
+<speed>1.4184924</speed>
+<bearing>151.03374</bearing>
+<bearingAccuracyDegrees>12.818381</bearingAccuracyDegrees>
+<time>1746104137504</time>
+</trkpt>
+<trkpt lat="55.943677" lon="-4.3196056">
+<ele>118.70637385657702></ele>
+<accuracy>6.208</accuracy>
+<speed>1.4324082</speed>
+<bearing>151.37442</bearing>
+<bearingAccuracyDegrees>12.444455</bearingAccuracyDegrees>
+<time>1746104138527</time>
+</trkpt>
+<trkpt lat="55.9436621" lon="-4.3195962">
+<ele>118.42451520651139></ele>
+<accuracy>6.235</accuracy>
+<speed>1.4438355</speed>
+<bearing>150.37955</bearing>
+<bearingAccuracyDegrees>12.454989</bearingAccuracyDegrees>
+<time>1746104139545</time>
+</trkpt>
+<trkpt lat="55.9436481" lon="-4.3195863">
+<ele>118.40994984063383></ele>
+<accuracy>6.213</accuracy>
+<speed>1.4097996</speed>
+<bearing>148.98836</bearing>
+<bearingAccuracyDegrees>12.264089</bearingAccuracyDegrees>
+<time>1746104140614</time>
+</trkpt>
+<trkpt lat="55.9436365" lon="-4.3195792">
+<ele>118.41827290382832></ele>
+<accuracy>6.18</accuracy>
+<speed>1.3928143</speed>
+<bearing>152.53252</bearing>
+<bearingAccuracyDegrees>12.085626</bearingAccuracyDegrees>
+<time>1746104141605</time>
+</trkpt>
+<trkpt lat="55.9436251" lon="-4.3195716">
+<ele>118.42763635955208></ele>
+<accuracy>6.143</accuracy>
+<speed>1.415219</speed>
+<bearing>155.56093</bearing>
+<bearingAccuracyDegrees>12.2187605</bearingAccuracyDegrees>
+<time>1746104142549</time>
+</trkpt>
+<trkpt lat="55.9436121" lon="-4.3195621">
+<ele>118.40936987029383></ele>
+<accuracy>6.076</accuracy>
+<speed>1.4379642</speed>
+<bearing>155.174</bearing>
+<bearingAccuracyDegrees>12.414632</bearingAccuracyDegrees>
+<time>1746104143549</time>
+</trkpt>
+<trkpt lat="55.9435997" lon="-4.3195508">
+<ele>118.26625487903155></ele>
+<accuracy>5.997</accuracy>
+<speed>1.4481604</speed>
+<bearing>154.86612</bearing>
+<bearingAccuracyDegrees>10.034072</bearingAccuracyDegrees>
+<time>1746104144549</time>
+</trkpt>
+<trkpt lat="55.9435841" lon="-4.3195348">
+<ele>118.2386848180798></ele>
+<accuracy>5.984</accuracy>
+<speed>1.4436995</speed>
+<bearing>155.2624</bearing>
+<bearingAccuracyDegrees>10.031415</bearingAccuracyDegrees>
+<time>1746104145548</time>
+</trkpt>
+<trkpt lat="55.9435683" lon="-4.3195178">
+<ele>118.16845959041433></ele>
+<accuracy>5.942</accuracy>
+<speed>1.4501265</speed>
+<bearing>152.60135</bearing>
+<bearingAccuracyDegrees>11.51113</bearingAccuracyDegrees>
+<time>1746104146549</time>
+</trkpt>
+<trkpt lat="55.9435545" lon="-4.3195029">
+<ele>118.2574750695002></ele>
+<accuracy>5.861</accuracy>
+<speed>1.4637911</speed>
+<bearing>150.57097</bearing>
+<bearingAccuracyDegrees>11.958446</bearingAccuracyDegrees>
+<time>1746104147549</time>
+</trkpt>
+<trkpt lat="55.943542" lon="-4.3194894">
+<ele>118.254353971586></ele>
+<accuracy>5.812</accuracy>
+<speed>1.4736031</speed>
+<bearing>151.37941</bearing>
+<bearingAccuracyDegrees>12.435254</bearingAccuracyDegrees>
+<time>1746104148549</time>
+</trkpt>
+<trkpt lat="55.9435299" lon="-4.3194747">
+<ele>118.18360938933787></ele>
+<accuracy>5.775</accuracy>
+<speed>1.4773123</speed>
+<bearing>149.16437</bearing>
+<bearingAccuracyDegrees>12.869861</bearingAccuracyDegrees>
+<time>1746104149551</time>
+</trkpt>
+<trkpt lat="55.943516" lon="-4.319463">
+<ele>118.1857153612536></ele>
+<accuracy>5.697</accuracy>
+<speed>1.4753045</speed>
+<bearing>152.20845</bearing>
+<bearingAccuracyDegrees>12.310614</bearingAccuracyDegrees>
+<time>1746104150553</time>
+</trkpt>
+<trkpt lat="55.9435008" lon="-4.3194535">
+<ele>118.17947326774461></ele>
+<accuracy>5.731</accuracy>
+<speed>1.4689504</speed>
+<bearing>154.14365</bearing>
+<bearingAccuracyDegrees>12.464462</bearingAccuracyDegrees>
+<time>1746104151555</time>
+</trkpt>
+<trkpt lat="55.9434879" lon="-4.319443">
+<ele>118.17843291926744></ele>
+<accuracy>5.776</accuracy>
+<speed>1.4734168</speed>
+<bearing>157.72894</bearing>
+<bearingAccuracyDegrees>12.823233</bearingAccuracyDegrees>
+<time>1746104152558</time>
+</trkpt>
+<trkpt lat="55.9434749" lon="-4.3194331">
+<ele>118.13681908335312></ele>
+<accuracy>5.862</accuracy>
+<speed>1.4633273</speed>
+<bearing>157.65785</bearing>
+<bearingAccuracyDegrees>12.477796</bearingAccuracyDegrees>
+<time>1746104153560</time>
+</trkpt>
+<trkpt lat="55.9434611" lon="-4.319423">
+<ele>118.14039755214421></ele>
+<accuracy>5.972</accuracy>
+<speed>1.4045684</speed>
+<bearing>152.25243</bearing>
+<bearingAccuracyDegrees>12.301383</bearingAccuracyDegrees>
+<time>1746104154561</time>
+</trkpt>
+<trkpt lat="55.9434472" lon="-4.3194116">
+<ele>118.4000015258789></ele>
+<accuracy>6.033</accuracy>
+<speed>1.4203687</speed>
+<bearing>149.3455</bearing>
+<bearingAccuracyDegrees>12.079165</bearingAccuracyDegrees>
+<time>1746104155464</time>
+</trkpt>
+<trkpt lat="55.9434299" lon="-4.3194019">
+<ele>118.4000015258789></ele>
+<accuracy>6.052</accuracy>
+<speed>1.4272146</speed>
+<bearing>151.79866</bearing>
+<bearingAccuracyDegrees>12.427736</bearingAccuracyDegrees>
+<time>1746104156440</time>
+</trkpt>
+<trkpt lat="55.9434152" lon="-4.3193922">
+<ele>118.4000015258789></ele>
+<accuracy>6.049</accuracy>
+<speed>1.4408187</speed>
+<bearing>155.33577</bearing>
+<bearingAccuracyDegrees>12.803455</bearingAccuracyDegrees>
+<time>1746104157445</time>
+</trkpt>
+<trkpt lat="55.9434027" lon="-4.3193819">
+<ele>118.4000015258789></ele>
+<accuracy>6.045</accuracy>
+<speed>1.4411565</speed>
+<bearing>151.97015</bearing>
+<bearingAccuracyDegrees>12.327764</bearingAccuracyDegrees>
+<time>1746104158445</time>
+</trkpt>
+<trkpt lat="55.9433905" lon="-4.3193696">
+<ele>118.4000015258789></ele>
+<accuracy>6.0</accuracy>
+<speed>1.4334979</speed>
+<bearing>153.52237</bearing>
+<bearingAccuracyDegrees>12.073198</bearingAccuracyDegrees>
+<time>1746104159487</time>
+</trkpt>
+<trkpt lat="55.9433744" lon="-4.3193602">
+<ele>117.85378793468828></ele>
+<accuracy>5.928</accuracy>
+<speed>1.4186025</speed>
+<bearing>154.55469</bearing>
+<bearingAccuracyDegrees>12.061492</bearingAccuracyDegrees>
+<time>1746104160523</time>
+</trkpt>
+<trkpt lat="55.9433621" lon="-4.3193523">
+<ele>117.79458566982606></ele>
+<accuracy>5.939</accuracy>
+<speed>1.3397828</speed>
+<bearing>151.74402</bearing>
+<bearingAccuracyDegrees>12.072087</bearingAccuracyDegrees>
+<time>1746104161465</time>
+</trkpt>
+<trkpt lat="55.9433512" lon="-4.3193415">
+<ele>117.63205455637426></ele>
+<accuracy>5.968</accuracy>
+<speed>1.3226683</speed>
+<bearing>152.20523</bearing>
+<bearingAccuracyDegrees>10.142371</bearingAccuracyDegrees>
+<time>1746104162423</time>
+</trkpt>
+<trkpt lat="55.9433367" lon="-4.3193289">
+<ele>117.93547582051619></ele>
+<accuracy>5.992</accuracy>
+<speed>1.464251</speed>
+<bearing>155.24614</bearing>
+<bearingAccuracyDegrees>12.29587</bearingAccuracyDegrees>
+<time>1746104163426</time>
+</trkpt>
+<trkpt lat="55.9433211" lon="-4.3193164">
+<ele>117.91154891699765></ele>
+<accuracy>6.015</accuracy>
+<speed>1.5589937</speed>
+<bearing>155.20177</bearing>
+<bearingAccuracyDegrees>11.840188</bearingAccuracyDegrees>
+<time>1746104164447</time>
+</trkpt>
+<trkpt lat="55.9433051" lon="-4.3193047">
+<ele>117.9105086183562></ele>
+<accuracy>6.043</accuracy>
+<speed>1.6023964</speed>
+<bearing>155.38307</bearing>
+<bearingAccuracyDegrees>10.473208</bearingAccuracyDegrees>
+<time>1746104165461</time>
+</trkpt>
+<trkpt lat="55.9432889" lon="-4.3192946">
+<ele>117.63357880878695></ele>
+<accuracy>6.063</accuracy>
+<speed>1.6025404</speed>
+<bearing>157.39534</bearing>
+<bearingAccuracyDegrees>11.567397</bearingAccuracyDegrees>
+<time>1746104166464</time>
+</trkpt>
+<trkpt lat="55.9432739" lon="-4.319285">
+<ele>117.90462049737911></ele>
+<accuracy>6.054</accuracy>
+<speed>1.5758847</speed>
+<bearing>154.90854</bearing>
+<bearingAccuracyDegrees>11.842595</bearingAccuracyDegrees>
+<time>1746104167445</time>
+</trkpt>
+<trkpt lat="55.9432595" lon="-4.3192719">
+<ele>117.73656898488326></ele>
+<accuracy>6.024</accuracy>
+<speed>1.5771589</speed>
+<bearing>149.70528</bearing>
+<bearingAccuracyDegrees>10.227725</bearingAccuracyDegrees>
+<time>1746104168467</time>
+</trkpt>
+<trkpt lat="55.9432464" lon="-4.3192585">
+<ele>117.73656898488326></ele>
+<accuracy>6.041</accuracy>
+<speed>1.5535266</speed>
+<bearing>149.46022</bearing>
+<bearingAccuracyDegrees>11.925355</bearingAccuracyDegrees>
+<time>1746104169461</time>
+</trkpt>
+<trkpt lat="55.9432324" lon="-4.3192448">
+<ele>117.65349210857713></ele>
+<accuracy>6.05</accuracy>
+<speed>1.5654753</speed>
+<bearing>153.00523</bearing>
+<bearingAccuracyDegrees>12.060245</bearingAccuracyDegrees>
+<time>1746104170482</time>
+</trkpt>
+<trkpt lat="55.9432191" lon="-4.3192329">
+<ele>117.6228031009311></ele>
+<accuracy>6.086</accuracy>
+<speed>1.5366105</speed>
+<bearing>152.11685</bearing>
+<bearingAccuracyDegrees>11.981538</bearingAccuracyDegrees>
+<time>1746104171532</time>
+</trkpt>
+<trkpt lat="55.943205" lon="-4.3192192">
+<ele>117.59263435270363></ele>
+<accuracy>6.116</accuracy>
+<speed>1.5424327</speed>
+<bearing>151.82726</bearing>
+<bearingAccuracyDegrees>10.2365055</bearingAccuracyDegrees>
+<time>1746104172549</time>
+</trkpt>
+<trkpt lat="55.9431904" lon="-4.3192054">
+<ele>117.46467842449468></ele>
+<accuracy>5.908</accuracy>
+<speed>1.5562775</speed>
+<bearing>151.0106</bearing>
+<bearingAccuracyDegrees>10.099012</bearingAccuracyDegrees>
+<time>1746104173606</time>
+</trkpt>
+<trkpt lat="55.943173" lon="-4.3191944">
+<ele>117.46467842449468></ele>
+<accuracy>5.338</accuracy>
+<speed>1.5544991</speed>
+<bearing>155.28937</bearing>
+<bearingAccuracyDegrees>10.057425</bearingAccuracyDegrees>
+<time>1746104174632</time>
+</trkpt>
+<trkpt lat="55.9431582" lon="-4.3191868">
+<ele>117.50535383481474></ele>
+<accuracy>4.945</accuracy>
+<speed>1.5509844</speed>
+<bearing>157.46034</bearing>
+<bearingAccuracyDegrees>9.93963</bearingAccuracyDegrees>
+<time>1746104175610</time>
+</trkpt>
+<trkpt lat="55.9431433" lon="-4.3191784">
+<ele>115.80000305175781></ele>
+<accuracy>4.32</accuracy>
+<speed>1.5412233</speed>
+<bearing>155.0239</bearing>
+<bearingAccuracyDegrees>9.445356</bearingAccuracyDegrees>
+<time>1746104176613</time>
+</trkpt>
+<trkpt lat="55.9431297" lon="-4.3191663">
+<ele>115.80000305175781></ele>
+<accuracy>3.522</accuracy>
+<speed>1.5390472</speed>
+<bearing>157.50714</bearing>
+<bearingAccuracyDegrees>9.946656</bearingAccuracyDegrees>
+<time>1746104177629</time>
+</trkpt>
+<trkpt lat="55.9431156" lon="-4.3191548">
+<ele>115.80000305175781></ele>
+<accuracy>3.458</accuracy>
+<speed>1.5618128</speed>
+<bearing>153.54451</bearing>
+<bearingAccuracyDegrees>10.008477</bearingAccuracyDegrees>
+<time>1746104178643</time>
+</trkpt>
+<trkpt lat="55.9431077" lon="-4.3191429">
+<ele>115.5></ele>
+<accuracy>3.562</accuracy>
+<speed>1.5608019</speed>
+<bearing>152.83992</bearing>
+<bearingAccuracyDegrees>10.015889</bearingAccuracyDegrees>
+<time>1746104179619</time>
+</trkpt>
+<trkpt lat="55.9430987" lon="-4.3191283">
+<ele>115.5></ele>
+<accuracy>3.71</accuracy>
+<speed>1.5532073</speed>
+<bearing>153.6411</bearing>
+<bearingAccuracyDegrees>10.375008</bearingAccuracyDegrees>
+<time>1746104180666</time>
+</trkpt>
+<trkpt lat="55.9430921" lon="-4.3191173">
+<ele>115.5></ele>
+<accuracy>3.973</accuracy>
+<speed>1.5244311</speed>
+<bearing>152.52026</bearing>
+<bearingAccuracyDegrees>11.812749</bearingAccuracyDegrees>
+<time>1746104181625</time>
+</trkpt>
+<trkpt lat="55.9430846" lon="-4.319106">
+<ele>115.5></ele>
+<accuracy>4.196</accuracy>
+<speed>1.5077703</speed>
+<bearing>150.65329</bearing>
+<bearingAccuracyDegrees>11.840376</bearingAccuracyDegrees>
+<time>1746104182627</time>
+</trkpt>
+<trkpt lat="55.9430784" lon="-4.3190932">
+<ele>116.2934675572038></ele>
+<accuracy>4.344</accuracy>
+<speed>1.5118015</speed>
+<bearing>148.44566</bearing>
+<bearingAccuracyDegrees>10.067324</bearingAccuracyDegrees>
+<time>1746104183630</time>
+</trkpt>
+<trkpt lat="55.9430703" lon="-4.3190849">
+<ele>116.21441885930324></ele>
+<accuracy>4.443</accuracy>
+<speed>1.5011224</speed>
+<bearing>148.2853</bearing>
+<bearingAccuracyDegrees>10.020738</bearingAccuracyDegrees>
+<time>1746104184631</time>
+</trkpt>
+<trkpt lat="55.9430627" lon="-4.3190687">
+<ele>116.1426515918105></ele>
+<accuracy>4.489</accuracy>
+<speed>1.4478668</speed>
+<bearing>144.57051</bearing>
+<bearingAccuracyDegrees>9.863462</bearingAccuracyDegrees>
+<time>1746104185634</time>
+</trkpt>
+<trkpt lat="55.9430561" lon="-4.319054">
+<ele>115.91897855363447></ele>
+<accuracy>4.373</accuracy>
+<speed>1.4248898</speed>
+<bearing>143.64847</bearing>
+<bearingAccuracyDegrees>9.601227</bearingAccuracyDegrees>
+<time>1746104186636</time>
+</trkpt>
+<trkpt lat="55.9430484" lon="-4.3190452">
+<ele>115.84603645315195></ele>
+<accuracy>4.178</accuracy>
+<speed>1.382763</speed>
+<bearing>146.11475</bearing>
+<bearingAccuracyDegrees>10.091482</bearingAccuracyDegrees>
+<time>1746104187639</time>
+</trkpt>
+<trkpt lat="55.9429658" lon="-4.3189721">
+<ele>115.5></ele>
+<accuracy>3.194</accuracy>
+<speed>1.4452406</speed>
+<bearing>151.8176</bearing>
+<bearingAccuracyDegrees>10.339326</bearingAccuracyDegrees>
+<time>1746104194409</time>
+</trkpt>
+<trkpt lat="55.9429408" lon="-4.3189633">
+<ele>115.5></ele>
+<accuracy>3.292</accuracy>
+<speed>1.5027213</speed>
+<bearing>158.11755</bearing>
+<bearingAccuracyDegrees>11.357351</bearingAccuracyDegrees>
+<time>1746104195419</time>
+</trkpt>
+<trkpt lat="55.9429139" lon="-4.3189493">
+<ele>115.5></ele>
+<accuracy>3.357</accuracy>
+<speed>1.6285123</speed>
+<bearing>161.01218</bearing>
+<bearingAccuracyDegrees>9.3911085</bearingAccuracyDegrees>
+<time>1746104196445</time>
+</trkpt>
+<trkpt lat="55.9428866" lon="-4.3189285">
+<ele>115.5></ele>
+<accuracy>3.405</accuracy>
+<speed>1.632746</speed>
+<bearing>159.973</bearing>
+<bearingAccuracyDegrees>9.633212</bearingAccuracyDegrees>
+<time>1746104197424</time>
+</trkpt>
+<trkpt lat="55.942858" lon="-4.3189038">
+<ele>115.5></ele>
+<accuracy>3.4</accuracy>
+<speed>1.6579322</speed>
+<bearing>159.29767</bearing>
+<bearingAccuracyDegrees>7.203596</bearingAccuracyDegrees>
+<time>1746104198469</time>
+</trkpt>
+<trkpt lat="55.9428312" lon="-4.318884">
+<ele>115.5></ele>
+<accuracy>3.345</accuracy>
+<speed>1.6899374</speed>
+<bearing>166.83904</bearing>
+<bearingAccuracyDegrees>6.4385676</bearingAccuracyDegrees>
+<time>1746104199462</time>
+</trkpt>
+<trkpt lat="55.9428068" lon="-4.3188754">
+<ele>115.5></ele>
+<accuracy>3.218</accuracy>
+<speed>1.6718906</speed>
+<bearing>177.73494</bearing>
+<bearingAccuracyDegrees>6.503471</bearingAccuracyDegrees>
+<time>1746104200484</time>
+</trkpt>
+<trkpt lat="55.942787" lon="-4.3188744">
+<ele>115.5></ele>
+<accuracy>3.131</accuracy>
+<speed>1.5918272</speed>
+<bearing>177.9523</bearing>
+<bearingAccuracyDegrees>6.736414</bearingAccuracyDegrees>
+<time>1746104201504</time>
+</trkpt>
+<trkpt lat="55.9427703" lon="-4.3188717">
+<ele>115.5></ele>
+<accuracy>3.073</accuracy>
+<speed>1.4955198</speed>
+<bearing>176.05449</bearing>
+<bearingAccuracyDegrees>7.1756725</bearingAccuracyDegrees>
+<time>1746104202547</time>
+</trkpt>
+<trkpt lat="55.9427583" lon="-4.3188693">
+<ele>115.5></ele>
+<accuracy>3.047</accuracy>
+<speed>1.3891226</speed>
+<bearing>175.116</bearing>
+<bearingAccuracyDegrees>9.109418</bearingAccuracyDegrees>
+<time>1746104203549</time>
+</trkpt>
+<trkpt lat="55.9427467" lon="-4.3188682">
+<ele>115.5></ele>
+<accuracy>3.042</accuracy>
+<speed>1.11947</speed>
+<bearing>177.78679</bearing>
+<bearingAccuracyDegrees>9.772132</bearingAccuracyDegrees>
+<time>1746104205081</time>
+</trkpt>
+<trkpt lat="55.9427377" lon="-4.3188699">
+<ele>115.5></ele>
+<accuracy>3.03</accuracy>
+<speed>1.1092712</speed>
+<bearing>176.3076</bearing>
+<bearingAccuracyDegrees>9.42735</bearingAccuracyDegrees>
+<time>1746104206083</time>
+</trkpt>
+<trkpt lat="55.9427264" lon="-4.318868">
+<ele>115.5></ele>
+<accuracy>3.024</accuracy>
+<speed>1.2764353</speed>
+<bearing>171.51591</bearing>
+<bearingAccuracyDegrees>9.72884</bearingAccuracyDegrees>
+<time>1746104207047</time>
+</trkpt>
+<trkpt lat="55.9427124" lon="-4.318859">
+<ele>115.5></ele>
+<accuracy>3.036</accuracy>
+<speed>1.4017504</speed>
+<bearing>161.95956</bearing>
+<bearingAccuracyDegrees>9.4072895</bearingAccuracyDegrees>
+<time>1746104208037</time>
+</trkpt>
+<trkpt lat="55.9426989" lon="-4.3188466">
+<ele>115.6761789507375></ele>
+<accuracy>3.066</accuracy>
+<speed>1.4215695</speed>
+<bearing>159.30559</bearing>
+<bearingAccuracyDegrees>9.999722</bearingAccuracyDegrees>
+<time>1746104209041</time>
+</trkpt>
+<trkpt lat="55.9426869" lon="-4.318834">
+<ele>115.7593829189512></ele>
+<accuracy>3.117</accuracy>
+<speed>1.3882786</speed>
+<bearing>155.51297</bearing>
+<bearingAccuracyDegrees>9.861185</bearingAccuracyDegrees>
+<time>1746104210043</time>
+</trkpt>
+<trkpt lat="55.942675" lon="-4.3188245">
+<ele>115.89095083653305></ele>
+<accuracy>3.162</accuracy>
+<speed>1.3945396</speed>
+<bearing>157.15906</bearing>
+<bearingAccuracyDegrees>9.821465</bearingAccuracyDegrees>
+<time>1746104211066</time>
+</trkpt>
+<trkpt lat="55.9426172" lon="-4.3187805">
+<ele>115.5></ele>
+<accuracy>3.13</accuracy>
+<speed>1.4322343</speed>
+<bearing>157.1541</bearing>
+<bearingAccuracyDegrees>10.08717</bearingAccuracyDegrees>
+<time>1746104215145</time>
+</trkpt>
+<trkpt lat="55.9426054" lon="-4.3187753">
+<ele>115.5></ele>
+<accuracy>3.061</accuracy>
+<speed>1.4282143</speed>
+<bearing>156.38202</bearing>
+<bearingAccuracyDegrees>9.897435</bearingAccuracyDegrees>
+<time>1746104216168</time>
+</trkpt>
+<trkpt lat="55.9425958" lon="-4.3187718">
+<ele>115.5></ele>
+<accuracy>3.067</accuracy>
+<speed>1.2944239</speed>
+<bearing>158.24368</bearing>
+<bearingAccuracyDegrees>10.344275</bearingAccuracyDegrees>
+<time>1746104217199</time>
+</trkpt>
+<trkpt lat="55.9425863" lon="-4.3187676">
+<ele>115.5></ele>
+<accuracy>3.115</accuracy>
+<speed>1.2516387</speed>
+<bearing>160.11359</bearing>
+<bearingAccuracyDegrees>10.100582</bearingAccuracyDegrees>
+<time>1746104218242</time>
+</trkpt>
+<trkpt lat="55.9425746" lon="-4.3187578">
+<ele>115.5></ele>
+<accuracy>3.151</accuracy>
+<speed>1.1822633</speed>
+<bearing>159.14844</bearing>
+<bearingAccuracyDegrees>9.557853</bearingAccuracyDegrees>
+<time>1746104219284</time>
+</trkpt>
+<trkpt lat="55.9425615" lon="-4.3187438">
+<ele>115.5></ele>
+<accuracy>3.17</accuracy>
+<speed>1.0922756</speed>
+<bearing>157.13405</bearing>
+<bearingAccuracyDegrees>9.631178</bearingAccuracyDegrees>
+<time>1746104220347</time>
+</trkpt>
+<trkpt lat="55.942549" lon="-4.3187307">
+<ele>115.5></ele>
+<accuracy>3.159</accuracy>
+<speed>1.0024123</speed>
+<bearing>153.11342</bearing>
+<bearingAccuracyDegrees>10.026821</bearingAccuracyDegrees>
+<time>1746104221360</time>
+</trkpt>
+<trkpt lat="55.9425349" lon="-4.3187171">
+<ele>115.5></ele>
+<accuracy>3.129</accuracy>
+<speed>0.97848547</speed>
+<bearing>151.38037</bearing>
+<bearingAccuracyDegrees>10.270738</bearingAccuracyDegrees>
+<time>1746104222383</time>
+</trkpt>
+<trkpt lat="55.9425223" lon="-4.3187008">
+<ele>115.5></ele>
+<accuracy>3.073</accuracy>
+<speed>0.96309173</speed>
+<bearing>148.63866</bearing>
+<bearingAccuracyDegrees>10.214207</bearingAccuracyDegrees>
+<time>1746104223405</time>
+</trkpt>
+<trkpt lat="55.9425125" lon="-4.3186852">
+<ele>115.5></ele>
+<accuracy>3.022</accuracy>
+<speed>0.9048892</speed>
+<bearing>146.77</bearing>
+<bearingAccuracyDegrees>12.064211</bearingAccuracyDegrees>
+<time>1746104224427</time>
+</trkpt>
+<trkpt lat="55.9425058" lon="-4.3186733">
+<ele>115.5></ele>
+<accuracy>3.0</accuracy>
+<speed>1.0212919</speed>
+<bearing>142.9382</bearing>
+<bearingAccuracyDegrees>12.568816</bearingAccuracyDegrees>
+<time>1746104225549</time>
+</trkpt>
+<trkpt lat="55.9424963" lon="-4.31866">
+<ele>115.5></ele>
+<accuracy>3.074</accuracy>
+<speed>0.9243954</speed>
+<bearing>146.96745</bearing>
+<bearingAccuracyDegrees>11.970842</bearingAccuracyDegrees>
+<time>1746104227003</time>
+</trkpt>
+<trkpt lat="55.9424823" lon="-4.3186417">
+<ele>115.5></ele>
+<accuracy>3.202</accuracy>
+<speed>1.2922927</speed>
+<bearing>146.81778</bearing>
+<bearingAccuracyDegrees>12.772566</bearingAccuracyDegrees>
+<time>1746104228045</time>
+</trkpt>
+<trkpt lat="55.9424682" lon="-4.3186222">
+<ele>113.7842425668371></ele>
+<accuracy>3.339</accuracy>
+<speed>1.3978488</speed>
+<bearing>144.2911</bearing>
+<bearingAccuracyDegrees>12.7866125</bearingAccuracyDegrees>
+<time>1746104229067</time>
+</trkpt>
+<trkpt lat="55.9424539" lon="-4.3186024">
+<ele>113.77020147310822></ele>
+<accuracy>3.548</accuracy>
+<speed>1.4236435</speed>
+<bearing>148.94824</bearing>
+<bearingAccuracyDegrees>12.780384</bearingAccuracyDegrees>
+<time>1746104230100</time>
+</trkpt>
+<trkpt lat="55.9424406" lon="-4.3185893">
+<ele>115.6824120341278></ele>
+<accuracy>3.882</accuracy>
+<speed>1.2123214</speed>
+<bearing>150.10738</bearing>
+<bearingAccuracyDegrees>12.928156</bearingAccuracyDegrees>
+<time>1746104231141</time>
+</trkpt>
+<trkpt lat="55.9424285" lon="-4.3185769">
+<ele>115.67045112051298></ele>
+<accuracy>4.146</accuracy>
+<speed>1.2056483</speed>
+<bearing>149.23375</bearing>
+<bearingAccuracyDegrees>12.740136</bearingAccuracyDegrees>
+<time>1746104232145</time>
+</trkpt>
+<trkpt lat="55.9424138" lon="-4.3185591">
+<ele>115.89396929295918></ele>
+<accuracy>4.439</accuracy>
+<speed>1.3598752</speed>
+<bearing>143.15904</bearing>
+<bearingAccuracyDegrees>12.675929</bearingAccuracyDegrees>
+<time>1746104233186</time>
+</trkpt>
+<trkpt lat="55.9424006" lon="-4.3185412">
+<ele>115.65400356896319></ele>
+<accuracy>4.677</accuracy>
+<speed>1.4114143</speed>
+<bearing>140.57207</bearing>
+<bearingAccuracyDegrees>12.435188</bearingAccuracyDegrees>
+<time>1746104234200</time>
+</trkpt>
+<trkpt lat="55.9423866" lon="-4.318523">
+<ele>115.37775316668734></ele>
+<accuracy>4.868</accuracy>
+<speed>1.4617206</speed>
+<bearing>141.60109</bearing>
+<bearingAccuracyDegrees>11.979575</bearingAccuracyDegrees>
+<time>1746104235222</time>
+</trkpt>
+<trkpt lat="55.9423706" lon="-4.3185048">
+<ele>115.36475240790134></ele>
+<accuracy>5.159</accuracy>
+<speed>1.4750654</speed>
+<bearing>147.75699</bearing>
+<bearingAccuracyDegrees>12.245744</bearingAccuracyDegrees>
+<time>1746104236285</time>
+</trkpt>
+<trkpt lat="55.942356" lon="-4.3184895">
+<ele>115.3569519620639></ele>
+<accuracy>5.322</accuracy>
+<speed>1.4502717</speed>
+<bearing>151.18988</bearing>
+<bearingAccuracyDegrees>12.572962</bearingAccuracyDegrees>
+<time>1746104237306</time>
+</trkpt>
+<trkpt lat="55.9423427" lon="-4.3184732">
+<ele>115.32419016680913></ele>
+<accuracy>5.46</accuracy>
+<speed>1.4429755</speed>
+<bearing>150.13228</bearing>
+<bearingAccuracyDegrees>12.867378</bearingAccuracyDegrees>
+<time>1746104238341</time>
+</trkpt>
+<trkpt lat="55.9423301" lon="-4.3184569">
+<ele>115.2357859452357></ele>
+<accuracy>5.581</accuracy>
+<speed>1.4349787</speed>
+<bearing>145.29742</bearing>
+<bearingAccuracyDegrees>12.818391</bearingAccuracyDegrees>
+<time>1746104239383</time>
+</trkpt>
+<trkpt lat="55.9423184" lon="-4.3184389">
+<ele>114.31695565804765></ele>
+<accuracy>5.69</accuracy>
+<speed>1.4672</speed>
+<bearing>141.4142</bearing>
+<bearingAccuracyDegrees>12.89702</bearingAccuracyDegrees>
+<time>1746104240404</time>
+</trkpt>
+<trkpt lat="55.9423034" lon="-4.3184219">
+<ele>115.66448701929394></ele>
+<accuracy>5.794</accuracy>
+<speed>1.4752401</speed>
+<bearing>146.03955</bearing>
+<bearingAccuracyDegrees>13.003632</bearingAccuracyDegrees>
+<time>1746104241446</time>
+</trkpt>
+<trkpt lat="55.9422875" lon="-4.3184069">
+<ele>115.62496569121186></ele>
+<accuracy>5.902</accuracy>
+<speed>1.4861813</speed>
+<bearing>145.26308</bearing>
+<bearingAccuracyDegrees>12.906744</bearingAccuracyDegrees>
+<time>1746104242469</time>
+</trkpt>
+<trkpt lat="55.942223" lon="-4.3183517">
+<ele>115.3411856398059></ele>
+<accuracy>5.95</accuracy>
+<speed>1.4766742</speed>
+<bearing>150.00056</bearing>
+<bearingAccuracyDegrees>13.090158</bearingAccuracyDegrees>
+<time>1746104246664</time>
+</trkpt>
+<trkpt lat="55.9422125" lon="-4.3183418">
+<ele>114.35477902810116></ele>
+<accuracy>5.886</accuracy>
+<speed>1.4479759</speed>
+<bearing>152.68245</bearing>
+<bearingAccuracyDegrees>12.536268</bearingAccuracyDegrees>
+<time>1746104247576</time>
+</trkpt>
+<trkpt lat="55.9422023" lon="-4.3183343">
+<ele>114.35477902810116></ele>
+<accuracy>5.706</accuracy>
+<speed>1.2825415</speed>
+<bearing>156.63731</bearing>
+<bearingAccuracyDegrees>12.651584</bearingAccuracyDegrees>
+<time>1746104248580</time>
+</trkpt>
+<trkpt lat="55.9421888" lon="-4.3183303">
+<ele>114.35737911696823></ele>
+<accuracy>5.511</accuracy>
+<speed>1.371691</speed>
+<bearing>158.6431</bearing>
+<bearingAccuracyDegrees>9.775697</bearingAccuracyDegrees>
+<time>1746104249589</time>
+</trkpt>
+<trkpt lat="55.9421742" lon="-4.3183242">
+<ele>114.34021854497018></ele>
+<accuracy>5.393</accuracy>
+<speed>1.4145561</speed>
+<bearing>158.67526</bearing>
+<bearingAccuracyDegrees>9.957539</bearingAccuracyDegrees>
+<time>1746104250588</time>
+</trkpt>
+<trkpt lat="55.9421583" lon="-4.3183166">
+<ele>114.2980972861499></ele>
+<accuracy>5.307</accuracy>
+<speed>1.4264469</speed>
+<bearing>160.76358</bearing>
+<bearingAccuracyDegrees>9.687763</bearingAccuracyDegrees>
+<time>1746104251587</time>
+</trkpt>
+<trkpt lat="55.9421408" lon="-4.3183069">
+<ele>114.2980972861499></ele>
+<accuracy>5.26</accuracy>
+<speed>1.5283164</speed>
+<bearing>163.93085</bearing>
+<bearingAccuracyDegrees>9.719145</bearingAccuracyDegrees>
+<time>1746104252589</time>
+</trkpt>
+<trkpt lat="55.9421215" lon="-4.3182999">
+<ele>114.2980972861499></ele>
+<accuracy>5.21</accuracy>
+<speed>1.5555959</speed>
+<bearing>168.19144</bearing>
+<bearingAccuracyDegrees>9.679248</bearingAccuracyDegrees>
+<time>1746104253591</time>
+</trkpt>
+<trkpt lat="55.9421031" lon="-4.3182953">
+<ele>114.2980972861499></ele>
+<accuracy>5.216</accuracy>
+<speed>1.5293854</speed>
+<bearing>167.71594</bearing>
+<bearingAccuracyDegrees>9.433411</bearingAccuracyDegrees>
+<time>1746104254593</time>
+</trkpt>
+<trkpt lat="55.942087" lon="-4.3182932">
+<ele>113.3442991905903></ele>
+<accuracy>5.229</accuracy>
+<speed>1.4805238</speed>
+<bearing>170.44516</bearing>
+<bearingAccuracyDegrees>9.665345</bearingAccuracyDegrees>
+<time>1746104255596</time>
+</trkpt>
+<trkpt lat="55.9420741" lon="-4.3182936">
+<ele>113.3442991905903></ele>
+<accuracy>5.205</accuracy>
+<speed>1.4648788</speed>
+<bearing>175.03537</bearing>
+<bearingAccuracyDegrees>9.799187</bearingAccuracyDegrees>
+<time>1746104256598</time>
+</trkpt>
+<trkpt lat="55.9420629" lon="-4.3182978">
+<ele>113.34533921931285></ele>
+<accuracy>5.148</accuracy>
+<speed>1.273862</speed>
+<bearing>180.35332</bearing>
+<bearingAccuracyDegrees>10.2894745</bearingAccuracyDegrees>
+<time>1746104257600</time>
+</trkpt>
+<trkpt lat="55.9420524" lon="-4.3182979">
+<ele>113.9000015258789></ele>
+<accuracy>5.08</accuracy>
+<speed>1.1937547</speed>
+<bearing>181.62228</bearing>
+<bearingAccuracyDegrees>10.150748</bearingAccuracyDegrees>
+<time>1746104258503</time>
+</trkpt>
+<trkpt lat="55.9420375" lon="-4.3182991">
+<ele>113.9000015258789></ele>
+<accuracy>5.067</accuracy>
+<speed>1.34668</speed>
+<bearing>187.88594</bearing>
+<bearingAccuracyDegrees>9.952796</bearingAccuracyDegrees>
+<time>1746104259505</time>
+</trkpt>
+<trkpt lat="55.94202" lon="-4.3183059">
+<ele>113.9000015258789></ele>
+<accuracy>5.04</accuracy>
+<speed>1.4917989</speed>
+<bearing>193.25189</bearing>
+<bearingAccuracyDegrees>9.904882</bearingAccuracyDegrees>
+<time>1746104260507</time>
+</trkpt>
+<trkpt lat="55.9420014" lon="-4.3183137">
+<ele>113.9000015258789></ele>
+<accuracy>5.007</accuracy>
+<speed>1.490476</speed>
+<bearing>194.66733</bearing>
+<bearingAccuracyDegrees>10.050828</bearingAccuracyDegrees>
+<time>1746104261589</time>
+</trkpt>
+<trkpt lat="55.9419846" lon="-4.3183156">
+<ele>113.9000015258789></ele>
+<accuracy>5.041</accuracy>
+<speed>1.5064582</speed>
+<bearing>164.67763</bearing>
+<bearingAccuracyDegrees>10.036656</bearingAccuracyDegrees>
+<time>1746104262589</time>
+</trkpt>
+<trkpt lat="55.9419682" lon="-4.3183074">
+<ele>113.9000015258789></ele>
+<accuracy>5.05</accuracy>
+<speed>1.5202506</speed>
+<bearing>165.3684</bearing>
+<bearingAccuracyDegrees>12.060504</bearingAccuracyDegrees>
+<time>1746104263589</time>
+</trkpt>
+<trkpt lat="55.9419516" lon="-4.3183078">
+<ele>113.9000015258789></ele>
+<accuracy>5.056</accuracy>
+<speed>1.5331076</speed>
+<bearing>182.1167</bearing>
+<bearingAccuracyDegrees>12.357142</bearingAccuracyDegrees>
+<time>1746104264516</time>
+</trkpt>
+<trkpt lat="55.9419353" lon="-4.3183137">
+<ele>113.9000015258789></ele>
+<accuracy>5.073</accuracy>
+<speed>1.5296953</speed>
+<bearing>190.80878</bearing>
+<bearingAccuracyDegrees>12.174372</bearingAccuracyDegrees>
+<time>1746104265463</time>
+</trkpt>
+<trkpt lat="55.9419188" lon="-4.3183242">
+<ele>113.9000015258789></ele>
+<accuracy>5.111</accuracy>
+<speed>1.537089</speed>
+<bearing>194.59396</bearing>
+<bearingAccuracyDegrees>11.751588</bearingAccuracyDegrees>
+<time>1746104266464</time>
+</trkpt>
+<trkpt lat="55.9419021" lon="-4.3183374">
+<ele>113.9000015258789></ele>
+<accuracy>5.137</accuracy>
+<speed>1.5132008</speed>
+<bearing>194.849</bearing>
+<bearingAccuracyDegrees>11.571379</bearingAccuracyDegrees>
+<time>1746104267504</time>
+</trkpt>
+<trkpt lat="55.9418868" lon="-4.3183485">
+<ele>113.9000015258789></ele>
+<accuracy>5.125</accuracy>
+<speed>1.4681773</speed>
+<bearing>199.93538</bearing>
+<bearingAccuracyDegrees>10.210972</bearingAccuracyDegrees>
+<time>1746104268550</time>
+</trkpt>
+<trkpt lat="55.9418727" lon="-4.3183593">
+<ele>113.9000015258789></ele>
+<accuracy>5.105</accuracy>
+<speed>1.4633949</speed>
+<bearing>194.04723</bearing>
+<bearingAccuracyDegrees>10.083346</bearingAccuracyDegrees>
+<time>1746104269547</time>
+</trkpt>
+<trkpt lat="55.9418591" lon="-4.3183588">
+<ele>113.9000015258789></ele>
+<accuracy>5.068</accuracy>
+<speed>1.3953949</speed>
+<bearing>160.92769</bearing>
+<bearingAccuracyDegrees>11.764039</bearingAccuracyDegrees>
+<time>1746104270631</time>
+</trkpt>
+<trkpt lat="55.9418443" lon="-4.3183492">
+<ele>114.76331704057984></ele>
+<accuracy>4.323</accuracy>
+<speed>1.3602158</speed>
+<bearing>170.04956</bearing>
+<bearingAccuracyDegrees>10.513668</bearingAccuracyDegrees>
+<time>1746104272290</time>
+</trkpt>
+<trkpt lat="55.9418311" lon="-4.318347">
+<ele>114.76331704057984></ele>
+<accuracy>3.948</accuracy>
+<speed>1.3990461</speed>
+<bearing>176.33281</bearing>
+<bearingAccuracyDegrees>11.859665</bearingAccuracyDegrees>
+<time>1746104273361</time>
+</trkpt>
+<trkpt lat="55.9418153" lon="-4.3183422">
+<ele>114.63591673813534></ele>
+<accuracy>3.581</accuracy>
+<speed>1.446429</speed>
+<bearing>179.42255</bearing>
+<bearingAccuracyDegrees>10.361498</bearingAccuracyDegrees>
+<time>1746104274343</time>
+</trkpt>
+<trkpt lat="55.9418001" lon="-4.3183416">
+<ele>112.81098955826116></ele>
+<accuracy>3.21</accuracy>
+<speed>1.4372004</speed>
+<bearing>184.53705</bearing>
+<bearingAccuracyDegrees>11.580048</bearingAccuracyDegrees>
+<time>1746104275385</time>
+</trkpt>
+<trkpt lat="55.9417867" lon="-4.3183404">
+<ele>112.61547543650437></ele>
+<accuracy>3.061</accuracy>
+<speed>1.4489197</speed>
+<bearing>183.28546</bearing>
+<bearingAccuracyDegrees>11.584296</bearingAccuracyDegrees>
+<time>1746104276364</time>
+</trkpt>
+<trkpt lat="55.9417773" lon="-4.3183401">
+<ele>112.51356026306789></ele>
+<accuracy>3.004</accuracy>
+<speed>1.2409168</speed>
+<bearing>181.01224</bearing>
+<bearingAccuracyDegrees>12.322176</bearingAccuracyDegrees>
+<time>1746104277547</time>
+</trkpt>
+<trkpt lat="55.9417664" lon="-4.3183372">
+<ele>112.52219582935109></ele>
+<accuracy>3.001</accuracy>
+<speed>0.8724021</speed>
+<bearing>173.91728</bearing>
+<bearingAccuracyDegrees>9.856289</bearingAccuracyDegrees>
+<time>1746104279404</time>
+</trkpt>
+<trkpt lat="55.9417561" lon="-4.3183354">
+<ele>112.44004181135223></ele>
+<accuracy>3.001</accuracy>
+<speed>0.7622275</speed>
+<bearing>171.29234</bearing>
+<bearingAccuracyDegrees>10.186356</bearingAccuracyDegrees>
+<time>1746104280947</time>
+</trkpt>
+<trkpt lat="55.9417465" lon="-4.3183338">
+<ele>112.38700609000757></ele>
+<accuracy>3.0</accuracy>
+<speed>0.8206168</speed>
+<bearing>170.8072</bearing>
+<bearingAccuracyDegrees>10.045809</bearingAccuracyDegrees>
+<time>1746104281983</time>
+</trkpt>
+<trkpt lat="55.9417323" lon="-4.3183312">
+<ele>112.44004181135223></ele>
+<accuracy>3.0</accuracy>
+<speed>0.9535552</speed>
+<bearing>167.55743</bearing>
+<bearingAccuracyDegrees>10.340026</bearingAccuracyDegrees>
+<time>1746104283041</time>
+</trkpt>
+<trkpt lat="55.9417138" lon="-4.3183243">
+<ele>112.46551987222205></ele>
+<accuracy>3.0</accuracy>
+<speed>1.239517</speed>
+<bearing>164.33353</bearing>
+<bearingAccuracyDegrees>9.684957</bearingAccuracyDegrees>
+<time>1746104284097</time>
+</trkpt>
+<trkpt lat="55.9416958" lon="-4.3183164">
+<ele>113.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3101488</speed>
+<bearing>155.82124</bearing>
+<bearingAccuracyDegrees>9.221452</bearingAccuracyDegrees>
+<time>1746104285148</time>
+</trkpt>
+<trkpt lat="55.9416805" lon="-4.3183051">
+<ele>113.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.1644001</speed>
+<bearing>132.61433</bearing>
+<bearingAccuracyDegrees>8.775517</bearingAccuracyDegrees>
+<time>1746104286200</time>
+</trkpt>
+<trkpt lat="55.9416726" lon="-4.3182882">
+<ele>113.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.140895</speed>
+<bearing>102.48177</bearing>
+<bearingAccuracyDegrees>9.287701</bearingAccuracyDegrees>
+<time>1746104287589</time>
+</trkpt>
+<trkpt lat="55.9416479" lon="-4.3181997">
+<ele>113.9000015258789></ele>
+<accuracy>3.054</accuracy>
+<speed>1.3355509</speed>
+<bearing>111.94209</bearing>
+<bearingAccuracyDegrees>9.604235</bearingAccuracyDegrees>
+<time>1746104293589</time>
+</trkpt>
+<trkpt lat="55.9416404" lon="-4.3181831">
+<ele>113.9000015258789></ele>
+<accuracy>3.064</accuracy>
+<speed>1.2432145</speed>
+<bearing>116.856</bearing>
+<bearingAccuracyDegrees>9.332604</bearingAccuracyDegrees>
+<time>1746104294586</time>
+</trkpt>
+<trkpt lat="55.9416319" lon="-4.318167">
+<ele>113.9000015258789></ele>
+<accuracy>3.073</accuracy>
+<speed>1.296367</speed>
+<bearing>128.64839</bearing>
+<bearingAccuracyDegrees>9.900982</bearingAccuracyDegrees>
+<time>1746104295588</time>
+</trkpt>
+<trkpt lat="55.9416221" lon="-4.3181535">
+<ele>112.51720006989257></ele>
+<accuracy>3.102</accuracy>
+<speed>1.3519549</speed>
+<bearing>135.36543</bearing>
+<bearingAccuracyDegrees>10.12862</bearingAccuracyDegrees>
+<time>1746104296504</time>
+</trkpt>
+<trkpt lat="55.9416118" lon="-4.3181421">
+<ele>112.52759952645621></ele>
+<accuracy>3.167</accuracy>
+<speed>1.3413502</speed>
+<bearing>141.41214</bearing>
+<bearingAccuracyDegrees>11.625429</bearingAccuracyDegrees>
+<time>1746104297647</time>
+</trkpt>
+<trkpt lat="55.9416032" lon="-4.3181317">
+<ele>112.84270902366154></ele>
+<accuracy>3.22</accuracy>
+<speed>1.369471</speed>
+<bearing>144.87502</bearing>
+<bearingAccuracyDegrees>10.541681</bearingAccuracyDegrees>
+<time>1746104298595</time>
+</trkpt>
+<trkpt lat="55.9415906" lon="-4.3181108">
+<ele>112.96906805534122></ele>
+<accuracy>3.246</accuracy>
+<speed>1.3503199</speed>
+<bearing>139.84612</bearing>
+<bearingAccuracyDegrees>11.889818</bearingAccuracyDegrees>
+<time>1746104299598</time>
+</trkpt>
+<trkpt lat="55.9415798" lon="-4.3180848">
+<ele>113.1859107204011></ele>
+<accuracy>3.268</accuracy>
+<speed>1.3770368</speed>
+<bearing>140.30127</bearing>
+<bearingAccuracyDegrees>11.721831</bearingAccuracyDegrees>
+<time>1746104300499</time>
+</trkpt>
+<trkpt lat="55.9415695" lon="-4.3180564">
+<ele>113.28471374786768></ele>
+<accuracy>3.277</accuracy>
+<speed>1.379716</speed>
+<bearing>142.14331</bearing>
+<bearingAccuracyDegrees>11.731137</bearingAccuracyDegrees>
+<time>1746104301501</time>
+</trkpt>
+<trkpt lat="55.9415592" lon="-4.3180277">
+<ele>113.28471374786768></ele>
+<accuracy>3.275</accuracy>
+<speed>1.4304208</speed>
+<bearing>141.21858</bearing>
+<bearingAccuracyDegrees>9.65115</bearingAccuracyDegrees>
+<time>1746104302447</time>
+</trkpt>
+<trkpt lat="55.9415477" lon="-4.3179962">
+<ele>113.53952679420459></ele>
+<accuracy>3.221</accuracy>
+<speed>1.47957</speed>
+<bearing>138.86026</bearing>
+<bearingAccuracyDegrees>10.014361</bearingAccuracyDegrees>
+<time>1746104303520</time>
+</trkpt>
+<trkpt lat="55.9415341" lon="-4.3179649">
+<ele>113.93921616120765></ele>
+<accuracy>3.234</accuracy>
+<speed>1.3913497</speed>
+<bearing>139.6966</bearing>
+<bearingAccuracyDegrees>9.24887</bearingAccuracyDegrees>
+<time>1746104304603</time>
+</trkpt>
+<trkpt lat="55.9415206" lon="-4.3179385">
+<ele>114.07963088968087></ele>
+<accuracy>3.233</accuracy>
+<speed>1.3803029</speed>
+<bearing>147.8808</bearing>
+<bearingAccuracyDegrees>9.045283</bearingAccuracyDegrees>
+<time>1746104305611</time>
+</trkpt>
+<trkpt lat="55.9414924" lon="-4.3179037">
+<ele>114.23213848757402></ele>
+<accuracy>3.127</accuracy>
+<speed>1.3336594</speed>
+<bearing>189.0146</bearing>
+<bearingAccuracyDegrees>9.03046</bearingAccuracyDegrees>
+<time>1746104307616</time>
+</trkpt>
+<trkpt lat="55.9414821" lon="-4.3179007">
+<ele>114.32783266229711></ele>
+<accuracy>3.1</accuracy>
+<speed>1.2239801</speed>
+<bearing>206.58444</bearing>
+<bearingAccuracyDegrees>10.018121</bearingAccuracyDegrees>
+<time>1746104309544</time>
+</trkpt>
+<trkpt lat="55.9414717" lon="-4.3179111">
+<ele>113.9000015258789></ele>
+<accuracy>3.133</accuracy>
+<speed>1.2246039</speed>
+<bearing>191.47017</bearing>
+<bearingAccuracyDegrees>9.657447</bearingAccuracyDegrees>
+<time>1746104312261</time>
+</trkpt>
+<trkpt lat="55.9414339" lon="-4.3179058">
+<ele>113.9000015258789></ele>
+<accuracy>3.423</accuracy>
+<speed>1.2957735</speed>
+<bearing>167.27724</bearing>
+<bearingAccuracyDegrees>11.873091</bearingAccuracyDegrees>
+<time>1746104315387</time>
+</trkpt>
+<trkpt lat="55.9414227" lon="-4.3179055">
+<ele>113.9000015258789></ele>
+<accuracy>3.612</accuracy>
+<speed>1.3039126</speed>
+<bearing>182.94269</bearing>
+<bearingAccuracyDegrees>12.07764</bearingAccuracyDegrees>
+<time>1746104316382</time>
+</trkpt>
+<trkpt lat="55.9414104" lon="-4.3179132">
+<ele>113.9000015258789></ele>
+<accuracy>3.91</accuracy>
+<speed>1.3145608</speed>
+<bearing>194.83742</bearing>
+<bearingAccuracyDegrees>12.001284</bearingAccuracyDegrees>
+<time>1746104317424</time>
+</trkpt>
+<trkpt lat="55.9413726" lon="-4.3179529">
+<ele>113.9000015258789></ele>
+<accuracy>4.559</accuracy>
+<speed>1.3959557</speed>
+<bearing>197.80392</bearing>
+<bearingAccuracyDegrees>11.75115</bearingAccuracyDegrees>
+<time>1746104320474</time>
+</trkpt>
+<trkpt lat="55.9413596" lon="-4.3179683">
+<ele>113.9000015258789></ele>
+<accuracy>4.772</accuracy>
+<speed>1.4155217</speed>
+<bearing>202.12146</bearing>
+<bearingAccuracyDegrees>10.437392</bearingAccuracyDegrees>
+<time>1746104321501</time>
+</trkpt>
+<trkpt lat="55.9413035" lon="-4.3180263">
+<ele>114.60410295446044></ele>
+<accuracy>5.28</accuracy>
+<speed>1.4433783</speed>
+<bearing>207.87704</bearing>
+<bearingAccuracyDegrees>11.711943</bearingAccuracyDegrees>
+<time>1746104325560</time>
+</trkpt>
+<trkpt lat="55.9412523" lon="-4.3180849">
+<ele>114.90132458795918></ele>
+<accuracy>5.222</accuracy>
+<speed>1.4955178</speed>
+<bearing>216.81078</bearing>
+<bearingAccuracyDegrees>12.2418585</bearingAccuracyDegrees>
+<time>1746104329567</time>
+</trkpt>
+<trkpt lat="55.9412426" lon="-4.3181039">
+<ele>114.96685956954235></ele>
+<accuracy>5.218</accuracy>
+<speed>1.4897203</speed>
+<bearing>221.00778</bearing>
+<bearingAccuracyDegrees>11.762516</bearingAccuracyDegrees>
+<time>1746104330569</time>
+</trkpt>
+<trkpt lat="55.9412137" lon="-4.3181591">
+<ele>114.96547429475078></ele>
+<accuracy>5.317</accuracy>
+<speed>1.4528418</speed>
+<bearing>217.14616</bearing>
+<bearingAccuracyDegrees>12.187539</bearingAccuracyDegrees>
+<time>1746104333575</time>
+</trkpt>
+<trkpt lat="55.9412037" lon="-4.3181744">
+<ele>115.07092008276274></ele>
+<accuracy>5.414</accuracy>
+<speed>1.4400418</speed>
+<bearing>218.56297</bearing>
+<bearingAccuracyDegrees>12.499308</bearingAccuracyDegrees>
+<time>1746104334578</time>
+</trkpt>
+<trkpt lat="55.9411935" lon="-4.3181878">
+<ele>115.03777106909338></ele>
+<accuracy>5.5</accuracy>
+<speed>1.4668931</speed>
+<bearing>219.3228</bearing>
+<bearingAccuracyDegrees>12.028191</bearingAccuracyDegrees>
+<time>1746104335581</time>
+</trkpt>
+<trkpt lat="55.9411239" lon="-4.3183688">
+<ele>112.06356180120099></ele>
+<accuracy>5.716</accuracy>
+<speed>1.4788907</speed>
+<bearing>230.92976</bearing>
+<bearingAccuracyDegrees>10.075728</bearingAccuracyDegrees>
+<time>1746104343499</time>
+</trkpt>
+<trkpt lat="55.9411158" lon="-4.3183916">
+<ele>112.06356180120099></ele>
+<accuracy>5.679</accuracy>
+<speed>1.4984069</speed>
+<bearing>231.04887</bearing>
+<bearingAccuracyDegrees>9.94127</bearingAccuracyDegrees>
+<time>1746104344404</time>
+</trkpt>
+<trkpt lat="55.9411058" lon="-4.3184164">
+<ele>112.06356180120099></ele>
+<accuracy>5.593</accuracy>
+<speed>1.5271846</speed>
+<bearing>231.64548</bearing>
+<bearingAccuracyDegrees>9.999291</bearingAccuracyDegrees>
+<time>1746104345407</time>
+</trkpt>
+<trkpt lat="55.9410953" lon="-4.318441">
+<ele>112.12064079296894></ele>
+<accuracy>5.462</accuracy>
+<speed>1.526271</speed>
+<bearing>232.89253</bearing>
+<bearingAccuracyDegrees>9.683823</bearingAccuracyDegrees>
+<time>1746104346428</time>
+</trkpt>
+<trkpt lat="55.9410858" lon="-4.3184668">
+<ele>111.70802930496387></ele>
+<accuracy>5.392</accuracy>
+<speed>1.5233881</speed>
+<bearing>238.15863</bearing>
+<bearingAccuracyDegrees>10.461479</bearingAccuracyDegrees>
+<time>1746104347441</time>
+</trkpt>
+<trkpt lat="55.9410765" lon="-4.3184919">
+<ele>112.23663119550224></ele>
+<accuracy>5.366</accuracy>
+<speed>1.5348805</speed>
+<bearing>239.8236</bearing>
+<bearingAccuracyDegrees>9.937497</bearingAccuracyDegrees>
+<time>1746104348485</time>
+</trkpt>
+<trkpt lat="55.9410666" lon="-4.318516">
+<ele>111.80113420617114></ele>
+<accuracy>5.403</accuracy>
+<speed>1.5378782</speed>
+<bearing>239.0645</bearing>
+<bearingAccuracyDegrees>10.324412</bearingAccuracyDegrees>
+<time>1746104349508</time>
+</trkpt>
+<trkpt lat="55.9410553" lon="-4.3185398">
+<ele>111.8359837859868></ele>
+<accuracy>5.479</accuracy>
+<speed>1.5287603</speed>
+<bearing>239.8561</bearing>
+<bearingAccuracyDegrees>11.8472185</bearingAccuracyDegrees>
+<time>1746104350570</time>
+</trkpt>
+<trkpt lat="55.9410436" lon="-4.318562">
+<ele>112.18974535231959></ele>
+<accuracy>5.551</accuracy>
+<speed>1.5270538</speed>
+<bearing>236.07747</bearing>
+<bearingAccuracyDegrees>11.752707</bearingAccuracyDegrees>
+<time>1746104351603</time>
+</trkpt>
+<trkpt lat="55.9410324" lon="-4.3185797">
+<ele>112.34868341558922></ele>
+<accuracy>5.624</accuracy>
+<speed>1.520794</speed>
+<bearing>232.08374</bearing>
+<bearingAccuracyDegrees>10.045035</bearingAccuracyDegrees>
+<time>1746104352520</time>
+</trkpt>
+<trkpt lat="55.9410182" lon="-4.3185985">
+<ele>112.42982784834895></ele>
+<accuracy>5.619</accuracy>
+<speed>1.5272528</speed>
+<bearing>226.02643</bearing>
+<bearingAccuracyDegrees>9.92676</bearingAccuracyDegrees>
+<time>1746104353522</time>
+</trkpt>
+<trkpt lat="55.9409976" lon="-4.3186104">
+<ele>112.22214574558245></ele>
+<accuracy>5.263</accuracy>
+<speed>1.5141171</speed>
+<bearing>223.3518</bearing>
+<bearingAccuracyDegrees>9.551638</bearingAccuracyDegrees>
+<time>1746104354525</time>
+</trkpt>
+<trkpt lat="55.9409508" lon="-4.3186949">
+<ele>112.10098095303536></ele>
+<accuracy>3.451</accuracy>
+<speed>1.5268886</speed>
+<bearing>244.83456</bearing>
+<bearingAccuracyDegrees>9.82159</bearingAccuracyDegrees>
+<time>1746104358534</time>
+</trkpt>
+<trkpt lat="55.9409804" lon="-4.3188391">
+<ele>112.40528541820257></ele>
+<accuracy>3.098</accuracy>
+<speed>1.4874153</speed>
+<bearing>309.05252</bearing>
+<bearingAccuracyDegrees>9.588068</bearingAccuracyDegrees>
+<time>1746104364565</time>
+</trkpt>
+<trkpt lat="55.9409941" lon="-4.3188535">
+<ele>111.92316264948083></ele>
+<accuracy>3.08</accuracy>
+<speed>1.5314438</speed>
+<bearing>318.23563</bearing>
+<bearingAccuracyDegrees>9.0806875</bearingAccuracyDegrees>
+<time>1746104365550</time>
+</trkpt>
+<trkpt lat="55.94101" lon="-4.318864">
+<ele>112.49735280865784></ele>
+<accuracy>3.074</accuracy>
+<speed>1.5062324</speed>
+<bearing>326.9037</bearing>
+<bearingAccuracyDegrees>9.494776</bearingAccuracyDegrees>
+<time>1746104366551</time>
+</trkpt>
+<trkpt lat="55.941024" lon="-4.3188699">
+<ele>112.54624775571938></ele>
+<accuracy>3.044</accuracy>
+<speed>1.4811621</speed>
+<bearing>334.85474</bearing>
+<bearingAccuracyDegrees>9.6614275</bearingAccuracyDegrees>
+<time>1746104367554</time>
+</trkpt>
+<trkpt lat="55.9410388" lon="-4.3188752">
+<ele>112.60607345848476></ele>
+<accuracy>3.06</accuracy>
+<speed>1.4464002</speed>
+<bearing>341.93127</bearing>
+<bearingAccuracyDegrees>9.595915</bearingAccuracyDegrees>
+<time>1746104368557</time>
+</trkpt>
+<trkpt lat="55.9410553" lon="-4.3188783">
+<ele>112.48894258246233></ele>
+<accuracy>3.101</accuracy>
+<speed>1.4277633</speed>
+<bearing>343.75607</bearing>
+<bearingAccuracyDegrees>9.255986</bearingAccuracyDegrees>
+<time>1746104369558</time>
+</trkpt>
+<trkpt lat="55.9410714" lon="-4.318883">
+<ele>112.48894258246233></ele>
+<accuracy>3.139</accuracy>
+<speed>1.410052</speed>
+<bearing>342.61115</bearing>
+<bearingAccuracyDegrees>9.514053</bearingAccuracyDegrees>
+<time>1746104370504</time>
+</trkpt>
+<trkpt lat="55.9410889" lon="-4.3188872">
+<ele>113.43027243976812></ele>
+<accuracy>3.224</accuracy>
+<speed>1.4099028</speed>
+<bearing>344.29074</bearing>
+<bearingAccuracyDegrees>10.011222</bearingAccuracyDegrees>
+<time>1746104371586</time>
+</trkpt>
+<trkpt lat="55.9411042" lon="-4.318892">
+<ele>113.0950394613358></ele>
+<accuracy>3.284</accuracy>
+<speed>1.4380767</speed>
+<bearing>344.64673</bearing>
+<bearingAccuracyDegrees>9.949581</bearingAccuracyDegrees>
+<time>1746104372565</time>
+</trkpt>
+<trkpt lat="55.9411202" lon="-4.318897">
+<ele>113.15694245915324></ele>
+<accuracy>3.331</accuracy>
+<speed>1.4391304</speed>
+<bearing>345.69727</bearing>
+<bearingAccuracyDegrees>10.06069</bearingAccuracyDegrees>
+<time>1746104373569</time>
+</trkpt>
+<trkpt lat="55.9411333" lon="-4.3189041">
+<ele>113.25460335119774></ele>
+<accuracy>3.344</accuracy>
+<speed>1.4174944</speed>
+<bearing>343.8449</bearing>
+<bearingAccuracyDegrees>9.424714</bearingAccuracyDegrees>
+<time>1746104374571</time>
+</trkpt>
+<trkpt lat="55.9411448" lon="-4.3189123">
+<ele>113.25460335119774></ele>
+<accuracy>3.326</accuracy>
+<speed>1.3709567</speed>
+<bearing>345.8486</bearing>
+<bearingAccuracyDegrees>9.363377</bearingAccuracyDegrees>
+<time>1746104375528</time>
+</trkpt>
+<trkpt lat="55.9411557" lon="-4.3189173">
+<ele>112.83608365228923></ele>
+<accuracy>3.359</accuracy>
+<speed>1.3288945</speed>
+<bearing>349.51248</bearing>
+<bearingAccuracyDegrees>9.299668</bearingAccuracyDegrees>
+<time>1746104376576</time>
+</trkpt>
+<trkpt lat="55.9411651" lon="-4.3189241">
+<ele>113.59951078590362></ele>
+<accuracy>3.326</accuracy>
+<speed>1.285779</speed>
+<bearing>350.25958</bearing>
+<bearingAccuracyDegrees>9.64854</bearingAccuracyDegrees>
+<time>1746104377577</time>
+</trkpt>
+<trkpt lat="55.9411745" lon="-4.318935">
+<ele>112.5999984741211></ele>
+<accuracy>3.321</accuracy>
+<speed>1.262593</speed>
+<bearing>348.14386</bearing>
+<bearingAccuracyDegrees>9.465969</bearingAccuracyDegrees>
+<time>1746104378580</time>
+</trkpt>
+<trkpt lat="55.941188" lon="-4.3189494">
+<ele>112.5999984741211></ele>
+<accuracy>3.29</accuracy>
+<speed>1.2433258</speed>
+<bearing>346.87402</bearing>
+<bearingAccuracyDegrees>9.468567</bearingAccuracyDegrees>
+<time>1746104379566</time>
+</trkpt>
+<trkpt lat="55.9411993" lon="-4.3189685">
+<ele>114.253520385505></ele>
+<accuracy>3.261</accuracy>
+<speed>1.2857108</speed>
+<bearing>341.86502</bearing>
+<bearingAccuracyDegrees>9.313576</bearingAccuracyDegrees>
+<time>1746104380585</time>
+</trkpt>
+<trkpt lat="55.9412052" lon="-4.3189925">
+<ele>112.5999984741211></ele>
+<accuracy>3.172</accuracy>
+<speed>1.2829366</speed>
+<bearing>336.04282</bearing>
+<bearingAccuracyDegrees>8.939277</bearingAccuracyDegrees>
+<time>1746104381586</time>
+</trkpt>
+<trkpt lat="55.9412101" lon="-4.3190095">
+<ele>112.5999984741211></ele>
+<accuracy>3.11</accuracy>
+<speed>1.2130553</speed>
+<bearing>334.6644</bearing>
+<bearingAccuracyDegrees>9.246245</bearingAccuracyDegrees>
+<time>1746104382590</time>
+</trkpt>
+<trkpt lat="55.9412114" lon="-4.3190277">
+<ele>114.9000015258789></ele>
+<accuracy>3.045</accuracy>
+<speed>1.1742895</speed>
+<bearing>330.01843</bearing>
+<bearingAccuracyDegrees>10.29456</bearingAccuracyDegrees>
+<time>1746104383607</time>
+</trkpt>
+<trkpt lat="55.9412127" lon="-4.319049">
+<ele>114.9000015258789></ele>
+<accuracy>3.01</accuracy>
+<speed>1.1376222</speed>
+<bearing>319.68396</bearing>
+<bearingAccuracyDegrees>10.150013</bearingAccuracyDegrees>
+<time>1746104384748</time>
+</trkpt>
+<trkpt lat="55.9412187" lon="-4.3190681">
+<ele>114.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.1784097</speed>
+<bearing>319.70303</bearing>
+<bearingAccuracyDegrees>9.277191</bearingAccuracyDegrees>
+<time>1746104385840</time>
+</trkpt>
+<trkpt lat="55.941228" lon="-4.3190873">
+<ele>114.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.2404065</speed>
+<bearing>318.58926</bearing>
+<bearingAccuracyDegrees>9.302721</bearingAccuracyDegrees>
+<time>1746104386983</time>
+</trkpt>
+<trkpt lat="55.941239" lon="-4.319108">
+<ele>114.9000015258789></ele>
+<accuracy>3.001</accuracy>
+<speed>1.2891171</speed>
+<bearing>314.88516</bearing>
+<bearingAccuracyDegrees>9.635212</bearingAccuracyDegrees>
+<time>1746104388105</time>
+</trkpt>
+<trkpt lat="55.9412501" lon="-4.3191268">
+<ele>114.50435777888977></ele>
+<accuracy>3.011</accuracy>
+<speed>1.3059722</speed>
+<bearing>313.07785</bearing>
+<bearingAccuracyDegrees>9.257139</bearingAccuracyDegrees>
+<time>1746104389268</time>
+</trkpt>
+<trkpt lat="55.9412616" lon="-4.3191464">
+<ele>112.5999984741211></ele>
+<accuracy>3.024</accuracy>
+<speed>1.3211138</speed>
+<bearing>313.74713</bearing>
+<bearingAccuracyDegrees>9.09518</bearingAccuracyDegrees>
+<time>1746104390401</time>
+</trkpt>
+<trkpt lat="55.9412758" lon="-4.319162">
+<ele>114.77386918163421></ele>
+<accuracy>3.053</accuracy>
+<speed>1.3487066</speed>
+<bearing>317.95465</bearing>
+<bearingAccuracyDegrees>9.13002</bearingAccuracyDegrees>
+<time>1746104391506</time>
+</trkpt>
+<trkpt lat="55.9412899" lon="-4.3191762">
+<ele>115.17173691749419></ele>
+<accuracy>3.095</accuracy>
+<speed>1.3713484</speed>
+<bearing>315.6369</bearing>
+<bearingAccuracyDegrees>9.588172</bearingAccuracyDegrees>
+<time>1746104392613</time>
+</trkpt>
+<trkpt lat="55.9413012" lon="-4.3191877">
+<ele>114.96036553573879></ele>
+<accuracy>3.122</accuracy>
+<speed>1.3597317</speed>
+<bearing>320.1468</bearing>
+<bearingAccuracyDegrees>9.488122</bearingAccuracyDegrees>
+<time>1746104393514</time>
+</trkpt>
+<trkpt lat="55.9413141" lon="-4.3191979">
+<ele>115.55466962694041></ele>
+<accuracy>3.146</accuracy>
+<speed>1.312145</speed>
+<bearing>337.51462</bearing>
+<bearingAccuracyDegrees>9.506585</bearingAccuracyDegrees>
+<time>1746104394517</time>
+</trkpt>
+<trkpt lat="55.9413276" lon="-4.3192039">
+<ele>115.55466962694041></ele>
+<accuracy>3.164</accuracy>
+<speed>1.3099118</speed>
+<bearing>343.01233</bearing>
+<bearingAccuracyDegrees>9.492844</bearingAccuracyDegrees>
+<time>1746104395523</time>
+</trkpt>
+<trkpt lat="55.9413387" lon="-4.3192106">
+<ele>116.30192584811303></ele>
+<accuracy>3.174</accuracy>
+<speed>1.3040656</speed>
+<bearing>328.99402</bearing>
+<bearingAccuracyDegrees>9.162165</bearingAccuracyDegrees>
+<time>1746104396521</time>
+</trkpt>
+<trkpt lat="55.9413488" lon="-4.3192218">
+<ele>117.26272088444088></ele>
+<accuracy>3.17</accuracy>
+<speed>1.304219</speed>
+<bearing>331.3383</bearing>
+<bearingAccuracyDegrees>9.464343</bearingAccuracyDegrees>
+<time>1746104397524</time>
+</trkpt>
+<trkpt lat="55.9413606" lon="-4.3192326">
+<ele>117.33141460581652></ele>
+<accuracy>3.266</accuracy>
+<speed>1.3369169</speed>
+<bearing>336.72113</bearing>
+<bearingAccuracyDegrees>9.939668</bearingAccuracyDegrees>
+<time>1746104398527</time>
+</trkpt>
+<trkpt lat="55.941373" lon="-4.3192405">
+<ele>117.45006868969432></ele>
+<accuracy>3.432</accuracy>
+<speed>1.3143274</speed>
+<bearing>338.67496</bearing>
+<bearingAccuracyDegrees>9.917602</bearingAccuracyDegrees>
+<time>1746104399529</time>
+</trkpt>
+<trkpt lat="55.9413872" lon="-4.3192498">
+<ele>117.45006868969432></ele>
+<accuracy>3.588</accuracy>
+<speed>1.3090554</speed>
+<bearing>336.20517</bearing>
+<bearingAccuracyDegrees>9.987445</bearingAccuracyDegrees>
+<time>1746104400562</time>
+</trkpt>
+<trkpt lat="55.9413993" lon="-4.3192601">
+<ele>117.58017373350202></ele>
+<accuracy>3.791</accuracy>
+<speed>1.2947017</speed>
+<bearing>327.54172</bearing>
+<bearingAccuracyDegrees>10.372755</bearingAccuracyDegrees>
+<time>1746104401533</time>
+</trkpt>
+<trkpt lat="55.9414108" lon="-4.31927">
+<ele>120.01222911702021></ele>
+<accuracy>4.254</accuracy>
+<speed>1.2623483</speed>
+<bearing>334.67557</bearing>
+<bearingAccuracyDegrees>11.786853</bearingAccuracyDegrees>
+<time>1746104402536</time>
+</trkpt>
+<trkpt lat="55.9414224" lon="-4.3192742">
+<ele>118.40394848908716></ele>
+<accuracy>4.5</accuracy>
+<speed>1.2363783</speed>
+<bearing>343.36627</bearing>
+<bearingAccuracyDegrees>11.504361</bearingAccuracyDegrees>
+<time>1746104403538</time>
+</trkpt>
+<trkpt lat="55.9414338" lon="-4.3192761">
+<ele>118.40394848908716></ele>
+<accuracy>4.737</accuracy>
+<speed>1.2419976</speed>
+<bearing>345.23544</bearing>
+<bearingAccuracyDegrees>11.9923</bearingAccuracyDegrees>
+<time>1746104404442</time>
+</trkpt>
+<trkpt lat="55.9414471" lon="-4.3192778">
+<ele>118.52260656525306></ele>
+<accuracy>4.941</accuracy>
+<speed>1.2920735</speed>
+<bearing>340.43396</bearing>
+<bearingAccuracyDegrees>12.487875</bearingAccuracyDegrees>
+<time>1746104405505</time>
+</trkpt>
+<trkpt lat="55.9414608" lon="-4.3192781">
+<ele>118.81509530592345></ele>
+<accuracy>5.111</accuracy>
+<speed>1.3096583</speed>
+<bearing>339.2882</bearing>
+<bearingAccuracyDegrees>11.99874</bearingAccuracyDegrees>
+<time>1746104406588</time>
+</trkpt>
+<trkpt lat="55.9414729" lon="-4.3192776">
+<ele>117.55672665836164></ele>
+<accuracy>5.244</accuracy>
+<speed>1.3254595</speed>
+<bearing>339.6522</bearing>
+<bearingAccuracyDegrees>11.877091</bearingAccuracyDegrees>
+<time>1746104407547</time>
+</trkpt>
+<trkpt lat="55.9414859" lon="-4.3192794">
+<ele>116.93718003405382></ele>
+<accuracy>5.282</accuracy>
+<speed>1.3368511</speed>
+<bearing>339.76456</bearing>
+<bearingAccuracyDegrees>11.7439375</bearingAccuracyDegrees>
+<time>1746104408550</time>
+</trkpt>
+<trkpt lat="55.9414988" lon="-4.3192846">
+<ele>116.8721223174052></ele>
+<accuracy>5.313</accuracy>
+<speed>1.3586316</speed>
+<bearing>339.22696</bearing>
+<bearingAccuracyDegrees>11.70527</bearingAccuracyDegrees>
+<time>1746104409551</time>
+</trkpt>
+<trkpt lat="55.9415125" lon="-4.3192903">
+<ele>116.90405144691964></ele>
+<accuracy>5.349</accuracy>
+<speed>1.3871341</speed>
+<bearing>341.90652</bearing>
+<bearingAccuracyDegrees>12.232325</bearingAccuracyDegrees>
+<time>1746104410554</time>
+</trkpt>
+<trkpt lat="55.9415688" lon="-4.3193216">
+<ele>117.00791936960691></ele>
+<accuracy>5.375</accuracy>
+<speed>1.4499007</speed>
+<bearing>344.58224</bearing>
+<bearingAccuracyDegrees>12.141643</bearingAccuracyDegrees>
+<time>1746104414564</time>
+</trkpt>
+<trkpt lat="55.941584" lon="-4.3193291">
+<ele>116.97304924383816></ele>
+<accuracy>5.306</accuracy>
+<speed>1.4672291</speed>
+<bearing>339.33832</bearing>
+<bearingAccuracyDegrees>11.784979</bearingAccuracyDegrees>
+<time>1746104415566</time>
+</trkpt>
+<trkpt lat="55.9415978" lon="-4.3193388">
+<ele>117.05892534850337></ele>
+<accuracy>5.234</accuracy>
+<speed>1.433345</speed>
+<bearing>338.58038</bearing>
+<bearingAccuracyDegrees>10.040651</bearingAccuracyDegrees>
+<time>1746104416567</time>
+</trkpt>
+<trkpt lat="55.9416133" lon="-4.3193501">
+<ele>117.48101525228327></ele>
+<accuracy>5.174</accuracy>
+<speed>1.4182317</speed>
+<bearing>340.14737</bearing>
+<bearingAccuracyDegrees>11.978128</bearingAccuracyDegrees>
+<time>1746104417571</time>
+</trkpt>
+<trkpt lat="55.9416297" lon="-4.3193613">
+<ele>117.3441388184663></ele>
+<accuracy>5.116</accuracy>
+<speed>1.4145379</speed>
+<bearing>339.46082</bearing>
+<bearingAccuracyDegrees>12.138167</bearingAccuracyDegrees>
+<time>1746104418572</time>
+</trkpt>
+<trkpt lat="55.9416455" lon="-4.3193713">
+<ele>117.26696173233219></ele>
+<accuracy>5.042</accuracy>
+<speed>1.4725177</speed>
+<bearing>339.0829</bearing>
+<bearingAccuracyDegrees>11.864098</bearingAccuracyDegrees>
+<time>1746104419574</time>
+</trkpt>
+<trkpt lat="55.9416608" lon="-4.3193825">
+<ele>117.26696173233219></ele>
+<accuracy>4.999</accuracy>
+<speed>1.4830152</speed>
+<bearing>338.17953</bearing>
+<bearingAccuracyDegrees>12.416112</bearingAccuracyDegrees>
+<time>1746104420522</time>
+</trkpt>
+<trkpt lat="55.9416761" lon="-4.3193948">
+<ele>117.35336062056567></ele>
+<accuracy>4.981</accuracy>
+<speed>1.4774306</speed>
+<bearing>336.80426</bearing>
+<bearingAccuracyDegrees>12.09657</bearingAccuracyDegrees>
+<time>1746104421582</time>
+</trkpt>
+<trkpt lat="55.9417181" lon="-4.3194344">
+<ele>117.46110020930695></ele>
+<accuracy>4.939</accuracy>
+<speed>1.1332297</speed>
+<bearing>333.97284</bearing>
+<bearingAccuracyDegrees>11.922116</bearingAccuracyDegrees>
+<time>1746104426264</time>
+</trkpt>
+<trkpt lat="55.9417254" lon="-4.3194443">
+<ele>117.44392424240458></ele>
+<accuracy>4.924</accuracy>
+<speed>1.1092883</speed>
+<bearing>333.31082</bearing>
+<bearingAccuracyDegrees>12.261298</bearingAccuracyDegrees>
+<time>1746104427288</time>
+</trkpt>
+<trkpt lat="55.941734" lon="-4.3194553">
+<ele>117.42622782753371></ele>
+<accuracy>4.971</accuracy>
+<speed>1.1264073</speed>
+<bearing>329.57196</bearing>
+<bearingAccuracyDegrees>12.715312</bearingAccuracyDegrees>
+<time>1746104428328</time>
+</trkpt>
+<trkpt lat="55.9417415" lon="-4.31947">
+<ele>117.8644521637161></ele>
+<accuracy>5.043</accuracy>
+<speed>1.134061</speed>
+<bearing>327.33154</bearing>
+<bearingAccuracyDegrees>12.153354</bearingAccuracyDegrees>
+<time>1746104429360</time>
+</trkpt>
+<trkpt lat="55.941756" lon="-4.3194837">
+<ele>117.85560396993806></ele>
+<accuracy>5.158</accuracy>
+<speed>1.2533985</speed>
+<bearing>326.45837</bearing>
+<bearingAccuracyDegrees>10.151183</bearingAccuracyDegrees>
+<time>1746104430407</time>
+</trkpt>
+<trkpt lat="55.941766" lon="-4.3195018">
+<ele>117.89687880518923></ele>
+<accuracy>5.287</accuracy>
+<speed>1.3412309</speed>
+<bearing>315.2918</bearing>
+<bearingAccuracyDegrees>11.851449</bearingAccuracyDegrees>
+<time>1746104431467</time>
+</trkpt>
+<trkpt lat="55.9417744" lon="-4.3195247">
+<ele>117.43663747892995></ele>
+<accuracy>5.401</accuracy>
+<speed>1.4035622</speed>
+<bearing>302.80243</bearing>
+<bearingAccuracyDegrees>12.055127</bearingAccuracyDegrees>
+<time>1746104432488</time>
+</trkpt>
+<trkpt lat="55.9417801" lon="-4.3195522">
+<ele>117.59018130061486></ele>
+<accuracy>5.438</accuracy>
+<speed>1.461702</speed>
+<bearing>282.3444</bearing>
+<bearingAccuracyDegrees>12.03038</bearingAccuracyDegrees>
+<time>1746104433539</time>
+</trkpt>
+<trkpt lat="55.9417843" lon="-4.3195777">
+<ele>117.46682553923193></ele>
+<accuracy>5.41</accuracy>
+<speed>1.4733669</speed>
+<bearing>282.0857</bearing>
+<bearingAccuracyDegrees>12.124442</bearingAccuracyDegrees>
+<time>1746104434563</time>
+</trkpt>
+<trkpt lat="55.9417884" lon="-4.3196022">
+<ele>117.36779082175532></ele>
+<accuracy>5.428</accuracy>
+<speed>1.4651504</speed>
+<bearing>277.9211</bearing>
+<bearingAccuracyDegrees>12.605161</bearingAccuracyDegrees>
+<time>1746104435586</time>
+</trkpt>
+<trkpt lat="55.9417883" lon="-4.3196322">
+<ele>117.3918760673256></ele>
+<accuracy>5.384</accuracy>
+<speed>1.5062711</speed>
+<bearing>271.19168</bearing>
+<bearingAccuracyDegrees>13.459597</bearingAccuracyDegrees>
+<time>1746104436606</time>
+</trkpt>
+<trkpt lat="55.9417886" lon="-4.3196624">
+<ele>117.14814907819488></ele>
+<accuracy>5.303</accuracy>
+<speed>1.5173249</speed>
+<bearing>269.19806</bearing>
+<bearingAccuracyDegrees>12.806704</bearingAccuracyDegrees>
+<time>1746104437600</time>
+</trkpt>
+<trkpt lat="55.941789" lon="-4.31969">
+<ele>117.0747629212388></ele>
+<accuracy>5.303</accuracy>
+<speed>1.556348</speed>
+<bearing>264.64658</bearing>
+<bearingAccuracyDegrees>12.727246</bearingAccuracyDegrees>
+<time>1746104438519</time>
+</trkpt>
+<trkpt lat="55.9417903" lon="-4.3197187">
+<ele>115.30000305175781></ele>
+<accuracy>5.258</accuracy>
+<speed>1.5681642</speed>
+<bearing>264.2161</bearing>
+<bearingAccuracyDegrees>12.418623</bearingAccuracyDegrees>
+<time>1746104439522</time>
+</trkpt>
+<trkpt lat="55.9417912" lon="-4.3197472">
+<ele>115.30000305175781></ele>
+<accuracy>5.214</accuracy>
+<speed>1.540658</speed>
+<bearing>258.6257</bearing>
+<bearingAccuracyDegrees>12.3155775</bearingAccuracyDegrees>
+<time>1746104440524</time>
+</trkpt>
+<trkpt lat="55.9417911" lon="-4.3197745">
+<ele>115.30000305175781></ele>
+<accuracy>5.166</accuracy>
+<speed>1.5062455</speed>
+<bearing>256.53192</bearing>
+<bearingAccuracyDegrees>12.284471</bearingAccuracyDegrees>
+<time>1746104441526</time>
+</trkpt>
+<trkpt lat="55.9417901" lon="-4.3197941">
+<ele>115.30000305175781></ele>
+<accuracy>5.157</accuracy>
+<speed>1.290778</speed>
+<bearing>255.69229</bearing>
+<bearingAccuracyDegrees>12.555836</bearingAccuracyDegrees>
+<time>1746104442528</time>
+</trkpt>
+<trkpt lat="55.9417894" lon="-4.3198111">
+<ele>115.30000305175781></ele>
+<accuracy>5.147</accuracy>
+<speed>1.1716782</speed>
+<bearing>257.7398</bearing>
+<bearingAccuracyDegrees>13.009981</bearingAccuracyDegrees>
+<time>1746104443530</time>
+</trkpt>
+<trkpt lat="55.9417852" lon="-4.3198269">
+<ele>115.0></ele>
+<accuracy>5.148</accuracy>
+<speed>1.0973835</speed>
+<bearing>255.88274</bearing>
+<bearingAccuracyDegrees>12.690375</bearingAccuracyDegrees>
+<time>1746104444532</time>
+</trkpt>
+<trkpt lat="55.9417811" lon="-4.3198445">
+<ele>115.0></ele>
+<accuracy>5.124</accuracy>
+<speed>1.18401</speed>
+<bearing>254.38954</bearing>
+<bearingAccuracyDegrees>12.559293</bearingAccuracyDegrees>
+<time>1746104445535</time>
+</trkpt>
+<trkpt lat="55.941781" lon="-4.3198703">
+<ele>115.0></ele>
+<accuracy>5.158</accuracy>
+<speed>1.3047016</speed>
+<bearing>251.7298</bearing>
+<bearingAccuracyDegrees>12.706251</bearingAccuracyDegrees>
+<time>1746104446538</time>
+</trkpt>
+<trkpt lat="55.9417793" lon="-4.3198949">
+<ele>115.0></ele>
+<accuracy>5.178</accuracy>
+<speed>1.3781719</speed>
+<bearing>251.90842</bearing>
+<bearingAccuracyDegrees>12.619728</bearingAccuracyDegrees>
+<time>1746104447443</time>
+</trkpt>
+<trkpt lat="55.9417754" lon="-4.3199205">
+<ele>115.0></ele>
+<accuracy>5.169</accuracy>
+<speed>1.4317676</speed>
+<bearing>252.5489</bearing>
+<bearingAccuracyDegrees>11.890062</bearingAccuracyDegrees>
+<time>1746104448486</time>
+</trkpt>
+<trkpt lat="55.9417707" lon="-4.3199473">
+<ele>115.30000305175781></ele>
+<accuracy>5.178</accuracy>
+<speed>1.4517447</speed>
+<bearing>252.17714</bearing>
+<bearingAccuracyDegrees>12.054152</bearingAccuracyDegrees>
+<time>1746104449527</time>
+</trkpt>
+<trkpt lat="55.9417667" lon="-4.3199739">
+<ele>115.30000305175781></ele>
+<accuracy>5.254</accuracy>
+<speed>1.4597524</speed>
+<bearing>253.17197</bearing>
+<bearingAccuracyDegrees>12.030145</bearingAccuracyDegrees>
+<time>1746104450561</time>
+</trkpt>
+<trkpt lat="55.9417617" lon="-4.3200012">
+<ele>115.0></ele>
+<accuracy>5.303</accuracy>
+<speed>1.4923446</speed>
+<bearing>252.95317</bearing>
+<bearingAccuracyDegrees>12.063817</bearingAccuracyDegrees>
+<time>1746104451602</time>
+</trkpt>
+<trkpt lat="55.9417579" lon="-4.3200262">
+<ele>115.0></ele>
+<accuracy>5.354</accuracy>
+<speed>1.5006871</speed>
+<bearing>255.55632</bearing>
+<bearingAccuracyDegrees>11.889561</bearingAccuracyDegrees>
+<time>1746104452552</time>
+</trkpt>
+<trkpt lat="55.9417527" lon="-4.3200528">
+<ele>115.0></ele>
+<accuracy>5.43</accuracy>
+<speed>1.4912184</speed>
+<bearing>227.64824</bearing>
+<bearingAccuracyDegrees>10.095949</bearingAccuracyDegrees>
+<time>1746104453554</time>
+</trkpt>
+<trkpt lat="55.9417399" lon="-4.3200716">
+<ele>115.0></ele>
+<accuracy>5.521</accuracy>
+<speed>1.4693415</speed>
+<bearing>223.4281</bearing>
+<bearingAccuracyDegrees>11.539483</bearingAccuracyDegrees>
+<time>1746104454556</time>
+</trkpt>
+<trkpt lat="55.9417313" lon="-4.3200968">
+<ele>115.0></ele>
+<accuracy>5.566</accuracy>
+<speed>1.4733144</speed>
+<bearing>245.4428</bearing>
+<bearingAccuracyDegrees>10.235637</bearingAccuracyDegrees>
+<time>1746104455559</time>
+</trkpt>
+<trkpt lat="55.9417248" lon="-4.3201225">
+<ele>115.0></ele>
+<accuracy>5.583</accuracy>
+<speed>1.4967605</speed>
+<bearing>248.77242</bearing>
+<bearingAccuracyDegrees>11.67004</bearingAccuracyDegrees>
+<time>1746104456561</time>
+</trkpt>
+<trkpt lat="55.9417165" lon="-4.3201471">
+<ele>115.0></ele>
+<accuracy>5.276</accuracy>
+<speed>1.5065938</speed>
+<bearing>250.48946</bearing>
+<bearingAccuracyDegrees>9.953077</bearingAccuracyDegrees>
+<time>1746104457563</time>
+</trkpt>
+<trkpt lat="55.9417095" lon="-4.3201727">
+<ele>115.0></ele>
+<accuracy>4.849</accuracy>
+<speed>1.5202203</speed>
+<bearing>251.18858</bearing>
+<bearingAccuracyDegrees>9.82154</bearingAccuracyDegrees>
+<time>1746104458566</time>
+</trkpt>
+<trkpt lat="55.9417021" lon="-4.3201987">
+<ele>115.0></ele>
+<accuracy>4.374</accuracy>
+<speed>1.5118448</speed>
+<bearing>248.14175</bearing>
+<bearingAccuracyDegrees>11.609635</bearingAccuracyDegrees>
+<time>1746104459568</time>
+</trkpt>
+<trkpt lat="55.941693" lon="-4.3202248">
+<ele>115.0></ele>
+<accuracy>3.797</accuracy>
+<speed>1.5201793</speed>
+<bearing>249.35849</bearing>
+<bearingAccuracyDegrees>12.1055765</bearingAccuracyDegrees>
+<time>1746104460570</time>
+</trkpt>
+<trkpt lat="55.9416831" lon="-4.3202471">
+<ele>115.0></ele>
+<accuracy>3.314</accuracy>
+<speed>1.5089692</speed>
+<bearing>243.55833</bearing>
+<bearingAccuracyDegrees>11.917771</bearingAccuracyDegrees>
+<time>1746104461573</time>
+</trkpt>
+<trkpt lat="55.9416701" lon="-4.3202634">
+<ele>115.0></ele>
+<accuracy>3.179</accuracy>
+<speed>1.536836</speed>
+<bearing>235.08333</bearing>
+<bearingAccuracyDegrees>11.798731</bearingAccuracyDegrees>
+<time>1746104462575</time>
+</trkpt>
+<trkpt lat="55.9416559" lon="-4.3202733">
+<ele>115.0></ele>
+<accuracy>3.208</accuracy>
+<speed>1.5390651</speed>
+<bearing>231.1242</bearing>
+<bearingAccuracyDegrees>12.153726</bearingAccuracyDegrees>
+<time>1746104463577</time>
+</trkpt>
+<trkpt lat="55.9416425" lon="-4.3202829">
+<ele>115.0></ele>
+<accuracy>3.268</accuracy>
+<speed>1.5384766</speed>
+<bearing>231.14427</bearing>
+<bearingAccuracyDegrees>12.665455</bearingAccuracyDegrees>
+<time>1746104464580</time>
+</trkpt>
+<trkpt lat="55.9416309" lon="-4.3202907">
+<ele>115.0></ele>
+<accuracy>3.339</accuracy>
+<speed>1.5067954</speed>
+<bearing>230.2871</bearing>
+<bearingAccuracyDegrees>12.3041725</bearingAccuracyDegrees>
+<time>1746104465482</time>
+</trkpt>
+<trkpt lat="55.9416192" lon="-4.3203023">
+<ele>115.0></ele>
+<accuracy>3.411</accuracy>
+<speed>1.4949101</speed>
+<bearing>228.12901</bearing>
+<bearingAccuracyDegrees>12.213172</bearingAccuracyDegrees>
+<time>1746104466584</time>
+</trkpt>
+<trkpt lat="55.9416076" lon="-4.3203152">
+<ele>115.0999984741211></ele>
+<accuracy>3.435</accuracy>
+<speed>1.4918796</speed>
+<bearing>226.40024</bearing>
+<bearingAccuracyDegrees>10.256105</bearingAccuracyDegrees>
+<time>1746104467587</time>
+</trkpt>
+<trkpt lat="55.9415973" lon="-4.3203328">
+<ele>115.0999984741211></ele>
+<accuracy>3.512</accuracy>
+<speed>1.4902446</speed>
+<bearing>221.10413</bearing>
+<bearingAccuracyDegrees>12.005289</bearingAccuracyDegrees>
+<time>1746104468488</time>
+</trkpt>
+<trkpt lat="55.9415856" lon="-4.3203505">
+<ele>115.0999984741211></ele>
+<accuracy>3.663</accuracy>
+<speed>1.4937603</speed>
+<bearing>209.66818</bearing>
+<bearingAccuracyDegrees>12.885025</bearingAccuracyDegrees>
+<time>1746104469591</time>
+</trkpt>
+<trkpt lat="55.941557" lon="-4.3204449">
+<ele>114.9000015258789></ele>
+<accuracy>4.798</accuracy>
+<speed>1.4924432</speed>
+<bearing>236.94066</bearing>
+<bearingAccuracyDegrees>12.792295</bearingAccuracyDegrees>
+<time>1746104473403</time>
+</trkpt>
+<trkpt lat="55.9415536" lon="-4.3204742">
+<ele>114.9000015258789></ele>
+<accuracy>5.065</accuracy>
+<speed>1.4580755</speed>
+<bearing>237.59532</bearing>
+<bearingAccuracyDegrees>12.234582</bearingAccuracyDegrees>
+<time>1746104474406</time>
+</trkpt>
+<trkpt lat="55.9415494" lon="-4.3205027">
+<ele>114.9000015258789></ele>
+<accuracy>5.264</accuracy>
+<speed>1.4752167</speed>
+<bearing>239.90408</bearing>
+<bearingAccuracyDegrees>12.390596</bearingAccuracyDegrees>
+<time>1746104475410</time>
+</trkpt>
+<trkpt lat="55.9415465" lon="-4.3205334">
+<ele>114.9000015258789></ele>
+<accuracy>5.417</accuracy>
+<speed>1.4965217</speed>
+<bearing>246.25136</bearing>
+<bearingAccuracyDegrees>12.176795</bearingAccuracyDegrees>
+<time>1746104476399</time>
+</trkpt>
+<trkpt lat="55.9415456" lon="-4.3205786">
+<ele>115.0999984741211></ele>
+<accuracy>5.479</accuracy>
+<speed>1.5147331</speed>
+<bearing>248.1088</bearing>
+<bearingAccuracyDegrees>10.162381</bearingAccuracyDegrees>
+<time>1746104477441</time>
+</trkpt>
+<trkpt lat="55.9415425" lon="-4.3206163">
+<ele>115.0999984741211></ele>
+<accuracy>5.497</accuracy>
+<speed>1.5452603</speed>
+<bearing>249.3797</bearing>
+<bearingAccuracyDegrees>9.748376</bearingAccuracyDegrees>
+<time>1746104478445</time>
+</trkpt>
+<trkpt lat="55.9415386" lon="-4.3206509">
+<ele>115.0999984741211></ele>
+<accuracy>5.443</accuracy>
+<speed>1.5512469</speed>
+<bearing>249.59792</bearing>
+<bearingAccuracyDegrees>10.083634</bearingAccuracyDegrees>
+<time>1746104479447</time>
+</trkpt>
+<trkpt lat="55.9415335" lon="-4.3206811">
+<ele>115.0999984741211></ele>
+<accuracy>5.365</accuracy>
+<speed>1.5181</speed>
+<bearing>241.85385</bearing>
+<bearingAccuracyDegrees>11.716598</bearingAccuracyDegrees>
+<time>1746104480461</time>
+</trkpt>
+<trkpt lat="55.9415253" lon="-4.3207064">
+<ele>115.0999984741211></ele>
+<accuracy>5.225</accuracy>
+<speed>1.4934921</speed>
+<bearing>232.63564</bearing>
+<bearingAccuracyDegrees>11.898874</bearingAccuracyDegrees>
+<time>1746104481482</time>
+</trkpt>
+<trkpt lat="55.9415146" lon="-4.3207251">
+<ele>115.0999984741211></ele>
+<accuracy>5.171</accuracy>
+<speed>1.4530255</speed>
+<bearing>218.73294</bearing>
+<bearingAccuracyDegrees>12.527561</bearingAccuracyDegrees>
+<time>1746104482525</time>
+</trkpt>
+<trkpt lat="55.9415011" lon="-4.3207348">
+<ele>115.0999984741211></ele>
+<accuracy>5.155</accuracy>
+<speed>1.423688</speed>
+<bearing>198.53484</bearing>
+<bearingAccuracyDegrees>12.470877</bearingAccuracyDegrees>
+<time>1746104483588</time>
+</trkpt>
+<trkpt lat="55.9414881" lon="-4.3207386">
+<ele>115.0999984741211></ele>
+<accuracy>5.205</accuracy>
+<speed>1.3944099</speed>
+<bearing>175.55565</bearing>
+<bearingAccuracyDegrees>11.886849</bearingAccuracyDegrees>
+<time>1746104484525</time>
+</trkpt>
+<trkpt lat="55.9414746" lon="-4.3207332">
+<ele>115.0999984741211></ele>
+<accuracy>5.168</accuracy>
+<speed>1.3954934</speed>
+<bearing>159.97293</bearing>
+<bearingAccuracyDegrees>12.115701</bearingAccuracyDegrees>
+<time>1746104485527</time>
+</trkpt>
+<trkpt lat="55.9414605" lon="-4.3207188">
+<ele>115.0999984741211></ele>
+<accuracy>5.17</accuracy>
+<speed>1.3967993</speed>
+<bearing>156.41322</bearing>
+<bearingAccuracyDegrees>12.589221</bearingAccuracyDegrees>
+<time>1746104486530</time>
+</trkpt>
+<trkpt lat="55.9414466" lon="-4.3207026">
+<ele>115.0999984741211></ele>
+<accuracy>5.178</accuracy>
+<speed>1.4211545</speed>
+<bearing>152.35655</bearing>
+<bearingAccuracyDegrees>12.36334</bearingAccuracyDegrees>
+<time>1746104487533</time>
+</trkpt>
+<trkpt lat="55.9414325" lon="-4.3206854">
+<ele>115.0999984741211></ele>
+<accuracy>5.169</accuracy>
+<speed>1.4365731</speed>
+<bearing>149.4322</bearing>
+<bearingAccuracyDegrees>12.254737</bearingAccuracyDegrees>
+<time>1746104488534</time>
+</trkpt>
+<trkpt lat="55.9413675" lon="-4.3206333">
+<ele>115.0999984741211></ele>
+<accuracy>5.159</accuracy>
+<speed>1.5093237</speed>
+<bearing>152.27608</bearing>
+<bearingAccuracyDegrees>10.07026</bearingAccuracyDegrees>
+<time>1746104492544</time>
+</trkpt>
+<trkpt lat="55.9413494" lon="-4.320619">
+<ele>115.0999984741211></ele>
+<accuracy>5.161</accuracy>
+<speed>1.5260588</speed>
+<bearing>150.63821</bearing>
+<bearingAccuracyDegrees>10.21027</bearingAccuracyDegrees>
+<time>1746104493561</time>
+</trkpt>
+<trkpt lat="55.9413332" lon="-4.3206056">
+<ele>115.0999984741211></ele>
+<accuracy>5.134</accuracy>
+<speed>1.533739</speed>
+<bearing>149.20195</bearing>
+<bearingAccuracyDegrees>11.210054</bearingAccuracyDegrees>
+<time>1746104494549</time>
+</trkpt>
+<trkpt lat="55.9413176" lon="-4.3205925">
+<ele>115.0999984741211></ele>
+<accuracy>5.128</accuracy>
+<speed>1.5362315</speed>
+<bearing>150.19618</bearing>
+<bearingAccuracyDegrees>12.192634</bearingAccuracyDegrees>
+<time>1746104495552</time>
+</trkpt>
+<trkpt lat="55.9413021" lon="-4.3205803">
+<ele>115.0999984741211></ele>
+<accuracy>5.136</accuracy>
+<speed>1.5352517</speed>
+<bearing>152.63321</bearing>
+<bearingAccuracyDegrees>11.872949</bearingAccuracyDegrees>
+<time>1746104496554</time>
+</trkpt>
+<trkpt lat="55.9412864" lon="-4.3205697">
+<ele>115.0999984741211></ele>
+<accuracy>5.096</accuracy>
+<speed>1.5470076</speed>
+<bearing>155.30519</bearing>
+<bearingAccuracyDegrees>11.554083</bearingAccuracyDegrees>
+<time>1746104497556</time>
+</trkpt>
+<trkpt lat="55.9412722" lon="-4.320559">
+<ele>115.0999984741211></ele>
+<accuracy>5.064</accuracy>
+<speed>1.5581614</speed>
+<bearing>156.50227</bearing>
+<bearingAccuracyDegrees>9.971957</bearingAccuracyDegrees>
+<time>1746104498460</time>
+</trkpt>
+<trkpt lat="55.9412562" lon="-4.3205475">
+<ele>115.0999984741211></ele>
+<accuracy>4.988</accuracy>
+<speed>1.565049</speed>
+<bearing>155.35793</bearing>
+<bearingAccuracyDegrees>9.502035</bearingAccuracyDegrees>
+<time>1746104499445</time>
+</trkpt>
+<trkpt lat="55.9412403" lon="-4.3205335">
+<ele>115.0999984741211></ele>
+<accuracy>4.886</accuracy>
+<speed>1.5696585</speed>
+<bearing>152.27405</bearing>
+<bearingAccuracyDegrees>10.036663</bearingAccuracyDegrees>
+<time>1746104500487</time>
+</trkpt>
+<trkpt lat="55.9412253" lon="-4.3205205">
+<ele>115.0999984741211></ele>
+<accuracy>4.781</accuracy>
+<speed>1.5518897</speed>
+<bearing>151.1059</bearing>
+<bearingAccuracyDegrees>9.879112</bearingAccuracyDegrees>
+<time>1746104501490</time>
+</trkpt>
+<trkpt lat="55.9412121" lon="-4.3205101">
+<ele>115.0999984741211></ele>
+<accuracy>4.539</accuracy>
+<speed>1.5544903</speed>
+<bearing>151.31322</bearing>
+<bearingAccuracyDegrees>8.693242</bearingAccuracyDegrees>
+<time>1746104502492</time>
+</trkpt>
+<trkpt lat="55.9411972" lon="-4.3204996">
+<ele>115.0999984741211></ele>
+<accuracy>4.186</accuracy>
+<speed>1.546017</speed>
+<bearing>157.7248</bearing>
+<bearingAccuracyDegrees>8.723596</bearingAccuracyDegrees>
+<time>1746104503522</time>
+</trkpt>
+<trkpt lat="55.9411811" lon="-4.3204964">
+<ele>115.0999984741211></ele>
+<accuracy>3.9</accuracy>
+<speed>1.5442098</speed>
+<bearing>188.41446</bearing>
+<bearingAccuracyDegrees>9.22973</bearingAccuracyDegrees>
+<time>1746104504566</time>
+</trkpt>
+<trkpt lat="55.9411659" lon="-4.3204935">
+<ele>115.0999984741211></ele>
+<accuracy>3.678</accuracy>
+<speed>1.5347102</speed>
+<bearing>154.45468</bearing>
+<bearingAccuracyDegrees>9.299649</bearingAccuracyDegrees>
+<time>1746104505575</time>
+</trkpt>
+<trkpt lat="55.9411504" lon="-4.3204754">
+<ele>115.0999984741211></ele>
+<accuracy>3.236</accuracy>
+<speed>1.5713049</speed>
+<bearing>156.21751</bearing>
+<bearingAccuracyDegrees>8.997785</bearingAccuracyDegrees>
+<time>1746104506577</time>
+</trkpt>
+<trkpt lat="55.9411355" lon="-4.3204671">
+<ele>115.0999984741211></ele>
+<accuracy>3.093</accuracy>
+<speed>1.4994903</speed>
+<bearing>195.9936</bearing>
+<bearingAccuracyDegrees>8.864071</bearingAccuracyDegrees>
+<time>1746104507579</time>
+</trkpt>
+<trkpt lat="55.9411261" lon="-4.3204815">
+<ele>115.0999984741211></ele>
+<accuracy>3.012</accuracy>
+<speed>1.4148358</speed>
+<bearing>229.12286</bearing>
+<bearingAccuracyDegrees>9.148</bearingAccuracyDegrees>
+<time>1746104508581</time>
+</trkpt>
+<trkpt lat="55.941121" lon="-4.3204957">
+<ele>115.0999984741211></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3703563</speed>
+<bearing>215.26465</bearing>
+<bearingAccuracyDegrees>9.238909</bearingAccuracyDegrees>
+<time>1746104509583</time>
+</trkpt>
+<trkpt lat="55.9411135" lon="-4.3205074">
+<ele>115.0999984741211></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3113992</speed>
+<bearing>210.0945</bearing>
+<bearingAccuracyDegrees>11.268199</bearingAccuracyDegrees>
+<time>1746104510818</time>
+</trkpt>
+<trkpt lat="55.9411066" lon="-4.3205204">
+<ele>115.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.103642</speed>
+<bearing>211.91373</bearing>
+<bearingAccuracyDegrees>11.93286</bearingAccuracyDegrees>
+<time>1746104512344</time>
+</trkpt>
+<trkpt lat="55.9410983" lon="-4.3205315">
+<ele>115.0></ele>
+<accuracy>3.049</accuracy>
+<speed>0.94606084</speed>
+<bearing>210.20235</bearing>
+<bearingAccuracyDegrees>12.893835</bearingAccuracyDegrees>
+<time>1746104513866</time>
+</trkpt>
+<trkpt lat="55.9410866" lon="-4.3205432">
+<ele>115.0></ele>
+<accuracy>3.228</accuracy>
+<speed>0.9874748</speed>
+<bearing>209.15051</bearing>
+<bearingAccuracyDegrees>12.914982</bearingAccuracyDegrees>
+<time>1746104515441</time>
+</trkpt>
+<trkpt lat="55.9410764" lon="-4.3205524">
+<ele>115.0></ele>
+<accuracy>3.455</accuracy>
+<speed>0.99480057</speed>
+<bearing>197.16063</bearing>
+<bearingAccuracyDegrees>12.860162</bearingAccuracyDegrees>
+<time>1746104516563</time>
+</trkpt>
+<trkpt lat="55.9410664" lon="-4.3205555">
+<ele>114.69999694824219></ele>
+<accuracy>3.749</accuracy>
+<speed>1.0315659</speed>
+<bearing>178.94795</bearing>
+<bearingAccuracyDegrees>12.704023</bearingAccuracyDegrees>
+<time>1746104517502</time>
+</trkpt>
+<trkpt lat="55.9410573" lon="-4.320551">
+<ele>114.69999694824219></ele>
+<accuracy>4.03</accuracy>
+<speed>1.0084515</speed>
+<bearing>169.90916</bearing>
+<bearingAccuracyDegrees>12.977595</bearingAccuracyDegrees>
+<time>1746104518505</time>
+</trkpt>
+<trkpt lat="55.9410467" lon="-4.3205471">
+<ele>114.69999694824219></ele>
+<accuracy>4.297</accuracy>
+<speed>1.0178312</speed>
+<bearing>163.79436</bearing>
+<bearingAccuracyDegrees>12.94383</bearingAccuracyDegrees>
+<time>1746104519607</time>
+</trkpt>
+<trkpt lat="55.9410344" lon="-4.3205417">
+<ele>114.69999694824219></ele>
+<accuracy>4.468</accuracy>
+<speed>1.107213</speed>
+<bearing>160.26234</bearing>
+<bearingAccuracyDegrees>13.137561</bearingAccuracyDegrees>
+<time>1746104520508</time>
+</trkpt>
+<trkpt lat="55.9410179" lon="-4.3205332">
+<ele>114.69999694824219></ele>
+<accuracy>4.619</accuracy>
+<speed>1.304833</speed>
+<bearing>156.53114</bearing>
+<bearingAccuracyDegrees>12.981499</bearingAccuracyDegrees>
+<time>1746104521512</time>
+</trkpt>
+<trkpt lat="55.9410029" lon="-4.3205242">
+<ele>113.9000015258789></ele>
+<accuracy>4.749</accuracy>
+<speed>1.4709725</speed>
+<bearing>154.64587</bearing>
+<bearingAccuracyDegrees>14.9973545</bearingAccuracyDegrees>
+<time>1746104522414</time>
+</trkpt>
+<trkpt lat="55.9409873" lon="-4.3205031">
+<ele>113.9000015258789></ele>
+<accuracy>4.871</accuracy>
+<speed>1.5249754</speed>
+<bearing>151.63582</bearing>
+<bearingAccuracyDegrees>12.671232</bearingAccuracyDegrees>
+<time>1746104523320</time>
+</trkpt>
+<trkpt lat="55.9409708" lon="-4.3204936">
+<ele>113.9000015258789></ele>
+<accuracy>5.032</accuracy>
+<speed>1.5313897</speed>
+<bearing>152.73741</bearing>
+<bearingAccuracyDegrees>12.474231</bearingAccuracyDegrees>
+<time>1746104524382</time>
+</trkpt>
+<trkpt lat="55.9409545" lon="-4.3204888">
+<ele>113.9000015258789></ele>
+<accuracy>5.214</accuracy>
+<speed>1.528959</speed>
+<bearing>154.3743</bearing>
+<bearingAccuracyDegrees>12.37938</bearingAccuracyDegrees>
+<time>1746104525402</time>
+</trkpt>
+<trkpt lat="55.9409381" lon="-4.3204838">
+<ele>113.9000015258789></ele>
+<accuracy>5.429</accuracy>
+<speed>1.5113834</speed>
+<bearing>154.50252</bearing>
+<bearingAccuracyDegrees>12.751493</bearingAccuracyDegrees>
+<time>1746104526465</time>
+</trkpt>
+<trkpt lat="55.9409215" lon="-4.320479">
+<ele>113.9000015258789></ele>
+<accuracy>5.743</accuracy>
+<speed>1.482314</speed>
+<bearing>155.90877</bearing>
+<bearingAccuracyDegrees>12.893477</bearingAccuracyDegrees>
+<time>1746104527529</time>
+</trkpt>
+<trkpt lat="55.9409053" lon="-4.3204736">
+<ele>113.9000015258789></ele>
+<accuracy>5.976</accuracy>
+<speed>1.49506</speed>
+<bearing>156.2523</bearing>
+<bearingAccuracyDegrees>13.150567</bearingAccuracyDegrees>
+<time>1746104528545</time>
+</trkpt>
+<trkpt lat="55.9408885" lon="-4.3204667">
+<ele>113.9000015258789></ele>
+<accuracy>6.108</accuracy>
+<speed>1.4874141</speed>
+<bearing>153.75923</bearing>
+<bearingAccuracyDegrees>12.616571</bearingAccuracyDegrees>
+<time>1746104529584</time>
+</trkpt>
+<trkpt lat="55.9408723" lon="-4.3204582">
+<ele>113.9000015258789></ele>
+<accuracy>6.139</accuracy>
+<speed>1.495124</speed>
+<bearing>155.29497</bearing>
+<bearingAccuracyDegrees>12.27578</bearingAccuracyDegrees>
+<time>1746104530585</time>
+</trkpt>
+<trkpt lat="55.9408548" lon="-4.3204503">
+<ele>113.9000015258789></ele>
+<accuracy>6.038</accuracy>
+<speed>1.5270054</speed>
+<bearing>158.6142</bearing>
+<bearingAccuracyDegrees>12.033533</bearingAccuracyDegrees>
+<time>1746104531609</time>
+</trkpt>
+<trkpt lat="55.9407541" lon="-4.3203863">
+<ele>113.9000015258789></ele>
+<accuracy>4.054</accuracy>
+<speed>1.5835464</speed>
+<bearing>160.77863</bearing>
+<bearingAccuracyDegrees>8.736234</bearingAccuracyDegrees>
+<time>1746104537549</time>
+</trkpt>
+<trkpt lat="55.9407348" lon="-4.3203766">
+<ele>113.9000015258789></ele>
+<accuracy>3.523</accuracy>
+<speed>1.6015114</speed>
+<bearing>160.77321</bearing>
+<bearingAccuracyDegrees>8.95014</bearingAccuracyDegrees>
+<time>1746104538551</time>
+</trkpt>
+<trkpt lat="55.9407147" lon="-4.3203621">
+<ele>113.9000015258789></ele>
+<accuracy>3.118</accuracy>
+<speed>1.6492704</speed>
+<bearing>155.79276</bearing>
+<bearingAccuracyDegrees>8.666773</bearingAccuracyDegrees>
+<time>1746104539553</time>
+</trkpt>
+<trkpt lat="55.9406937" lon="-4.3203486">
+<ele>113.9000015258789></ele>
+<accuracy>3.018</accuracy>
+<speed>1.6382917</speed>
+<bearing>159.39</bearing>
+<bearingAccuracyDegrees>7.046924</bearingAccuracyDegrees>
+<time>1746104540556</time>
+</trkpt>
+<trkpt lat="55.9406742" lon="-4.3203384">
+<ele>113.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.626548</speed>
+<bearing>163.41455</bearing>
+<bearingAccuracyDegrees>9.463667</bearingAccuracyDegrees>
+<time>1746104541558</time>
+</trkpt>
+<trkpt lat="55.9406572" lon="-4.3203289">
+<ele>113.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.6170353</speed>
+<bearing>163.30663</bearing>
+<bearingAccuracyDegrees>9.020182</bearingAccuracyDegrees>
+<time>1746104542463</time>
+</trkpt>
+<trkpt lat="55.9406432" lon="-4.3203195">
+<ele>113.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5848994</speed>
+<bearing>157.7685</bearing>
+<bearingAccuracyDegrees>9.440749</bearingAccuracyDegrees>
+<time>1746104543504</time>
+</trkpt>
+<trkpt lat="55.9406306" lon="-4.3203096">
+<ele>113.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5613847</speed>
+<bearing>157.10736</bearing>
+<bearingAccuracyDegrees>9.189368</bearingAccuracyDegrees>
+<time>1746104544548</time>
+</trkpt>
+<trkpt lat="55.9406183" lon="-4.3202997">
+<ele>113.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5543761</speed>
+<bearing>158.55882</bearing>
+<bearingAccuracyDegrees>9.569239</bearingAccuracyDegrees>
+<time>1746104545589</time>
+</trkpt>
+<trkpt lat="55.9406065" lon="-4.3202909">
+<ele>113.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5571308</speed>
+<bearing>160.40062</bearing>
+<bearingAccuracyDegrees>9.269904</bearingAccuracyDegrees>
+<time>1746104546570</time>
+</trkpt>
+<trkpt lat="55.9405926" lon="-4.320281">
+<ele>113.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5602897</speed>
+<bearing>171.48953</bearing>
+<bearingAccuracyDegrees>9.092474</bearingAccuracyDegrees>
+<time>1746104547572</time>
+</trkpt>
+<trkpt lat="55.9405804" lon="-4.3202784">
+<ele>113.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5435174</speed>
+<bearing>187.75261</bearing>
+<bearingAccuracyDegrees>9.084735</bearingAccuracyDegrees>
+<time>1746104548575</time>
+</trkpt>
+<trkpt lat="55.9405706" lon="-4.3202856">
+<ele>113.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5039326</speed>
+<bearing>207.1689</bearing>
+<bearingAccuracyDegrees>8.9214325</bearingAccuracyDegrees>
+<time>1746104549576</time>
+</trkpt>
+<trkpt lat="55.9405629" lon="-4.3203027">
+<ele>113.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4871938</speed>
+<bearing>225.38249</bearing>
+<bearingAccuracyDegrees>8.872183</bearingAccuracyDegrees>
+<time>1746104550579</time>
+</trkpt>
+<trkpt lat="55.9405587" lon="-4.3203242">
+<ele>113.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4631612</speed>
+<bearing>238.99187</bearing>
+<bearingAccuracyDegrees>8.57594</bearingAccuracyDegrees>
+<time>1746104551582</time>
+</trkpt>
+<trkpt lat="55.9405578" lon="-4.3203487">
+<ele>113.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4402338</speed>
+<bearing>247.33661</bearing>
+<bearingAccuracyDegrees>8.708458</bearingAccuracyDegrees>
+<time>1746104552584</time>
+</trkpt>
+<trkpt lat="55.9405561" lon="-4.3203756">
+<ele>115.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4445444</speed>
+<bearing>250.12117</bearing>
+<bearingAccuracyDegrees>9.082665</bearingAccuracyDegrees>
+<time>1746104553586</time>
+</trkpt>
+<trkpt lat="55.9405513" lon="-4.3204008">
+<ele>115.0></ele>
+<accuracy>3.004</accuracy>
+<speed>1.4392937</speed>
+<bearing>250.9033</bearing>
+<bearingAccuracyDegrees>9.307871</bearingAccuracyDegrees>
+<time>1746104554563</time>
+</trkpt>
+<trkpt lat="55.940547" lon="-4.3204243">
+<ele>115.0></ele>
+<accuracy>3.07</accuracy>
+<speed>1.4137431</speed>
+<bearing>244.2241</bearing>
+<bearingAccuracyDegrees>10.139153</bearingAccuracyDegrees>
+<time>1746104555591</time>
+</trkpt>
+<trkpt lat="55.9405423" lon="-4.3204459">
+<ele>115.0></ele>
+<accuracy>3.197</accuracy>
+<speed>1.4070529</speed>
+<bearing>243.7748</bearing>
+<bearingAccuracyDegrees>10.019039</bearingAccuracyDegrees>
+<time>1746104556492</time>
+</trkpt>
+<trkpt lat="55.9405376" lon="-4.3204705">
+<ele>115.0></ele>
+<accuracy>3.407</accuracy>
+<speed>1.4085342</speed>
+<bearing>248.87386</bearing>
+<bearingAccuracyDegrees>11.799473</bearingAccuracyDegrees>
+<time>1746104557596</time>
+</trkpt>
+<trkpt lat="55.9405338" lon="-4.3204931">
+<ele>115.0></ele>
+<accuracy>3.629</accuracy>
+<speed>1.3877609</speed>
+<bearing>250.95055</bearing>
+<bearingAccuracyDegrees>11.959417</bearingAccuracyDegrees>
+<time>1746104558598</time>
+</trkpt>
+<trkpt lat="55.9405308" lon="-4.3205144">
+<ele>115.0></ele>
+<accuracy>3.901</accuracy>
+<speed>1.3682734</speed>
+<bearing>252.31276</bearing>
+<bearingAccuracyDegrees>12.482104</bearingAccuracyDegrees>
+<time>1746104559500</time>
+</trkpt>
+<trkpt lat="55.9405279" lon="-4.3205392">
+<ele>115.0></ele>
+<accuracy>4.207</accuracy>
+<speed>1.348103</speed>
+<bearing>255.90265</bearing>
+<bearingAccuracyDegrees>12.220526</bearingAccuracyDegrees>
+<time>1746104560527</time>
+</trkpt>
+<trkpt lat="55.940526" lon="-4.3205653">
+<ele>115.0></ele>
+<accuracy>4.498</accuracy>
+<speed>1.3481113</speed>
+<bearing>259.34344</bearing>
+<bearingAccuracyDegrees>12.08294</bearingAccuracyDegrees>
+<time>1746104561591</time>
+</trkpt>
+<trkpt lat="55.9405248" lon="-4.3205903">
+<ele>115.0></ele>
+<accuracy>4.746</accuracy>
+<speed>1.3702215</speed>
+<bearing>261.44693</bearing>
+<bearingAccuracyDegrees>12.6514635</bearingAccuracyDegrees>
+<time>1746104562646</time>
+</trkpt>
+<trkpt lat="55.9405157" lon="-4.3206142">
+<ele>115.0999984741211></ele>
+<accuracy>4.982</accuracy>
+<speed>1.3863709</speed>
+<bearing>253.71304</bearing>
+<bearingAccuracyDegrees>12.146471</bearingAccuracyDegrees>
+<time>1746104563745</time>
+</trkpt>
+<trkpt lat="55.9405081" lon="-4.3206394">
+<ele>115.0999984741211></ele>
+<accuracy>5.185</accuracy>
+<speed>1.4052823</speed>
+<bearing>245.31009</bearing>
+<bearingAccuracyDegrees>11.887888</bearingAccuracyDegrees>
+<time>1746104564844</time>
+</trkpt>
+<trkpt lat="55.9405034" lon="-4.3206634">
+<ele>115.0999984741211></ele>
+<accuracy>5.316</accuracy>
+<speed>1.4022543</speed>
+<bearing>246.64307</bearing>
+<bearingAccuracyDegrees>12.240293</bearingAccuracyDegrees>
+<time>1746104565868</time>
+</trkpt>
+<trkpt lat="55.9404994" lon="-4.320689">
+<ele>115.0999984741211></ele>
+<accuracy>5.44</accuracy>
+<speed>1.3885978</speed>
+<bearing>246.71634</bearing>
+<bearingAccuracyDegrees>12.37865</bearingAccuracyDegrees>
+<time>1746104566960</time>
+</trkpt>
+<trkpt lat="55.9404956" lon="-4.3207133">
+<ele>115.0999984741211></ele>
+<accuracy>5.506</accuracy>
+<speed>1.377719</speed>
+<bearing>248.31241</bearing>
+<bearingAccuracyDegrees>12.159445</bearingAccuracyDegrees>
+<time>1746104568044</time>
+</trkpt>
+<trkpt lat="55.9404869" lon="-4.3207404">
+<ele>115.30000305175781></ele>
+<accuracy>5.59</accuracy>
+<speed>1.374204</speed>
+<bearing>248.44298</bearing>
+<bearingAccuracyDegrees>11.992706</bearingAccuracyDegrees>
+<time>1746104569166</time>
+</trkpt>
+<trkpt lat="55.9404817" lon="-4.320765">
+<ele>115.30000305175781></ele>
+<accuracy>5.615</accuracy>
+<speed>1.3619889</speed>
+<bearing>248.69046</bearing>
+<bearingAccuracyDegrees>11.844185</bearingAccuracyDegrees>
+<time>1746104570250</time>
+</trkpt>
+<trkpt lat="55.9404519" lon="-4.3209011">
+<ele>115.0999984741211></ele>
+<accuracy>5.289</accuracy>
+<speed>1.4046218</speed>
+<bearing>250.23682</bearing>
+<bearingAccuracyDegrees>11.769668</bearingAccuracyDegrees>
+<time>1746104576540</time>
+</trkpt>
+<trkpt lat="55.9404386" lon="-4.3209485">
+<ele>116.0></ele>
+<accuracy>5.092</accuracy>
+<speed>1.4684244</speed>
+<bearing>247.35277</bearing>
+<bearingAccuracyDegrees>11.981579</bearingAccuracyDegrees>
+<time>1746104578543</time>
+</trkpt>
+<trkpt lat="55.9404292" lon="-4.3209736">
+<ele>116.0></ele>
+<accuracy>5.022</accuracy>
+<speed>1.4725643</speed>
+<bearing>246.71648</bearing>
+<bearingAccuracyDegrees>12.070209</bearingAccuracyDegrees>
+<time>1746104579546</time>
+</trkpt>
+<trkpt lat="55.9404231" lon="-4.3209995">
+<ele>116.0></ele>
+<accuracy>5.012</accuracy>
+<speed>1.4672742</speed>
+<bearing>245.38042</bearing>
+<bearingAccuracyDegrees>12.091166</bearingAccuracyDegrees>
+<time>1746104580548</time>
+</trkpt>
+<trkpt lat="55.9404177" lon="-4.321026">
+<ele>116.0></ele>
+<accuracy>5.068</accuracy>
+<speed>1.4858195</speed>
+<bearing>245.80925</bearing>
+<bearingAccuracyDegrees>13.090643</bearingAccuracyDegrees>
+<time>1746104581551</time>
+</trkpt>
+<trkpt lat="55.9404118" lon="-4.3210518">
+<ele>116.0></ele>
+<accuracy>5.153</accuracy>
+<speed>1.4661223</speed>
+<bearing>246.88193</bearing>
+<bearingAccuracyDegrees>12.980708</bearingAccuracyDegrees>
+<time>1746104582487</time>
+</trkpt>
+<trkpt lat="55.9404056" lon="-4.3210824">
+<ele>116.0></ele>
+<accuracy>5.314</accuracy>
+<speed>1.4818001</speed>
+<bearing>248.86336</bearing>
+<bearingAccuracyDegrees>12.953319</bearingAccuracyDegrees>
+<time>1746104583542</time>
+</trkpt>
+<trkpt lat="55.9403997" lon="-4.321113">
+<ele>116.0></ele>
+<accuracy>5.45</accuracy>
+<speed>1.483021</speed>
+<bearing>246.32521</bearing>
+<bearingAccuracyDegrees>12.923484</bearingAccuracyDegrees>
+<time>1746104584558</time>
+</trkpt>
+<trkpt lat="55.9403912" lon="-4.3211435">
+<ele>116.0></ele>
+<accuracy>5.49</accuracy>
+<speed>1.5126348</speed>
+<bearing>240.88673</bearing>
+<bearingAccuracyDegrees>13.387477</bearingAccuracyDegrees>
+<time>1746104585561</time>
+</trkpt>
+<trkpt lat="55.9403814" lon="-4.3211707">
+<ele>116.0></ele>
+<accuracy>5.524</accuracy>
+<speed>1.5250818</speed>
+<bearing>243.15144</bearing>
+<bearingAccuracyDegrees>12.908126</bearingAccuracyDegrees>
+<time>1746104586563</time>
+</trkpt>
+<trkpt lat="55.9403725" lon="-4.3211958">
+<ele>116.0></ele>
+<accuracy>5.476</accuracy>
+<speed>1.5283343</speed>
+<bearing>244.32613</bearing>
+<bearingAccuracyDegrees>12.751095</bearingAccuracyDegrees>
+<time>1746104587564</time>
+</trkpt>
+<trkpt lat="55.9403416" lon="-4.3213752">
+<ele>116.0></ele>
+<accuracy>3.966</accuracy>
+<speed>1.4926662</speed>
+<bearing>248.21326</bearing>
+<bearingAccuracyDegrees>9.860554</bearingAccuracyDegrees>
+<time>1746104594488</time>
+</trkpt>
+<trkpt lat="55.940333" lon="-4.3214253">
+<ele>116.0></ele>
+<accuracy>3.211</accuracy>
+<speed>1.4401877</speed>
+<bearing>248.03122</bearing>
+<bearingAccuracyDegrees>9.792853</bearingAccuracyDegrees>
+<time>1746104596560</time>
+</trkpt>
+<trkpt lat="55.9403282" lon="-4.3214451">
+<ele>116.0></ele>
+<accuracy>3.096</accuracy>
+<speed>1.4372987</speed>
+<bearing>246.78647</bearing>
+<bearingAccuracyDegrees>9.817869</bearingAccuracyDegrees>
+<time>1746104597589</time>
+</trkpt>
+<trkpt lat="55.9403225" lon="-4.3214656">
+<ele>116.0></ele>
+<accuracy>3.048</accuracy>
+<speed>1.4422503</speed>
+<bearing>245.03212</bearing>
+<bearingAccuracyDegrees>9.716429</bearingAccuracyDegrees>
+<time>1746104598591</time>
+</trkpt>
+<trkpt lat="55.9403157" lon="-4.3214882">
+<ele>116.0></ele>
+<accuracy>3.031</accuracy>
+<speed>1.4525955</speed>
+<bearing>242.00836</bearing>
+<bearingAccuracyDegrees>10.1735525</bearingAccuracyDegrees>
+<time>1746104599593</time>
+</trkpt>
+<trkpt lat="55.9403081" lon="-4.3215093">
+<ele>116.0></ele>
+<accuracy>3.023</accuracy>
+<speed>1.4471104</speed>
+<bearing>251.22157</bearing>
+<bearingAccuracyDegrees>9.424806</bearingAccuracyDegrees>
+<time>1746104600596</time>
+</trkpt>
+<trkpt lat="55.9403068" lon="-4.3215312">
+<ele>116.0></ele>
+<accuracy>3.038</accuracy>
+<speed>1.4075899</speed>
+<bearing>290.39352</bearing>
+<bearingAccuracyDegrees>9.8300705</bearingAccuracyDegrees>
+<time>1746104601498</time>
+</trkpt>
+<trkpt lat="55.9403077" lon="-4.3215536">
+<ele>116.0></ele>
+<accuracy>3.038</accuracy>
+<speed>1.3969154</speed>
+<bearing>253.61703</bearing>
+<bearingAccuracyDegrees>9.28763</bearingAccuracyDegrees>
+<time>1746104602500</time>
+</trkpt>
+<trkpt lat="55.9402993" lon="-4.3215761">
+<ele>116.0></ele>
+<accuracy>3.046</accuracy>
+<speed>1.4055306</speed>
+<bearing>243.87335</bearing>
+<bearingAccuracyDegrees>9.406618</bearingAccuracyDegrees>
+<time>1746104603424</time>
+</trkpt>
+<trkpt lat="55.9402888" lon="-4.3216025">
+<ele>116.0></ele>
+<accuracy>3.065</accuracy>
+<speed>1.427676</speed>
+<bearing>239.39516</bearing>
+<bearingAccuracyDegrees>9.510406</bearingAccuracyDegrees>
+<time>1746104604487</time>
+</trkpt>
+<trkpt lat="55.9402791" lon="-4.3216248">
+<ele>116.0></ele>
+<accuracy>3.074</accuracy>
+<speed>1.4308962</speed>
+<bearing>238.18752</bearing>
+<bearingAccuracyDegrees>9.931276</bearingAccuracyDegrees>
+<time>1746104605519</time>
+</trkpt>
+<trkpt lat="55.9402698" lon="-4.3216462">
+<ele>116.0></ele>
+<accuracy>3.075</accuracy>
+<speed>1.4329122</speed>
+<bearing>238.97482</bearing>
+<bearingAccuracyDegrees>9.331706</bearingAccuracyDegrees>
+<time>1746104606585</time>
+</trkpt>
+<trkpt lat="55.9402615" lon="-4.3216665">
+<ele>116.0></ele>
+<accuracy>3.077</accuracy>
+<speed>1.4428943</speed>
+<bearing>238.47899</bearing>
+<bearingAccuracyDegrees>9.116037</bearingAccuracyDegrees>
+<time>1746104607612</time>
+</trkpt>
+<trkpt lat="55.9402544" lon="-4.3216853">
+<ele>116.0></ele>
+<accuracy>3.057</accuracy>
+<speed>1.429945</speed>
+<bearing>239.80745</bearing>
+<bearingAccuracyDegrees>8.964391</bearingAccuracyDegrees>
+<time>1746104608514</time>
+</trkpt>
+<trkpt lat="55.9402477" lon="-4.3217083">
+<ele>116.0></ele>
+<accuracy>3.041</accuracy>
+<speed>1.4475886</speed>
+<bearing>245.15797</bearing>
+<bearingAccuracyDegrees>8.992727</bearingAccuracyDegrees>
+<time>1746104609516</time>
+</trkpt>
+<trkpt lat="55.9402427" lon="-4.3217327">
+<ele>116.0></ele>
+<accuracy>3.028</accuracy>
+<speed>1.4483502</speed>
+<bearing>240.33566</bearing>
+<bearingAccuracyDegrees>9.41303</bearingAccuracyDegrees>
+<time>1746104610519</time>
+</trkpt>
+<trkpt lat="55.9402372" lon="-4.3217549">
+<ele>116.0></ele>
+<accuracy>3.019</accuracy>
+<speed>1.4071394</speed>
+<bearing>237.26564</bearing>
+<bearingAccuracyDegrees>9.617285</bearingAccuracyDegrees>
+<time>1746104611521</time>
+</trkpt>
+<trkpt lat="55.9402323" lon="-4.3217763">
+<ele>116.9000015258789></ele>
+<accuracy>3.009</accuracy>
+<speed>1.4177887</speed>
+<bearing>240.70802</bearing>
+<bearingAccuracyDegrees>9.727056</bearingAccuracyDegrees>
+<time>1746104612446</time>
+</trkpt>
+<trkpt lat="55.9402256" lon="-4.3218006">
+<ele>116.9000015258789></ele>
+<accuracy>3.064</accuracy>
+<speed>1.4093344</speed>
+<bearing>243.36539</bearing>
+<bearingAccuracyDegrees>9.728967</bearingAccuracyDegrees>
+<time>1746104613488</time>
+</trkpt>
+<trkpt lat="55.94022" lon="-4.3218261">
+<ele>116.9000015258789></ele>
+<accuracy>3.181</accuracy>
+<speed>1.4135668</speed>
+<bearing>245.14584</bearing>
+<bearingAccuracyDegrees>9.545589</bearingAccuracyDegrees>
+<time>1746104614543</time>
+</trkpt>
+<trkpt lat="55.9402149" lon="-4.3218508">
+<ele>116.9000015258789></ele>
+<accuracy>3.321</accuracy>
+<speed>1.4394997</speed>
+<bearing>245.50195</bearing>
+<bearingAccuracyDegrees>9.651202</bearingAccuracyDegrees>
+<time>1746104615584</time>
+</trkpt>
+<trkpt lat="55.9402111" lon="-4.3218775">
+<ele>116.9000015258789></ele>
+<accuracy>3.526</accuracy>
+<speed>1.44567</speed>
+<bearing>249.20863</bearing>
+<bearingAccuracyDegrees>10.572591</bearingAccuracyDegrees>
+<time>1746104616626</time>
+</trkpt>
+<trkpt lat="55.9402086" lon="-4.3219015">
+<ele>116.9000015258789></ele>
+<accuracy>3.891</accuracy>
+<speed>1.4734248</speed>
+<bearing>246.3762</bearing>
+<bearingAccuracyDegrees>11.64549</bearingAccuracyDegrees>
+<time>1746104617535</time>
+</trkpt>
+<trkpt lat="55.9402041" lon="-4.3219273">
+<ele>116.9000015258789></ele>
+<accuracy>4.13</accuracy>
+<speed>1.4624547</speed>
+<bearing>244.24057</bearing>
+<bearingAccuracyDegrees>11.717055</bearingAccuracyDegrees>
+<time>1746104618536</time>
+</trkpt>
+<trkpt lat="55.9402004" lon="-4.3219513">
+<ele>116.9000015258789></ele>
+<accuracy>4.436</accuracy>
+<speed>1.4431189</speed>
+<bearing>246.00847</bearing>
+<bearingAccuracyDegrees>12.235926</bearingAccuracyDegrees>
+<time>1746104619540</time>
+</trkpt>
+<trkpt lat="55.9401956" lon="-4.3219753">
+<ele>116.9000015258789></ele>
+<accuracy>4.661</accuracy>
+<speed>1.440308</speed>
+<bearing>246.76299</bearing>
+<bearingAccuracyDegrees>12.154114</bearingAccuracyDegrees>
+<time>1746104620542</time>
+</trkpt>
+<trkpt lat="55.9401877" lon="-4.3220015">
+<ele>117.0999984741211></ele>
+<accuracy>4.906</accuracy>
+<speed>1.4361069</speed>
+<bearing>245.41327</bearing>
+<bearingAccuracyDegrees>12.11229</bearingAccuracyDegrees>
+<time>1746104621543</time>
+</trkpt>
+<trkpt lat="55.9401821" lon="-4.322023">
+<ele>117.0999984741211></ele>
+<accuracy>5.04</accuracy>
+<speed>1.4192584</speed>
+<bearing>245.88023</bearing>
+<bearingAccuracyDegrees>11.851863</bearingAccuracyDegrees>
+<time>1746104622459</time>
+</trkpt>
+<trkpt lat="55.9401769" lon="-4.3220446">
+<ele>117.0999984741211></ele>
+<accuracy>5.254</accuracy>
+<speed>1.3929695</speed>
+<bearing>248.98944</bearing>
+<bearingAccuracyDegrees>12.069291</bearingAccuracyDegrees>
+<time>1746104623508</time>
+</trkpt>
+<trkpt lat="55.9401725" lon="-4.3220704">
+<ele>117.0999984741211></ele>
+<accuracy>5.458</accuracy>
+<speed>1.3961735</speed>
+<bearing>250.58246</bearing>
+<bearingAccuracyDegrees>12.026274</bearingAccuracyDegrees>
+<time>1746104624606</time>
+</trkpt>
+<trkpt lat="55.9401693" lon="-4.3220905">
+<ele>117.0999984741211></ele>
+<accuracy>5.658</accuracy>
+<speed>1.3818002</speed>
+<bearing>249.36205</bearing>
+<bearingAccuracyDegrees>12.250202</bearingAccuracyDegrees>
+<time>1746104625553</time>
+</trkpt>
+<trkpt lat="55.9401614" lon="-4.3221184">
+<ele>117.19999694824219></ele>
+<accuracy>5.935</accuracy>
+<speed>1.4411801</speed>
+<bearing>245.64485</bearing>
+<bearingAccuracyDegrees>12.6315975</bearingAccuracyDegrees>
+<time>1746104626556</time>
+</trkpt>
+<trkpt lat="55.9401527" lon="-4.3221456">
+<ele>117.19999694824219></ele>
+<accuracy>6.184</accuracy>
+<speed>1.4570202</speed>
+<bearing>249.83614</bearing>
+<bearingAccuracyDegrees>12.900317</bearingAccuracyDegrees>
+<time>1746104627558</time>
+</trkpt>
+<trkpt lat="55.9401514" lon="-4.3221681">
+<ele>117.19999694824219></ele>
+<accuracy>6.315</accuracy>
+<speed>1.4262915</speed>
+<bearing>254.78592</bearing>
+<bearingAccuracyDegrees>12.69808</bearingAccuracyDegrees>
+<time>1746104628561</time>
+</trkpt>
+<trkpt lat="55.9401515" lon="-4.322192">
+<ele>117.19999694824219></ele>
+<accuracy>6.458</accuracy>
+<speed>1.4173698</speed>
+<bearing>256.12234</bearing>
+<bearingAccuracyDegrees>12.235367</bearingAccuracyDegrees>
+<time>1746104629563</time>
+</trkpt>
+<trkpt lat="55.9401489" lon="-4.3222143">
+<ele>117.19999694824219></ele>
+<accuracy>6.474</accuracy>
+<speed>1.4194971</speed>
+<bearing>253.38226</bearing>
+<bearingAccuracyDegrees>12.011232</bearingAccuracyDegrees>
+<time>1746104630489</time>
+</trkpt>
+<trkpt lat="55.9401453" lon="-4.3222346">
+<ele>117.19999694824219></ele>
+<accuracy>6.443</accuracy>
+<speed>1.4013988</speed>
+<bearing>251.4625</bearing>
+<bearingAccuracyDegrees>11.952507</bearingAccuracyDegrees>
+<time>1746104631467</time>
+</trkpt>
+<trkpt lat="55.9401255" lon="-4.3222701">
+<ele>117.19999694824219></ele>
+<accuracy>6.199</accuracy>
+<speed>1.4151944</speed>
+<bearing>248.1161</bearing>
+<bearingAccuracyDegrees>11.699632</bearingAccuracyDegrees>
+<time>1746104632570</time>
+</trkpt>
+<trkpt lat="55.9401219" lon="-4.3222934">
+<ele>117.19999694824219></ele>
+<accuracy>5.981</accuracy>
+<speed>1.417145</speed>
+<bearing>246.71024</bearing>
+<bearingAccuracyDegrees>10.409294</bearingAccuracyDegrees>
+<time>1746104633572</time>
+</trkpt>
+<trkpt lat="55.9401169" lon="-4.3223167">
+<ele>117.19999694824219></ele>
+<accuracy>5.81</accuracy>
+<speed>1.4252268</speed>
+<bearing>247.36165</bearing>
+<bearingAccuracyDegrees>11.740284</bearingAccuracyDegrees>
+<time>1746104634575</time>
+</trkpt>
+<trkpt lat="55.9401127" lon="-4.322341">
+<ele>117.19999694824219></ele>
+<accuracy>5.758</accuracy>
+<speed>1.4286325</speed>
+<bearing>251.2303</bearing>
+<bearingAccuracyDegrees>12.060365</bearingAccuracyDegrees>
+<time>1746104635576</time>
+</trkpt>
+<trkpt lat="55.9401085" lon="-4.3223646">
+<ele>117.19999694824219></ele>
+<accuracy>5.711</accuracy>
+<speed>1.4457575</speed>
+<bearing>252.81192</bearing>
+<bearingAccuracyDegrees>12.447379</bearingAccuracyDegrees>
+<time>1746104636579</time>
+</trkpt>
+<trkpt lat="55.9401046" lon="-4.3223867">
+<ele>117.19999694824219></ele>
+<accuracy>5.733</accuracy>
+<speed>1.4294991</speed>
+<bearing>253.61118</bearing>
+<bearingAccuracyDegrees>12.367201</bearingAccuracyDegrees>
+<time>1746104637582</time>
+</trkpt>
+<trkpt lat="55.9401011" lon="-4.3224057">
+<ele>117.19999694824219></ele>
+<accuracy>5.765</accuracy>
+<speed>1.4003402</speed>
+<bearing>256.86252</bearing>
+<bearingAccuracyDegrees>12.559097</bearingAccuracyDegrees>
+<time>1746104638521</time>
+</trkpt>
+<trkpt lat="55.940082" lon="-4.3224959">
+<ele>117.19999694824219></ele>
+<accuracy>5.571</accuracy>
+<speed>1.4006832</speed>
+<bearing>256.6822</bearing>
+<bearingAccuracyDegrees>12.176447</bearingAccuracyDegrees>
+<time>1746104642592</time>
+</trkpt>
+<trkpt lat="55.9400805" lon="-4.3226173">
+<ele>117.19999694824219></ele>
+<accuracy>5.401</accuracy>
+<speed>1.3604864</speed>
+<bearing>256.7262</bearing>
+<bearingAccuracyDegrees>12.6673565</bearingAccuracyDegrees>
+<time>1746104647504</time>
+</trkpt>
+<trkpt lat="55.9400794" lon="-4.3226404">
+<ele>117.19999694824219></ele>
+<accuracy>5.45</accuracy>
+<speed>1.336591</speed>
+<bearing>259.7753</bearing>
+<bearingAccuracyDegrees>13.0273285</bearingAccuracyDegrees>
+<time>1746104648507</time>
+</trkpt>
+<trkpt lat="55.9400777" lon="-4.3226586">
+<ele>117.0999984741211></ele>
+<accuracy>5.524</accuracy>
+<speed>1.3244232</speed>
+<bearing>241.09196</bearing>
+<bearingAccuracyDegrees>12.986514</bearingAccuracyDegrees>
+<time>1746104649408</time>
+</trkpt>
+<trkpt lat="55.9400592" lon="-4.3226597">
+<ele>117.0999984741211></ele>
+<accuracy>5.576</accuracy>
+<speed>1.2825345</speed>
+<bearing>209.85127</bearing>
+<bearingAccuracyDegrees>12.745161</bearingAccuracyDegrees>
+<time>1746104650365</time>
+</trkpt>
+<trkpt lat="55.9400534" lon="-4.3226754">
+<ele>117.0999984741211></ele>
+<accuracy>5.645</accuracy>
+<speed>1.2922903</speed>
+<bearing>247.60905</bearing>
+<bearingAccuracyDegrees>14.48652</bearingAccuracyDegrees>
+<time>1746104651386</time>
+</trkpt>
+<trkpt lat="55.9400494" lon="-4.3226971">
+<ele>117.0999984741211></ele>
+<accuracy>5.714</accuracy>
+<speed>1.3009043</speed>
+<bearing>218.83263</bearing>
+<bearingAccuracyDegrees>13.310413</bearingAccuracyDegrees>
+<time>1746104652480</time>
+</trkpt>
+<trkpt lat="55.9400414" lon="-4.3227089">
+<ele>117.0999984741211></ele>
+<accuracy>5.782</accuracy>
+<speed>1.2767887</speed>
+<bearing>185.98447</bearing>
+<bearingAccuracyDegrees>13.28494</bearingAccuracyDegrees>
+<time>1746104653519</time>
+</trkpt>
+<trkpt lat="55.9400269" lon="-4.3227007">
+<ele>117.19999694824219></ele>
+<accuracy>5.745</accuracy>
+<speed>1.2439269</speed>
+<bearing>161.49724</bearing>
+<bearingAccuracyDegrees>12.225505</bearingAccuracyDegrees>
+<time>1746104654685</time>
+</trkpt>
+<trkpt lat="55.9400133" lon="-4.3226897">
+<ele>117.19999694824219></ele>
+<accuracy>5.705</accuracy>
+<speed>1.2913885</speed>
+<bearing>170.494</bearing>
+<bearingAccuracyDegrees>12.428359</bearingAccuracyDegrees>
+<time>1746104655624</time>
+</trkpt>
+<trkpt lat="55.9400024" lon="-4.3226898">
+<ele>117.19999694824219></ele>
+<accuracy>5.583</accuracy>
+<speed>1.3303139</speed>
+<bearing>183.6428</bearing>
+<bearingAccuracyDegrees>12.358171</bearingAccuracyDegrees>
+<time>1746104656526</time>
+</trkpt>
+<trkpt lat="55.9399899" lon="-4.322697">
+<ele>117.19999694824219></ele>
+<accuracy>5.479</accuracy>
+<speed>1.4015899</speed>
+<bearing>186.82793</bearing>
+<bearingAccuracyDegrees>12.790551</bearingAccuracyDegrees>
+<time>1746104657528</time>
+</trkpt>
+<trkpt lat="55.9399759" lon="-4.3227056">
+<ele>117.19999694824219></ele>
+<accuracy>5.237</accuracy>
+<speed>1.433245</speed>
+<bearing>196.21526</bearing>
+<bearingAccuracyDegrees>12.394816</bearingAccuracyDegrees>
+<time>1746104658531</time>
+</trkpt>
+<trkpt lat="55.9399625" lon="-4.3227134">
+<ele>118.19999694824219></ele>
+<accuracy>5.095</accuracy>
+<speed>1.4291438</speed>
+<bearing>190.14758</bearing>
+<bearingAccuracyDegrees>12.449665</bearingAccuracyDegrees>
+<time>1746104659433</time>
+</trkpt>
+<trkpt lat="55.9399438" lon="-4.3227117">
+<ele>118.19999694824219></ele>
+<accuracy>5.027</accuracy>
+<speed>1.4317814</speed>
+<bearing>178.98143</bearing>
+<bearingAccuracyDegrees>12.350269</bearingAccuracyDegrees>
+<time>1746104660487</time>
+</trkpt>
+<trkpt lat="55.9399272" lon="-4.3227111">
+<ele>118.19999694824219></ele>
+<accuracy>4.963</accuracy>
+<speed>1.4241266</speed>
+<bearing>174.7263</bearing>
+<bearingAccuracyDegrees>12.550163</bearingAccuracyDegrees>
+<time>1746104661588</time>
+</trkpt>
+<trkpt lat="55.9399123" lon="-4.3227111">
+<ele>118.19999694824219></ele>
+<accuracy>4.954</accuracy>
+<speed>1.4498782</speed>
+<bearing>173.70285</bearing>
+<bearingAccuracyDegrees>12.259568</bearingAccuracyDegrees>
+<time>1746104662570</time>
+</trkpt>
+<trkpt lat="55.9398963" lon="-4.3227118">
+<ele>118.19999694824219></ele>
+<accuracy>5.011</accuracy>
+<speed>1.4781258</speed>
+<bearing>168.75911</bearing>
+<bearingAccuracyDegrees>12.377391</bearingAccuracyDegrees>
+<time>1746104663615</time>
+</trkpt>
+<trkpt lat="55.9398818" lon="-4.3227124">
+<ele>118.19999694824219></ele>
+<accuracy>5.057</accuracy>
+<speed>1.4750347</speed>
+<bearing>161.91943</bearing>
+<bearingAccuracyDegrees>11.847247</bearingAccuracyDegrees>
+<time>1746104664545</time>
+</trkpt>
+<trkpt lat="55.9398652" lon="-4.3227075">
+<ele>118.19999694824219></ele>
+<accuracy>5.117</accuracy>
+<speed>1.505505</speed>
+<bearing>154.06963</bearing>
+<bearingAccuracyDegrees>11.832169</bearingAccuracyDegrees>
+<time>1746104665547</time>
+</trkpt>
+<trkpt lat="55.9398503" lon="-4.3226963">
+<ele>118.19999694824219></ele>
+<accuracy>5.167</accuracy>
+<speed>1.5157819</speed>
+<bearing>148.89534</bearing>
+<bearingAccuracyDegrees>10.271298</bearingAccuracyDegrees>
+<time>1746104666549</time>
+</trkpt>
+<trkpt lat="55.9398366" lon="-4.3226823">
+<ele>118.19999694824219></ele>
+<accuracy>5.185</accuracy>
+<speed>1.5019724</speed>
+<bearing>145.849</bearing>
+<bearingAccuracyDegrees>11.807243</bearingAccuracyDegrees>
+<time>1746104667552</time>
+</trkpt>
+<trkpt lat="55.9398244" lon="-4.3226644">
+<ele>118.19999694824219></ele>
+<accuracy>5.181</accuracy>
+<speed>1.4972792</speed>
+<bearing>143.10457</bearing>
+<bearingAccuracyDegrees>12.390438</bearingAccuracyDegrees>
+<time>1746104668554</time>
+</trkpt>
+<trkpt lat="55.9398145" lon="-4.3226461">
+<ele>118.19999694824219></ele>
+<accuracy>5.139</accuracy>
+<speed>1.4692035</speed>
+<bearing>142.98605</bearing>
+<bearingAccuracyDegrees>12.649246</bearingAccuracyDegrees>
+<time>1746104669483</time>
+</trkpt>
+<trkpt lat="55.9398038" lon="-4.3226283">
+<ele>118.19999694824219></ele>
+<accuracy>5.173</accuracy>
+<speed>1.4479344</speed>
+<bearing>140.94765</bearing>
+<bearingAccuracyDegrees>12.274695</bearingAccuracyDegrees>
+<time>1746104670543</time>
+</trkpt>
+<trkpt lat="55.9397945" lon="-4.322611">
+<ele>118.19999694824219></ele>
+<accuracy>5.217</accuracy>
+<speed>1.4276466</speed>
+<bearing>139.2703</bearing>
+<bearingAccuracyDegrees>12.027404</bearingAccuracyDegrees>
+<time>1746104671584</time>
+</trkpt>
+<trkpt lat="55.9397936" lon="-4.3225946">
+<ele>118.19999694824219></ele>
+<accuracy>4.84</accuracy>
+<speed>1.4221429</speed>
+<bearing>139.46317</bearing>
+<bearingAccuracyDegrees>9.483355</bearingAccuracyDegrees>
+<time>1746104672686</time>
+</trkpt>
+<trkpt lat="55.9397842" lon="-4.3225776">
+<ele>118.19999694824219></ele>
+<accuracy>4.395</accuracy>
+<speed>1.4277084</speed>
+<bearing>142.10806</bearing>
+<bearingAccuracyDegrees>9.641054</bearingAccuracyDegrees>
+<time>1746104673779</time>
+</trkpt>
+<trkpt lat="55.9397721" lon="-4.3225604">
+<ele>118.19999694824219></ele>
+<accuracy>3.934</accuracy>
+<speed>1.4120083</speed>
+<bearing>140.53242</bearing>
+<bearingAccuracyDegrees>9.715764</bearingAccuracyDegrees>
+<time>1746104674900</time>
+</trkpt>
+<trkpt lat="55.9397595" lon="-4.3225426">
+<ele>118.19999694824219></ele>
+<accuracy>3.428</accuracy>
+<speed>1.4094114</speed>
+<bearing>142.12971</bearing>
+<bearingAccuracyDegrees>9.8557205</bearingAccuracyDegrees>
+<time>1746104676003</time>
+</trkpt>
+<trkpt lat="55.9397458" lon="-4.3225245">
+<ele>118.19999694824219></ele>
+<accuracy>3.223</accuracy>
+<speed>1.4068552</speed>
+<bearing>139.68997</bearing>
+<bearingAccuracyDegrees>9.714457</bearingAccuracyDegrees>
+<time>1746104677106</time>
+</trkpt>
+<trkpt lat="55.9397312" lon="-4.3225062">
+<ele>118.19999694824219></ele>
+<accuracy>3.332</accuracy>
+<speed>1.4139396</speed>
+<bearing>143.05591</bearing>
+<bearingAccuracyDegrees>9.566574</bearingAccuracyDegrees>
+<time>1746104678240</time>
+</trkpt>
+<trkpt lat="55.9397173" lon="-4.3224895">
+<ele>118.19999694824219></ele>
+<accuracy>3.53</accuracy>
+<speed>1.4358966</speed>
+<bearing>141.19305</bearing>
+<bearingAccuracyDegrees>9.944793</bearingAccuracyDegrees>
+<time>1746104679321</time>
+</trkpt>
+<trkpt lat="55.9397011" lon="-4.3224746">
+<ele>118.19999694824219></ele>
+<accuracy>3.966</accuracy>
+<speed>1.4794893</speed>
+<bearing>207.12602</bearing>
+<bearingAccuracyDegrees>10.026242</bearingAccuracyDegrees>
+<time>1746104680582</time>
+</trkpt>
+<trkpt lat="55.9396917" lon="-4.3224968">
+<ele>118.19999694824219></ele>
+<accuracy>4.124</accuracy>
+<speed>1.5176481</speed>
+<bearing>220.3445</bearing>
+<bearingAccuracyDegrees>21.003204</bearingAccuracyDegrees>
+<time>1746104681583</time>
+</trkpt>
+<trkpt lat="55.939679" lon="-4.3225089">
+<ele>118.19999694824219></ele>
+<accuracy>4.286</accuracy>
+<speed>1.4923915</speed>
+<bearing>202.09418</bearing>
+<bearingAccuracyDegrees>19.300993</bearingAccuracyDegrees>
+<time>1746104682519</time>
+</trkpt>
+<trkpt lat="55.9396661" lon="-4.3225191">
+<ele>118.19999694824219></ele>
+<accuracy>4.43</accuracy>
+<speed>1.5382223</speed>
+<bearing>210.46846</bearing>
+<bearingAccuracyDegrees>19.147959</bearingAccuracyDegrees>
+<time>1746104683589</time>
+</trkpt>
+<trkpt lat="55.9396523" lon="-4.3225091">
+<ele>118.69999694824219></ele>
+<accuracy>4.558</accuracy>
+<speed>1.4900279</speed>
+<bearing>159.99568</bearing>
+<bearingAccuracyDegrees>18.428404</bearingAccuracyDegrees>
+<time>1746104684591</time>
+</trkpt>
+<trkpt lat="55.9396401" lon="-4.3224791">
+<ele>118.69999694824219></ele>
+<accuracy>4.619</accuracy>
+<speed>1.5043882</speed>
+<bearing>135.72383</bearing>
+<bearingAccuracyDegrees>18.111773</bearingAccuracyDegrees>
+<time>1746104685606</time>
+</trkpt>
+<trkpt lat="55.9396284" lon="-4.3224479">
+<ele>118.69999694824219></ele>
+<accuracy>4.721</accuracy>
+<speed>1.5277503</speed>
+<bearing>127.46029</bearing>
+<bearingAccuracyDegrees>15.912492</bearingAccuracyDegrees>
+<time>1746104686614</time>
+</trkpt>
+<trkpt lat="55.9396176" lon="-4.3224219">
+<ele>118.69999694824219></ele>
+<accuracy>4.867</accuracy>
+<speed>1.5339614</speed>
+<bearing>127.27978</bearing>
+<bearingAccuracyDegrees>15.594124</bearingAccuracyDegrees>
+<time>1746104687598</time>
+</trkpt>
+<trkpt lat="55.939605" lon="-4.3223958">
+<ele>118.69999694824219></ele>
+<accuracy>5.031</accuracy>
+<speed>1.5589361</speed>
+<bearing>127.3075</bearing>
+<bearingAccuracyDegrees>15.409164</bearingAccuracyDegrees>
+<time>1746104688601</time>
+</trkpt>
+<trkpt lat="55.9395919" lon="-4.3223761">
+<ele>118.69999694824219></ele>
+<accuracy>5.169</accuracy>
+<speed>1.5482954</speed>
+<bearing>129.27176</bearing>
+<bearingAccuracyDegrees>15.445976</bearingAccuracyDegrees>
+<time>1746104689503</time>
+</trkpt>
+<trkpt lat="55.9395789" lon="-4.3223558">
+<ele>118.69999694824219></ele>
+<accuracy>5.271</accuracy>
+<speed>1.566071</speed>
+<bearing>126.35332</bearing>
+<bearingAccuracyDegrees>12.696505</bearingAccuracyDegrees>
+<time>1746104690604</time>
+</trkpt>
+<trkpt lat="55.9395652" lon="-4.3223378">
+<ele>118.69999694824219></ele>
+<accuracy>5.388</accuracy>
+<speed>1.5645174</speed>
+<bearing>136.86949</bearing>
+<bearingAccuracyDegrees>12.513656</bearingAccuracyDegrees>
+<time>1746104691608</time>
+</trkpt>
+<trkpt lat="55.9395497" lon="-4.3223256">
+<ele>118.69999694824219></ele>
+<accuracy>5.478</accuracy>
+<speed>1.5377439</speed>
+<bearing>144.97804</bearing>
+<bearingAccuracyDegrees>10.151557</bearingAccuracyDegrees>
+<time>1746104692510</time>
+</trkpt>
+<trkpt lat="55.9395337" lon="-4.3223134">
+<ele>118.69999694824219></ele>
+<accuracy>5.474</accuracy>
+<speed>1.4890574</speed>
+<bearing>143.99219</bearing>
+<bearingAccuracyDegrees>10.044038</bearingAccuracyDegrees>
+<time>1746104693587</time>
+</trkpt>
+<trkpt lat="55.9395198" lon="-4.322303">
+<ele>118.69999694824219></ele>
+<accuracy>5.429</accuracy>
+<speed>1.4756565</speed>
+<bearing>143.1745</bearing>
+<bearingAccuracyDegrees>10.250623</bearingAccuracyDegrees>
+<time>1746104694513</time>
+</trkpt>
+<trkpt lat="55.9395053" lon="-4.3222902">
+<ele>118.69999694824219></ele>
+<accuracy>5.27</accuracy>
+<speed>1.4657289</speed>
+<bearing>140.83858</bearing>
+<bearingAccuracyDegrees>11.428033</bearingAccuracyDegrees>
+<time>1746104695516</time>
+</trkpt>
+<trkpt lat="55.9394919" lon="-4.3222754">
+<ele>118.69999694824219></ele>
+<accuracy>5.086</accuracy>
+<speed>1.4761075</speed>
+<bearing>141.8008</bearing>
+<bearingAccuracyDegrees>12.043982</bearingAccuracyDegrees>
+<time>1746104696519</time>
+</trkpt>
+<trkpt lat="55.9394709" lon="-4.322266">
+<ele>118.69999694824219></ele>
+<accuracy>4.812</accuracy>
+<speed>1.485415</speed>
+<bearing>150.12769</bearing>
+<bearingAccuracyDegrees>10.096324</bearingAccuracyDegrees>
+<time>1746104697521</time>
+</trkpt>
+<trkpt lat="55.9394525" lon="-4.3222561">
+<ele>118.69999694824219></ele>
+<accuracy>4.319</accuracy>
+<speed>1.4667158</speed>
+<bearing>153.0136</bearing>
+<bearingAccuracyDegrees>10.450532</bearingAccuracyDegrees>
+<time>1746104698624</time>
+</trkpt>
+<trkpt lat="55.9394395" lon="-4.3222495">
+<ele>118.69999694824219></ele>
+<accuracy>3.906</accuracy>
+<speed>1.4519337</speed>
+<bearing>157.35638</bearing>
+<bearingAccuracyDegrees>10.036753</bearingAccuracyDegrees>
+<time>1746104699526</time>
+</trkpt>
+<trkpt lat="55.9394261" lon="-4.3222429">
+<ele>118.69999694824219></ele>
+<accuracy>3.596</accuracy>
+<speed>1.42525</speed>
+<bearing>159.87459</bearing>
+<bearingAccuracyDegrees>9.721827</bearingAccuracyDegrees>
+<time>1746104700541</time>
+</trkpt>
+<trkpt lat="55.939413" lon="-4.3222364">
+<ele>118.69999694824219></ele>
+<accuracy>3.227</accuracy>
+<speed>1.4110426</speed>
+<bearing>157.87311</bearing>
+<bearingAccuracyDegrees>9.539561</bearingAccuracyDegrees>
+<time>1746104701584</time>
+</trkpt>
+<trkpt lat="55.9394013" lon="-4.3222303">
+<ele>118.69999694824219></ele>
+<accuracy>3.064</accuracy>
+<speed>1.4027249</speed>
+<bearing>155.34633</bearing>
+<bearingAccuracyDegrees>9.334997</bearingAccuracyDegrees>
+<time>1746104702533</time>
+</trkpt>
+<trkpt lat="55.9393874" lon="-4.3222244">
+<ele>118.69999694824219></ele>
+<accuracy>3.009</accuracy>
+<speed>1.4196913</speed>
+<bearing>157.93773</bearing>
+<bearingAccuracyDegrees>9.8977585</bearingAccuracyDegrees>
+<time>1746104703535</time>
+</trkpt>
+<trkpt lat="55.9393723" lon="-4.3222196">
+<ele>118.69999694824219></ele>
+<accuracy>3.009</accuracy>
+<speed>1.4375447</speed>
+<bearing>154.94547</bearing>
+<bearingAccuracyDegrees>9.0430565</bearingAccuracyDegrees>
+<time>1746104704538</time>
+</trkpt>
+<trkpt lat="55.9393561" lon="-4.3222091">
+<ele>118.69999694824219></ele>
+<accuracy>3.001</accuracy>
+<speed>1.4713254</speed>
+<bearing>154.5962</bearing>
+<bearingAccuracyDegrees>9.277289</bearingAccuracyDegrees>
+<time>1746104705540</time>
+</trkpt>
+<trkpt lat="55.9393419" lon="-4.3222003">
+<ele>118.69999694824219></ele>
+<accuracy>3.001</accuracy>
+<speed>1.4830251</speed>
+<bearing>156.53496</bearing>
+<bearingAccuracyDegrees>9.313822</bearingAccuracyDegrees>
+<time>1746104706446</time>
+</trkpt>
+<trkpt lat="55.9393274" lon="-4.3221908">
+<ele>118.69999694824219></ele>
+<accuracy>3.001</accuracy>
+<speed>1.4790356</speed>
+<bearing>159.7633</bearing>
+<bearingAccuracyDegrees>9.452237</bearingAccuracyDegrees>
+<time>1746104707490</time>
+</trkpt>
+<trkpt lat="55.9393153" lon="-4.3221839">
+<ele>118.69999694824219></ele>
+<accuracy>3.001</accuracy>
+<speed>1.469022</speed>
+<bearing>157.15956</bearing>
+<bearingAccuracyDegrees>9.176489</bearingAccuracyDegrees>
+<time>1746104708520</time>
+</trkpt>
+<trkpt lat="55.9393024" lon="-4.322177">
+<ele>118.69999694824219></ele>
+<accuracy>3.008</accuracy>
+<speed>1.4508607</speed>
+<bearing>163.63441</bearing>
+<bearingAccuracyDegrees>9.147387</bearingAccuracyDegrees>
+<time>1746104709619</time>
+</trkpt>
+<trkpt lat="55.9392918" lon="-4.322176">
+<ele>118.69999694824219></ele>
+<accuracy>3.013</accuracy>
+<speed>1.4199919</speed>
+<bearing>172.99838</bearing>
+<bearingAccuracyDegrees>9.04342</bearingAccuracyDegrees>
+<time>1746104710552</time>
+</trkpt>
+<trkpt lat="55.9392783" lon="-4.322177">
+<ele>120.2292447482021></ele>
+<accuracy>3.012</accuracy>
+<speed>1.4450556</speed>
+<bearing>176.8528</bearing>
+<bearingAccuracyDegrees>7.066883</bearingAccuracyDegrees>
+<time>1746104711554</time>
+</trkpt>
+<trkpt lat="55.9392638" lon="-4.322176">
+<ele>120.33860726504727></ele>
+<accuracy>3.033</accuracy>
+<speed>1.4356809</speed>
+<bearing>174.30922</bearing>
+<bearingAccuracyDegrees>9.28351</bearingAccuracyDegrees>
+<time>1746104712556</time>
+</trkpt>
+<trkpt lat="55.9392493" lon="-4.3221731">
+<ele>120.33059128309573></ele>
+<accuracy>3.127</accuracy>
+<speed>1.4468082</speed>
+<bearing>170.02217</bearing>
+<bearingAccuracyDegrees>10.301815</bearingAccuracyDegrees>
+<time>1746104713559</time>
+</trkpt>
+<trkpt lat="55.9392343" lon="-4.3221663">
+<ele>120.37121195888801></ele>
+<accuracy>3.29</accuracy>
+<speed>1.4365959</speed>
+<bearing>162.46135</bearing>
+<bearingAccuracyDegrees>10.311581</bearingAccuracyDegrees>
+<time>1746104714561</time>
+</trkpt>
+<trkpt lat="55.9392209" lon="-4.3221565">
+<ele>120.37121195888801></ele>
+<accuracy>3.438</accuracy>
+<speed>1.4245589</speed>
+<bearing>159.56802</bearing>
+<bearingAccuracyDegrees>11.544087</bearingAccuracyDegrees>
+<time>1746104715466</time>
+</trkpt>
+<trkpt lat="55.9392054" lon="-4.3221465">
+<ele>120.45471696947655></ele>
+<accuracy>3.804</accuracy>
+<speed>1.4394228</speed>
+<bearing>165.58566</bearing>
+<bearingAccuracyDegrees>11.621739</bearingAccuracyDegrees>
+<time>1746104716569</time>
+</trkpt>
+<trkpt lat="55.9391907" lon="-4.3221394">
+<ele>122.19999694824219></ele>
+<accuracy>4.091</accuracy>
+<speed>1.4342961</speed>
+<bearing>167.1551</bearing>
+<bearingAccuracyDegrees>12.122163</bearingAccuracyDegrees>
+<time>1746104717621</time>
+</trkpt>
+<trkpt lat="55.9391376" lon="-4.3221139">
+<ele>120.41521434192904></ele>
+<accuracy>4.801</accuracy>
+<speed>1.4073137</speed>
+<bearing>167.29224</bearing>
+<bearingAccuracyDegrees>10.181403</bearingAccuracyDegrees>
+<time>1746104721577</time>
+</trkpt>
+<trkpt lat="55.9391234" lon="-4.322109">
+<ele>120.41521434192904></ele>
+<accuracy>4.826</accuracy>
+<speed>1.4279295</speed>
+<bearing>165.79306</bearing>
+<bearingAccuracyDegrees>9.911431</bearingAccuracyDegrees>
+<time>1746104722504</time>
+</trkpt>
+<trkpt lat="55.9391072" lon="-4.3221021">
+<ele>120.47875165750096></ele>
+<accuracy>4.835</accuracy>
+<speed>1.422396</speed>
+<bearing>163.0575</bearing>
+<bearingAccuracyDegrees>9.91209</bearingAccuracyDegrees>
+<time>1746104723612</time>
+</trkpt>
+<trkpt lat="55.9390936" lon="-4.3220972">
+<ele>120.74436355134472></ele>
+<accuracy>4.869</accuracy>
+<speed>1.3962942</speed>
+<bearing>166.87593</bearing>
+<bearingAccuracyDegrees>10.10094</bearingAccuracyDegrees>
+<time>1746104724584</time>
+</trkpt>
+<trkpt lat="55.9390788" lon="-4.322094">
+<ele>120.98269160166734></ele>
+<accuracy>4.857</accuracy>
+<speed>1.4138196</speed>
+<bearing>169.5501</bearing>
+<bearingAccuracyDegrees>10.134793</bearingAccuracyDegrees>
+<time>1746104725587</time>
+</trkpt>
+<trkpt lat="55.9390636" lon="-4.32209">
+<ele>122.69999694824219></ele>
+<accuracy>4.851</accuracy>
+<speed>1.4337006</speed>
+<bearing>171.54315</bearing>
+<bearingAccuracyDegrees>11.824895</bearingAccuracyDegrees>
+<time>1746104726589</time>
+</trkpt>
+<trkpt lat="55.9390481" lon="-4.3220836">
+<ele>122.69999694824219></ele>
+<accuracy>4.907</accuracy>
+<speed>1.4360286</speed>
+<bearing>170.38135</bearing>
+<bearingAccuracyDegrees>11.8668995</bearingAccuracyDegrees>
+<time>1746104727591</time>
+</trkpt>
+<trkpt lat="55.9390329" lon="-4.3220754">
+<ele>122.69999694824219></ele>
+<accuracy>4.984</accuracy>
+<speed>1.4511107</speed>
+<bearing>168.07599</bearing>
+<bearingAccuracyDegrees>12.11142</bearingAccuracyDegrees>
+<time>1746104728594</time>
+</trkpt>
+<trkpt lat="55.9390195" lon="-4.3220658">
+<ele>122.69999694824219></ele>
+<accuracy>5.012</accuracy>
+<speed>1.4292594</speed>
+<bearing>165.61212</bearing>
+<bearingAccuracyDegrees>11.885997</bearingAccuracyDegrees>
+<time>1746104729513</time>
+</trkpt>
+<trkpt lat="55.9390042" lon="-4.3220573">
+<ele>122.69999694824219></ele>
+<accuracy>5.11</accuracy>
+<speed>1.4130392</speed>
+<bearing>164.88222</bearing>
+<bearingAccuracyDegrees>12.000644</bearingAccuracyDegrees>
+<time>1746104730602</time>
+</trkpt>
+<trkpt lat="55.9389909" lon="-4.3220516">
+<ele>122.69999694824219></ele>
+<accuracy>5.2</accuracy>
+<speed>1.3977969</speed>
+<bearing>162.6173</bearing>
+<bearingAccuracyDegrees>11.99832</bearingAccuracyDegrees>
+<time>1746104731601</time>
+</trkpt>
+<trkpt lat="55.9389778" lon="-4.3220437">
+<ele>122.69999694824219></ele>
+<accuracy>5.237</accuracy>
+<speed>1.3999872</speed>
+<bearing>163.29593</bearing>
+<bearingAccuracyDegrees>12.183332</bearingAccuracyDegrees>
+<time>1746104732602</time>
+</trkpt>
+<trkpt lat="55.9389656" lon="-4.3220376">
+<ele>122.69999694824219></ele>
+<accuracy>5.248</accuracy>
+<speed>1.4186167</speed>
+<bearing>167.76715</bearing>
+<bearingAccuracyDegrees>12.092861</bearingAccuracyDegrees>
+<time>1746104733505</time>
+</trkpt>
+<trkpt lat="55.9389565" lon="-4.3220403">
+<ele>122.69999694824219></ele>
+<accuracy>5.067</accuracy>
+<speed>1.4254482</speed>
+<bearing>168.13043</bearing>
+<bearingAccuracyDegrees>9.96475</bearingAccuracyDegrees>
+<time>1746104734436</time>
+</trkpt>
+<trkpt lat="55.9389445" lon="-4.3220385">
+<ele>122.69999694824219></ele>
+<accuracy>4.723</accuracy>
+<speed>1.4162457</speed>
+<bearing>166.13759</bearing>
+<bearingAccuracyDegrees>10.109387</bearingAccuracyDegrees>
+<time>1746104735525</time>
+</trkpt>
+<trkpt lat="55.9389318" lon="-4.3220309">
+<ele>123.80000305175781></ele>
+<accuracy>4.186</accuracy>
+<speed>1.3980463</speed>
+<bearing>165.99849</bearing>
+<bearingAccuracyDegrees>10.225122</bearingAccuracyDegrees>
+<time>1746104736585</time>
+</trkpt>
+<trkpt lat="55.93892" lon="-4.322025">
+<ele>123.80000305175781></ele>
+<accuracy>3.807</accuracy>
+<speed>1.3834072</speed>
+<bearing>167.52257</bearing>
+<bearingAccuracyDegrees>10.367793</bearingAccuracyDegrees>
+<time>1746104737514</time>
+</trkpt>
+<trkpt lat="55.9389056" lon="-4.3220192">
+<ele>123.80000305175781></ele>
+<accuracy>3.465</accuracy>
+<speed>1.3717245</speed>
+<bearing>169.2918</bearing>
+<bearingAccuracyDegrees>9.947616</bearingAccuracyDegrees>
+<time>1746104738617</time>
+</trkpt>
+<trkpt lat="55.9388921" lon="-4.3220152">
+<ele>123.80000305175781></ele>
+<accuracy>3.461</accuracy>
+<speed>1.3996503</speed>
+<bearing>169.38806</bearing>
+<bearingAccuracyDegrees>10.220839</bearingAccuracyDegrees>
+<time>1746104739519</time>
+</trkpt>
+<trkpt lat="55.9388775" lon="-4.3220074">
+<ele>123.80000305175781></ele>
+<accuracy>3.617</accuracy>
+<speed>1.4101433</speed>
+<bearing>164.97226</bearing>
+<bearingAccuracyDegrees>11.585703</bearingAccuracyDegrees>
+<time>1746104740521</time>
+</trkpt>
+<trkpt lat="55.9388629" lon="-4.3219978">
+<ele>123.80000305175781></ele>
+<accuracy>3.892</accuracy>
+<speed>1.4386208</speed>
+<bearing>160.57669</bearing>
+<bearingAccuracyDegrees>9.829774</bearingAccuracyDegrees>
+<time>1746104741524</time>
+</trkpt>
+<trkpt lat="55.9388497" lon="-4.3219885">
+<ele>123.80000305175781></ele>
+<accuracy>4.182</accuracy>
+<speed>1.4417642</speed>
+<bearing>163.53352</bearing>
+<bearingAccuracyDegrees>9.886117</bearingAccuracyDegrees>
+<time>1746104742479</time>
+</trkpt>
+<trkpt lat="55.938835" lon="-4.3219808">
+<ele>123.80000305175781></ele>
+<accuracy>4.47</accuracy>
+<speed>1.4454857</speed>
+<bearing>163.08743</bearing>
+<bearingAccuracyDegrees>10.205762</bearingAccuracyDegrees>
+<time>1746104743557</time>
+</trkpt>
+<trkpt lat="55.93882" lon="-4.3219718">
+<ele>123.80000305175781></ele>
+<accuracy>4.689</accuracy>
+<speed>1.444806</speed>
+<bearing>158.70488</bearing>
+<bearingAccuracyDegrees>10.463468</bearingAccuracyDegrees>
+<time>1746104744624</time>
+</trkpt>
+<trkpt lat="55.9388086" lon="-4.3219645">
+<ele>123.80000305175781></ele>
+<accuracy>4.88</accuracy>
+<speed>1.4192088</speed>
+<bearing>156.24846</bearing>
+<bearingAccuracyDegrees>11.932235</bearingAccuracyDegrees>
+<time>1746104745533</time>
+</trkpt>
+<trkpt lat="55.9387959" lon="-4.3219565">
+<ele>123.80000305175781></ele>
+<accuracy>5.026</accuracy>
+<speed>1.4305669</speed>
+<bearing>158.88808</bearing>
+<bearingAccuracyDegrees>10.220347</bearingAccuracyDegrees>
+<time>1746104746535</time>
+</trkpt>
+<trkpt lat="55.9387826" lon="-4.3219527">
+<ele>123.80000305175781></ele>
+<accuracy>5.113</accuracy>
+<speed>1.440374</speed>
+<bearing>166.0969</bearing>
+<bearingAccuracyDegrees>11.369881</bearingAccuracyDegrees>
+<time>1746104747538</time>
+</trkpt>
+<trkpt lat="55.9387699" lon="-4.3219505">
+<ele>124.30000305175781></ele>
+<accuracy>5.17</accuracy>
+<speed>1.430586</speed>
+<bearing>168.3697</bearing>
+<bearingAccuracyDegrees>10.547293</bearingAccuracyDegrees>
+<time>1746104748440</time>
+</trkpt>
+<trkpt lat="55.9387552" lon="-4.3219453">
+<ele>124.30000305175781></ele>
+<accuracy>5.186</accuracy>
+<speed>1.4190643</speed>
+<bearing>168.14879</bearing>
+<bearingAccuracyDegrees>12.094083</bearingAccuracyDegrees>
+<time>1746104749541</time>
+</trkpt>
+<trkpt lat="55.9387417" lon="-4.3219438">
+<ele>124.30000305175781></ele>
+<accuracy>5.157</accuracy>
+<speed>1.4386984</speed>
+<bearing>164.09885</bearing>
+<bearingAccuracyDegrees>11.906808</bearingAccuracyDegrees>
+<time>1746104750528</time>
+</trkpt>
+<trkpt lat="55.9387288" lon="-4.3219372">
+<ele>124.30000305175781></ele>
+<accuracy>5.132</accuracy>
+<speed>1.4434519</speed>
+<bearing>158.19617</bearing>
+<bearingAccuracyDegrees>12.227941</bearingAccuracyDegrees>
+<time>1746104751606</time>
+</trkpt>
+<trkpt lat="55.9387189" lon="-4.321931">
+<ele>124.30000305175781></ele>
+<accuracy>5.094</accuracy>
+<speed>1.4075843</speed>
+<bearing>160.30656</bearing>
+<bearingAccuracyDegrees>12.536034</bearingAccuracyDegrees>
+<time>1746104752549</time>
+</trkpt>
+<trkpt lat="55.9387089" lon="-4.321925">
+<ele>124.19999694824219></ele>
+<accuracy>5.046</accuracy>
+<speed>1.3804489</speed>
+<bearing>163.0852</bearing>
+<bearingAccuracyDegrees>12.681458</bearingAccuracyDegrees>
+<time>1746104753552</time>
+</trkpt>
+<trkpt lat="55.938697" lon="-4.3219217">
+<ele>124.19999694824219></ele>
+<accuracy>4.982</accuracy>
+<speed>1.3981905</speed>
+<bearing>164.78644</bearing>
+<bearingAccuracyDegrees>12.498084</bearingAccuracyDegrees>
+<time>1746104754554</time>
+</trkpt>
+<trkpt lat="55.9386843" lon="-4.3219147">
+<ele>124.19999694824219></ele>
+<accuracy>5.011</accuracy>
+<speed>1.4101747</speed>
+<bearing>163.3895</bearing>
+<bearingAccuracyDegrees>12.3560915</bearingAccuracyDegrees>
+<time>1746104755556</time>
+</trkpt>
+<trkpt lat="55.9386714" lon="-4.3219086">
+<ele>124.19999694824219></ele>
+<accuracy>5.031</accuracy>
+<speed>1.4503208</speed>
+<bearing>164.09906</bearing>
+<bearingAccuracyDegrees>12.683816</bearingAccuracyDegrees>
+<time>1746104756559</time>
+</trkpt>
+<trkpt lat="55.9386582" lon="-4.3219038">
+<ele>124.19999694824219></ele>
+<accuracy>5.125</accuracy>
+<speed>1.4622198</speed>
+<bearing>162.8958</bearing>
+<bearingAccuracyDegrees>12.456097</bearingAccuracyDegrees>
+<time>1746104757561</time>
+</trkpt>
+<trkpt lat="55.938646" lon="-4.3218957">
+<ele>124.19999694824219></ele>
+<accuracy>5.278</accuracy>
+<speed>1.4656283</speed>
+<bearing>159.1664</bearing>
+<bearingAccuracyDegrees>11.932886</bearingAccuracyDegrees>
+<time>1746104758463</time>
+</trkpt>
+<trkpt lat="55.938633" lon="-4.321893">
+<ele>124.19999694824219></ele>
+<accuracy>5.438</accuracy>
+<speed>1.4388065</speed>
+<bearing>159.77495</bearing>
+<bearingAccuracyDegrees>12.164063</bearingAccuracyDegrees>
+<time>1746104759489</time>
+</trkpt>
+<trkpt lat="55.9386194" lon="-4.3218851">
+<ele>124.19999694824219></ele>
+<accuracy>5.584</accuracy>
+<speed>1.445199</speed>
+<bearing>167.85768</bearing>
+<bearingAccuracyDegrees>12.6092005</bearingAccuracyDegrees>
+<time>1746104760520</time>
+</trkpt>
+<trkpt lat="55.9386056" lon="-4.3218807">
+<ele>124.19999694824219></ele>
+<accuracy>5.727</accuracy>
+<speed>1.4615179</speed>
+<bearing>169.11804</bearing>
+<bearingAccuracyDegrees>12.651014</bearingAccuracyDegrees>
+<time>1746104761564</time>
+</trkpt>
+<trkpt lat="55.9385921" lon="-4.3218733">
+<ele>124.19999694824219></ele>
+<accuracy>5.854</accuracy>
+<speed>1.4565784</speed>
+<bearing>162.60832</bearing>
+<bearingAccuracyDegrees>13.179508</bearingAccuracyDegrees>
+<time>1746104762626</time>
+</trkpt>
+<trkpt lat="55.9385814" lon="-4.3218708">
+<ele>124.19999694824219></ele>
+<accuracy>5.939</accuracy>
+<speed>1.4492738</speed>
+<bearing>165.66115</bearing>
+<bearingAccuracyDegrees>12.1778965</bearingAccuracyDegrees>
+<time>1746104763575</time>
+</trkpt>
+<trkpt lat="55.9385668" lon="-4.3218726">
+<ele>124.19999694824219></ele>
+<accuracy>5.92</accuracy>
+<speed>1.4799706</speed>
+<bearing>168.38191</bearing>
+<bearingAccuracyDegrees>12.163341</bearingAccuracyDegrees>
+<time>1746104764577</time>
+</trkpt>
+<trkpt lat="55.9385501" lon="-4.3218689">
+<ele>124.19999694824219></ele>
+<accuracy>5.876</accuracy>
+<speed>1.5188684</speed>
+<bearing>167.52121</bearing>
+<bearingAccuracyDegrees>10.164775</bearingAccuracyDegrees>
+<time>1746104765579</time>
+</trkpt>
+<trkpt lat="55.9385332" lon="-4.3218627">
+<ele>124.19999694824219></ele>
+<accuracy>5.753</accuracy>
+<speed>1.5312874</speed>
+<bearing>167.805</bearing>
+<bearingAccuracyDegrees>9.84544</bearingAccuracyDegrees>
+<time>1746104766581</time>
+</trkpt>
+<trkpt lat="55.9385173" lon="-4.3218563">
+<ele>124.19999694824219></ele>
+<accuracy>5.578</accuracy>
+<speed>1.510547</speed>
+<bearing>166.27948</bearing>
+<bearingAccuracyDegrees>9.87409</bearingAccuracyDegrees>
+<time>1746104767584</time>
+</trkpt>
+<trkpt lat="55.9385011" lon="-4.3218502">
+<ele>124.19999694824219></ele>
+<accuracy>5.361</accuracy>
+<speed>1.5088888</speed>
+<bearing>165.923</bearing>
+<bearingAccuracyDegrees>9.819304</bearingAccuracyDegrees>
+<time>1746104768587</time>
+</trkpt>
+<trkpt lat="55.9384851" lon="-4.3218437">
+<ele>124.19999694824219></ele>
+<accuracy>5.226</accuracy>
+<speed>1.5255971</speed>
+<bearing>164.702</bearing>
+<bearingAccuracyDegrees>9.510805</bearingAccuracyDegrees>
+<time>1746104769589</time>
+</trkpt>
+<trkpt lat="55.9384698" lon="-4.3218352">
+<ele>124.19999694824219></ele>
+<accuracy>5.103</accuracy>
+<speed>1.5175775</speed>
+<bearing>161.6045</bearing>
+<bearingAccuracyDegrees>10.176848</bearingAccuracyDegrees>
+<time>1746104770591</time>
+</trkpt>
+<trkpt lat="55.9384559" lon="-4.321826">
+<ele>124.19999694824219></ele>
+<accuracy>5.023</accuracy>
+<speed>1.52318</speed>
+<bearing>158.19653</bearing>
+<bearingAccuracyDegrees>9.595076</bearingAccuracyDegrees>
+<time>1746104771508</time>
+</trkpt>
+<trkpt lat="55.9384411" lon="-4.3218164">
+<ele>124.19999694824219></ele>
+<accuracy>4.945</accuracy>
+<speed>1.5371552</speed>
+<bearing>158.21086</bearing>
+<bearingAccuracyDegrees>9.725511</bearingAccuracyDegrees>
+<time>1746104772540</time>
+</trkpt>
+<trkpt lat="55.9384267" lon="-4.3218082">
+<ele>124.19999694824219></ele>
+<accuracy>4.857</accuracy>
+<speed>1.5025957</speed>
+<bearing>163.04562</bearing>
+<bearingAccuracyDegrees>9.886551</bearingAccuracyDegrees>
+<time>1746104773598</time>
+</trkpt>
+<trkpt lat="55.9384122" lon="-4.3218026">
+<ele>124.19999694824219></ele>
+<accuracy>4.769</accuracy>
+<speed>1.4896195</speed>
+<bearing>167.66623</bearing>
+<bearingAccuracyDegrees>11.661285</bearingAccuracyDegrees>
+<time>1746104774601</time>
+</trkpt>
+<trkpt lat="55.9383987" lon="-4.3217981">
+<ele>124.19999694824219></ele>
+<accuracy>4.726</accuracy>
+<speed>1.4817713</speed>
+<bearing>167.61362</bearing>
+<bearingAccuracyDegrees>9.733017</bearingAccuracyDegrees>
+<time>1746104775503</time>
+</trkpt>
+<trkpt lat="55.9383831" lon="-4.3217954">
+<ele>124.19999694824219></ele>
+<accuracy>4.457</accuracy>
+<speed>1.473949</speed>
+<bearing>166.71933</bearing>
+<bearingAccuracyDegrees>9.208215</bearingAccuracyDegrees>
+<time>1746104776604</time>
+</trkpt>
+<trkpt lat="55.9383282" lon="-4.3217782">
+<ele>124.19999694824219></ele>
+<accuracy>3.116</accuracy>
+<speed>1.4942038</speed>
+<bearing>169.25447</bearing>
+<bearingAccuracyDegrees>9.8372755</bearingAccuracyDegrees>
+<time>1746104780614</time>
+</trkpt>
+<trkpt lat="55.9383144" lon="-4.3217773">
+<ele>122.69999694824219></ele>
+<accuracy>3.092</accuracy>
+<speed>1.4927845</speed>
+<bearing>169.14938</bearing>
+<bearingAccuracyDegrees>9.6495</bearingAccuracyDegrees>
+<time>1746104781517</time>
+</trkpt>
+<trkpt lat="55.9382997" lon="-4.3217754">
+<ele>122.69999694824219></ele>
+<accuracy>3.068</accuracy>
+<speed>1.4761245</speed>
+<bearing>169.95012</bearing>
+<bearingAccuracyDegrees>9.4061575</bearingAccuracyDegrees>
+<time>1746104782551</time>
+</trkpt>
+<trkpt lat="55.9382867" lon="-4.3217745">
+<ele>122.69999694824219></ele>
+<accuracy>3.084</accuracy>
+<speed>1.4891888</speed>
+<bearing>169.08876</bearing>
+<bearingAccuracyDegrees>9.443752</bearingAccuracyDegrees>
+<time>1746104783505</time>
+</trkpt>
+<trkpt lat="55.9382715" lon="-4.3217734">
+<ele>120.95977543567707></ele>
+<accuracy>3.113</accuracy>
+<speed>1.4999683</speed>
+<bearing>170.97665</bearing>
+<bearingAccuracyDegrees>9.641231</bearingAccuracyDegrees>
+<time>1746104784567</time>
+</trkpt>
+<trkpt lat="55.9382215" lon="-4.3217647">
+<ele>122.69999694824219></ele>
+<accuracy>3.089</accuracy>
+<speed>1.4651037</speed>
+<bearing>172.34312</bearing>
+<bearingAccuracyDegrees>9.541686</bearingAccuracyDegrees>
+<time>1746104788532</time>
+</trkpt>
+<trkpt lat="55.9382068" lon="-4.3217576">
+<ele>122.69999694824219></ele>
+<accuracy>3.088</accuracy>
+<speed>1.4670017</speed>
+<bearing>164.89894</bearing>
+<bearingAccuracyDegrees>9.46675</bearingAccuracyDegrees>
+<time>1746104789536</time>
+</trkpt>
+<trkpt lat="55.9381911" lon="-4.3217449">
+<ele>122.69999694824219></ele>
+<accuracy>3.065</accuracy>
+<speed>1.496335</speed>
+<bearing>154.30408</bearing>
+<bearingAccuracyDegrees>9.3308</bearingAccuracyDegrees>
+<time>1746104790538</time>
+</trkpt>
+<trkpt lat="55.9381769" lon="-4.3217271">
+<ele>122.69999694824219></ele>
+<accuracy>3.057</accuracy>
+<speed>1.5089678</speed>
+<bearing>141.55527</bearing>
+<bearingAccuracyDegrees>9.140143</bearingAccuracyDegrees>
+<time>1746104791540</time>
+</trkpt>
+<trkpt lat="55.9381655" lon="-4.3217071">
+<ele>122.69999694824219></ele>
+<accuracy>3.062</accuracy>
+<speed>1.4902942</speed>
+<bearing>128.37009</bearing>
+<bearingAccuracyDegrees>9.199114</bearingAccuracyDegrees>
+<time>1746104792543</time>
+</trkpt>
+<trkpt lat="55.9381581" lon="-4.321683">
+<ele>122.69999694824219></ele>
+<accuracy>3.075</accuracy>
+<speed>1.5057573</speed>
+<bearing>108.978004</bearing>
+<bearingAccuracyDegrees>9.329142</bearingAccuracyDegrees>
+<time>1746104793447</time>
+</trkpt>
+<trkpt lat="55.9381565" lon="-4.3216509">
+<ele>124.19999694824219></ele>
+<accuracy>3.094</accuracy>
+<speed>1.5306581</speed>
+<bearing>92.55124</bearing>
+<bearingAccuracyDegrees>9.932374</bearingAccuracyDegrees>
+<time>1746104794485</time>
+</trkpt>
+<trkpt lat="55.9381573" lon="-4.3216214">
+<ele>124.19999694824219></ele>
+<accuracy>3.102</accuracy>
+<speed>1.5440055</speed>
+<bearing>90.39314</bearing>
+<bearingAccuracyDegrees>9.839508</bearingAccuracyDegrees>
+<time>1746104795482</time>
+</trkpt>
+<trkpt lat="55.9381574" lon="-4.3215932">
+<ele>124.19999694824219></ele>
+<accuracy>3.102</accuracy>
+<speed>1.5415606</speed>
+<bearing>91.203514</bearing>
+<bearingAccuracyDegrees>10.097315</bearingAccuracyDegrees>
+<time>1746104796552</time>
+</trkpt>
+<trkpt lat="55.9381574" lon="-4.321566">
+<ele>124.19999694824219></ele>
+<accuracy>3.1</accuracy>
+<speed>1.533512</speed>
+<bearing>90.63532</bearing>
+<bearingAccuracyDegrees>10.21833</bearingAccuracyDegrees>
+<time>1746104797567</time>
+</trkpt>
+<trkpt lat="55.9381577" lon="-4.3215408">
+<ele>124.19999694824219></ele>
+<accuracy>3.102</accuracy>
+<speed>1.5255779</speed>
+<bearing>88.64436</bearing>
+<bearingAccuracyDegrees>9.961677</bearingAccuracyDegrees>
+<time>1746104798556</time>
+</trkpt>
+<trkpt lat="55.9381568" lon="-4.3215123">
+<ele>123.80000305175781></ele>
+<accuracy>3.097</accuracy>
+<speed>1.52046</speed>
+<bearing>86.966576</bearing>
+<bearingAccuracyDegrees>9.519043</bearingAccuracyDegrees>
+<time>1746104799559</time>
+</trkpt>
+<trkpt lat="55.9381563" lon="-4.3214837">
+<ele>123.80000305175781></ele>
+<accuracy>3.086</accuracy>
+<speed>1.5043674</speed>
+<bearing>89.47452</bearing>
+<bearingAccuracyDegrees>10.385741</bearingAccuracyDegrees>
+<time>1746104800561</time>
+</trkpt>
+<trkpt lat="55.9381663" lon="-4.3213785">
+<ele>124.19999694824219></ele>
+<accuracy>3.037</accuracy>
+<speed>1.5163193</speed>
+<bearing>87.70599</bearing>
+<bearingAccuracyDegrees>9.959043</bearingAccuracyDegrees>
+<time>1746104804571</time>
+</trkpt>
+<trkpt lat="55.938168" lon="-4.3213524">
+<ele>124.19999694824219></ele>
+<accuracy>3.017</accuracy>
+<speed>1.521889</speed>
+<bearing>84.23368</bearing>
+<bearingAccuracyDegrees>9.815521</bearingAccuracyDegrees>
+<time>1746104805573</time>
+</trkpt>
+<trkpt lat="55.93817" lon="-4.3213269">
+<ele>124.19999694824219></ele>
+<accuracy>3.006</accuracy>
+<speed>1.5216854</speed>
+<bearing>83.166664</bearing>
+<bearingAccuracyDegrees>9.903968</bearingAccuracyDegrees>
+<time>1746104806575</time>
+</trkpt>
+<trkpt lat="55.9381723" lon="-4.3213014">
+<ele>124.19999694824219></ele>
+<accuracy>3.019</accuracy>
+<speed>1.504761</speed>
+<bearing>83.3029</bearing>
+<bearingAccuracyDegrees>10.310203</bearingAccuracyDegrees>
+<time>1746104807522</time>
+</trkpt>
+<trkpt lat="55.9381753" lon="-4.3212728">
+<ele>124.19999694824219></ele>
+<accuracy>3.049</accuracy>
+<speed>1.5356091</speed>
+<bearing>80.48899</bearing>
+<bearingAccuracyDegrees>9.717187</bearingAccuracyDegrees>
+<time>1746104808580</time>
+</trkpt>
+<trkpt lat="55.9381784" lon="-4.3212389">
+<ele>124.19999694824219></ele>
+<accuracy>3.065</accuracy>
+<speed>1.5674257</speed>
+<bearing>78.94197</bearing>
+<bearingAccuracyDegrees>9.5195055</bearingAccuracyDegrees>
+<time>1746104809581</time>
+</trkpt>
+<trkpt lat="55.9381822" lon="-4.3212021">
+<ele>124.19999694824219></ele>
+<accuracy>3.063</accuracy>
+<speed>1.6146516</speed>
+<bearing>79.72233</bearing>
+<bearingAccuracyDegrees>9.117863</bearingAccuracyDegrees>
+<time>1746104810585</time>
+</trkpt>
+<trkpt lat="55.9381858" lon="-4.3211704">
+<ele>124.19999694824219></ele>
+<accuracy>3.065</accuracy>
+<speed>1.5699595</speed>
+<bearing>77.19239</bearing>
+<bearingAccuracyDegrees>9.182254</bearingAccuracyDegrees>
+<time>1746104811560</time>
+</trkpt>
+<trkpt lat="55.9381895" lon="-4.3211424">
+<ele>124.19999694824219></ele>
+<accuracy>3.044</accuracy>
+<speed>1.5645682</speed>
+<bearing>72.64346</bearing>
+<bearingAccuracyDegrees>9.166079</bearingAccuracyDegrees>
+<time>1746104812627</time>
+</trkpt>
+<trkpt lat="55.9381927" lon="-4.321124">
+<ele>124.19999694824219></ele>
+<accuracy>3.037</accuracy>
+<speed>1.5311425</speed>
+<bearing>72.44799</bearing>
+<bearingAccuracyDegrees>9.020494</bearingAccuracyDegrees>
+<time>1746104813592</time>
+</trkpt>
+<trkpt lat="55.9381945" lon="-4.3211038">
+<ele>122.69999694824219></ele>
+<accuracy>3.008</accuracy>
+<speed>1.4886022</speed>
+<bearing>77.51536</bearing>
+<bearingAccuracyDegrees>9.041882</bearingAccuracyDegrees>
+<time>1746104814593</time>
+</trkpt>
+<trkpt lat="55.9381938" lon="-4.3210853">
+<ele>122.69999694824219></ele>
+<accuracy>3.005</accuracy>
+<speed>1.4755719</speed>
+<bearing>86.17344</bearing>
+<bearingAccuracyDegrees>8.87387</bearingAccuracyDegrees>
+<time>1746104815596</time>
+</trkpt>
+<trkpt lat="55.938191" lon="-4.3210684">
+<ele>122.69999694824219></ele>
+<accuracy>3.005</accuracy>
+<speed>1.4632888</speed>
+<bearing>89.93086</bearing>
+<bearingAccuracyDegrees>9.2838545</bearingAccuracyDegrees>
+<time>1746104816599</time>
+</trkpt>
+<trkpt lat="55.9381882" lon="-4.3210497">
+<ele>122.69999694824219></ele>
+<accuracy>3.007</accuracy>
+<speed>1.4459914</speed>
+<bearing>87.99807</bearing>
+<bearingAccuracyDegrees>9.906059</bearingAccuracyDegrees>
+<time>1746104817601</time>
+</trkpt>
+<trkpt lat="55.9381853" lon="-4.3210274">
+<ele>122.08606993050114></ele>
+<accuracy>3.028</accuracy>
+<speed>1.4558258</speed>
+<bearing>89.36145</bearing>
+<bearingAccuracyDegrees>9.537894</bearingAccuracyDegrees>
+<time>1746104818603</time>
+</trkpt>
+<trkpt lat="55.9381845" lon="-4.3210007">
+<ele>122.1442034608412></ele>
+<accuracy>3.131</accuracy>
+<speed>1.4796118</speed>
+<bearing>87.61533</bearing>
+<bearingAccuracyDegrees>11.71502</bearingAccuracyDegrees>
+<time>1746104819606</time>
+</trkpt>
+<trkpt lat="55.9381847" lon="-4.3209743">
+<ele>121.92178978342521></ele>
+<accuracy>3.314</accuracy>
+<speed>1.4788165</speed>
+<bearing>84.66187</bearing>
+<bearingAccuracyDegrees>12.298455</bearingAccuracyDegrees>
+<time>1746104820608</time>
+</trkpt>
+<trkpt lat="55.9381856" lon="-4.3209469">
+<ele>121.92178978342521></ele>
+<accuracy>3.565</accuracy>
+<speed>1.4830693</speed>
+<bearing>83.363396</bearing>
+<bearingAccuracyDegrees>12.373869</bearingAccuracyDegrees>
+<time>1746104821562</time>
+</trkpt>
+<trkpt lat="55.938186" lon="-4.3209171">
+<ele>121.84938938234144></ele>
+<accuracy>3.937</accuracy>
+<speed>1.5010312</speed>
+<bearing>90.31581</bearing>
+<bearingAccuracyDegrees>13.173911</bearingAccuracyDegrees>
+<time>1746104822606</time>
+</trkpt>
+<trkpt lat="55.9381842" lon="-4.3208917">
+<ele>121.5363558140878></ele>
+<accuracy>4.395</accuracy>
+<speed>1.4890056</speed>
+<bearing>97.213356</bearing>
+<bearingAccuracyDegrees>12.5482645</bearingAccuracyDegrees>
+<time>1746104823548</time>
+</trkpt>
+<trkpt lat="55.938182" lon="-4.3208663">
+<ele>121.25302077777494></ele>
+<accuracy>4.693</accuracy>
+<speed>1.4490194</speed>
+<bearing>91.99509</bearing>
+<bearingAccuracyDegrees>12.638218</bearingAccuracyDegrees>
+<time>1746104824617</time>
+</trkpt>
+<trkpt lat="55.9381812" lon="-4.3208418">
+<ele>121.056788846171></ele>
+<accuracy>5.138</accuracy>
+<speed>1.4464526</speed>
+<bearing>88.93296</bearing>
+<bearingAccuracyDegrees>12.821395</bearingAccuracyDegrees>
+<time>1746104825520</time>
+</trkpt>
+<trkpt lat="55.9381815" lon="-4.3208106">
+<ele>121.056788846171></ele>
+<accuracy>5.407</accuracy>
+<speed>1.4807283</speed>
+<bearing>88.89043</bearing>
+<bearingAccuracyDegrees>12.89074</bearingAccuracyDegrees>
+<time>1746104826630</time>
+</trkpt>
+<trkpt lat="55.9381807" lon="-4.320782">
+<ele>119.19999694824219></ele>
+<accuracy>5.518</accuracy>
+<speed>1.5203654</speed>
+<bearing>90.30777</bearing>
+<bearingAccuracyDegrees>12.954118</bearingAccuracyDegrees>
+<time>1746104827650</time>
+</trkpt>
+<trkpt lat="55.9381803" lon="-4.3207554">
+<ele>119.19999694824219></ele>
+<accuracy>5.541</accuracy>
+<speed>1.4910108</speed>
+<bearing>92.11221</bearing>
+<bearingAccuracyDegrees>12.580033</bearingAccuracyDegrees>
+<time>1746104828656</time>
+</trkpt>
+<trkpt lat="55.9381805" lon="-4.3207302">
+<ele>119.19999694824219></ele>
+<accuracy>5.574</accuracy>
+<speed>1.4904354</speed>
+<bearing>90.88725</bearing>
+<bearingAccuracyDegrees>13.080314</bearingAccuracyDegrees>
+<time>1746104829641</time>
+</trkpt>
+<trkpt lat="55.9381826" lon="-4.3207074">
+<ele>119.19999694824219></ele>
+<accuracy>5.505</accuracy>
+<speed>1.4691315</speed>
+<bearing>80.56653</bearing>
+<bearingAccuracyDegrees>10.128586</bearingAccuracyDegrees>
+<time>1746104830824</time>
+</trkpt>
+<trkpt lat="55.9381859" lon="-4.3206905">
+<ele>119.19999694824219></ele>
+<accuracy>5.128</accuracy>
+<speed>1.4376465</speed>
+<bearing>82.72029</bearing>
+<bearingAccuracyDegrees>9.9851885</bearingAccuracyDegrees>
+<time>1746104831827</time>
+</trkpt>
+<trkpt lat="55.9381855" lon="-4.3206695">
+<ele>119.89845413409131></ele>
+<accuracy>4.712</accuracy>
+<speed>1.4387732</speed>
+<bearing>92.97167</bearing>
+<bearingAccuracyDegrees>10.304737</bearingAccuracyDegrees>
+<time>1746104832759</time>
+</trkpt>
+<trkpt lat="55.9381851" lon="-4.3206393">
+<ele>119.63079492927889></ele>
+<accuracy>4.426</accuracy>
+<speed>1.4657922</speed>
+<bearing>88.69306</bearing>
+<bearingAccuracyDegrees>11.913145</bearingAccuracyDegrees>
+<time>1746104833940</time>
+</trkpt>
+<trkpt lat="55.9381865" lon="-4.3206128">
+<ele>119.42146415799053></ele>
+<accuracy>4.171</accuracy>
+<speed>1.4719628</speed>
+<bearing>83.242584</bearing>
+<bearingAccuracyDegrees>12.203037</bearingAccuracyDegrees>
+<time>1746104834965</time>
+</trkpt>
+<trkpt lat="55.938189" lon="-4.3205845">
+<ele>119.37616190054588></ele>
+<accuracy>4.091</accuracy>
+<speed>1.476037</speed>
+<bearing>80.448166</bearing>
+<bearingAccuracyDegrees>12.126641</bearingAccuracyDegrees>
+<time>1746104836010</time>
+</trkpt>
+<trkpt lat="55.938193" lon="-4.320551">
+<ele>119.14548858971563></ele>
+<accuracy>4.387</accuracy>
+<speed>1.5163788</speed>
+<bearing>85.618546</bearing>
+<bearingAccuracyDegrees>12.90521</bearingAccuracyDegrees>
+<time>1746104837347</time>
+</trkpt>
+<trkpt lat="55.9381943" lon="-4.3205115">
+<ele>119.16319241693608></ele>
+<accuracy>4.847</accuracy>
+<speed>1.5209599</speed>
+<bearing>90.46654</bearing>
+<bearingAccuracyDegrees>12.924693</bearingAccuracyDegrees>
+<time>1746104838623</time>
+</trkpt>
+<trkpt lat="55.9381929" lon="-4.3204847">
+<ele>119.08977384187185></ele>
+<accuracy>5.084</accuracy>
+<speed>1.4746375</speed>
+<bearing>91.07768</bearing>
+<bearingAccuracyDegrees>12.765789</bearingAccuracyDegrees>
+<time>1746104839626</time>
+</trkpt>
+<trkpt lat="55.9381905" lon="-4.3204578">
+<ele>118.69189843601657></ele>
+<accuracy>5.246</accuracy>
+<speed>1.5151652</speed>
+<bearing>92.29573</bearing>
+<bearingAccuracyDegrees>12.639348</bearingAccuracyDegrees>
+<time>1746104840554</time>
+</trkpt>
+<trkpt lat="55.9381876" lon="-4.3204328">
+<ele>118.69189843601657></ele>
+<accuracy>5.374</accuracy>
+<speed>1.4955019</speed>
+<bearing>96.003784</bearing>
+<bearingAccuracyDegrees>12.744332</bearingAccuracyDegrees>
+<time>1746104841460</time>
+</trkpt>
+<trkpt lat="55.9381846" lon="-4.3204063">
+<ele>118.35346000235697></ele>
+<accuracy>5.499</accuracy>
+<speed>1.474646</speed>
+<bearing>95.41848</bearing>
+<bearingAccuracyDegrees>12.289874</bearingAccuracyDegrees>
+<time>1746104842493</time>
+</trkpt>
+<trkpt lat="55.9381821" lon="-4.320379">
+<ele>118.26182372439695></ele>
+<accuracy>5.581</accuracy>
+<speed>1.4905641</speed>
+<bearing>96.269035</bearing>
+<bearingAccuracyDegrees>12.760367</bearingAccuracyDegrees>
+<time>1746104843527</time>
+</trkpt>
+<trkpt lat="55.938179" lon="-4.3203509">
+<ele>118.21184071160171></ele>
+<accuracy>5.642</accuracy>
+<speed>1.5055498</speed>
+<bearing>98.294</bearing>
+<bearingAccuracyDegrees>12.44604</bearingAccuracyDegrees>
+<time>1746104844588</time>
+</trkpt>
+<trkpt lat="55.9381762" lon="-4.3203259">
+<ele>118.04731534636295></ele>
+<accuracy>5.673</accuracy>
+<speed>1.5195259</speed>
+<bearing>98.103</bearing>
+<bearingAccuracyDegrees>12.170735</bearingAccuracyDegrees>
+<time>1746104845524</time>
+</trkpt>
+<trkpt lat="55.9381733" lon="-4.3202982">
+<ele>118.23118752828154></ele>
+<accuracy>5.705</accuracy>
+<speed>1.5194</speed>
+<bearing>100.35612</bearing>
+<bearingAccuracyDegrees>12.086946</bearingAccuracyDegrees>
+<time>1746104846566</time>
+</trkpt>
+<trkpt lat="55.9381695" lon="-4.3202718">
+<ele>119.19999694824219></ele>
+<accuracy>5.752</accuracy>
+<speed>1.5097044</speed>
+<bearing>101.29834</bearing>
+<bearingAccuracyDegrees>12.463812</bearingAccuracyDegrees>
+<time>1746104847591</time>
+</trkpt>
+<trkpt lat="55.9381656" lon="-4.3202495">
+<ele>119.19999694824219></ele>
+<accuracy>5.759</accuracy>
+<speed>1.5156152</speed>
+<bearing>105.342064</bearing>
+<bearingAccuracyDegrees>11.542182</bearingAccuracyDegrees>
+<time>1746104848573</time>
+</trkpt>
+<trkpt lat="55.938161" lon="-4.320225">
+<ele>119.19999694824219></ele>
+<accuracy>5.739</accuracy>
+<speed>1.5115808</speed>
+<bearing>109.42781</bearing>
+<bearingAccuracyDegrees>11.548055</bearingAccuracyDegrees>
+<time>1746104849576</time>
+</trkpt>
+<trkpt lat="55.9381555" lon="-4.3201967">
+<ele>119.19999694824219></ele>
+<accuracy>5.677</accuracy>
+<speed>1.5348315</speed>
+<bearing>111.59848</bearing>
+<bearingAccuracyDegrees>10.354441</bearingAccuracyDegrees>
+<time>1746104850578</time>
+</trkpt>
+<trkpt lat="55.938149" lon="-4.3201683">
+<ele>119.19999694824219></ele>
+<accuracy>5.6</accuracy>
+<speed>1.5646971</speed>
+<bearing>110.528564</bearing>
+<bearingAccuracyDegrees>11.985606</bearingAccuracyDegrees>
+<time>1746104851580</time>
+</trkpt>
+<trkpt lat="55.9381428" lon="-4.3201373">
+<ele>119.19999694824219></ele>
+<accuracy>5.503</accuracy>
+<speed>1.6024321</speed>
+<bearing>108.08703</bearing>
+<bearingAccuracyDegrees>12.381241</bearingAccuracyDegrees>
+<time>1746104852583</time>
+</trkpt>
+<trkpt lat="55.9381381" lon="-4.3201045">
+<ele>117.54031948368396></ele>
+<accuracy>5.361</accuracy>
+<speed>1.618299</speed>
+<bearing>109.09292</bearing>
+<bearingAccuracyDegrees>11.941439</bearingAccuracyDegrees>
+<time>1746104853585</time>
+</trkpt>
+<trkpt lat="55.9381326" lon="-4.3200757">
+<ele>117.41025562202697></ele>
+<accuracy>5.271</accuracy>
+<speed>1.595263</speed>
+<bearing>112.297966</bearing>
+<bearingAccuracyDegrees>11.801517</bearingAccuracyDegrees>
+<time>1746104854607</time>
+</trkpt>
+<trkpt lat="55.9381269" lon="-4.3200511">
+<ele>117.3545516262739></ele>
+<accuracy>5.212</accuracy>
+<speed>1.5988345</speed>
+<bearing>114.79409</bearing>
+<bearingAccuracyDegrees>12.477835</bearingAccuracyDegrees>
+<time>1746104855609</time>
+</trkpt>
+<trkpt lat="55.9381219" lon="-4.3200286">
+<ele>117.14429072902578></ele>
+<accuracy>5.249</accuracy>
+<speed>1.5906042</speed>
+<bearing>115.76605</bearing>
+<bearingAccuracyDegrees>12.037999</bearingAccuracyDegrees>
+<time>1746104856612</time>
+</trkpt>
+<trkpt lat="55.938119" lon="-4.3200093">
+<ele>117.21919762610173></ele>
+<accuracy>5.325</accuracy>
+<speed>1.535125</speed>
+<bearing>114.222404</bearing>
+<bearingAccuracyDegrees>12.283251</bearingAccuracyDegrees>
+<time>1746104857514</time>
+</trkpt>
+<trkpt lat="55.9381143" lon="-4.31999">
+<ele>117.0973808473381></ele>
+<accuracy>5.397</accuracy>
+<speed>1.506344</speed>
+<bearing>114.929634</bearing>
+<bearingAccuracyDegrees>12.314608</bearingAccuracyDegrees>
+<time>1746104858516</time>
+</trkpt>
+<trkpt lat="55.93811" lon="-4.3199713">
+<ele>116.90203096876824></ele>
+<accuracy>5.455</accuracy>
+<speed>1.4901829</speed>
+<bearing>116.4496</bearing>
+<bearingAccuracyDegrees>11.9166565</bearingAccuracyDegrees>
+<time>1746104859519</time>
+</trkpt>
+<trkpt lat="55.9381049" lon="-4.3199535">
+<ele>116.80690078215912></ele>
+<accuracy>5.463</accuracy>
+<speed>1.4616216</speed>
+<bearing>121.4069</bearing>
+<bearingAccuracyDegrees>11.996593</bearingAccuracyDegrees>
+<time>1746104860521</time>
+</trkpt>
+<trkpt lat="55.9380977" lon="-4.3199355">
+<ele>116.80690078215912></ele>
+<accuracy>5.442</accuracy>
+<speed>1.4726621</speed>
+<bearing>125.209854</bearing>
+<bearingAccuracyDegrees>12.015984</bearingAccuracyDegrees>
+<time>1746104861506</time>
+</trkpt>
+<trkpt lat="55.9380896" lon="-4.3199161">
+<ele>115.0></ele>
+<accuracy>5.464</accuracy>
+<speed>1.500676</speed>
+<bearing>128.34058</bearing>
+<bearingAccuracyDegrees>11.8355465</bearingAccuracyDegrees>
+<time>1746104862509</time>
+</trkpt>
+<trkpt lat="55.9380783" lon="-4.3198943">
+<ele>115.0></ele>
+<accuracy>5.532</accuracy>
+<speed>1.5182916</speed>
+<bearing>131.6849</bearing>
+<bearingAccuracyDegrees>11.848829</bearingAccuracyDegrees>
+<time>1746104863561</time>
+</trkpt>
+<trkpt lat="55.9380662" lon="-4.3198718">
+<ele>115.0></ele>
+<accuracy>5.583</accuracy>
+<speed>1.601683</speed>
+<bearing>131.39069</bearing>
+<bearingAccuracyDegrees>10.187295</bearingAccuracyDegrees>
+<time>1746104864465</time>
+</trkpt>
+<trkpt lat="55.9380534" lon="-4.3198483">
+<ele>115.0></ele>
+<accuracy>5.653</accuracy>
+<speed>1.5986091</speed>
+<bearing>130.40642</bearing>
+<bearingAccuracyDegrees>11.266081</bearingAccuracyDegrees>
+<time>1746104865485</time>
+</trkpt>
+<trkpt lat="55.9380408" lon="-4.3198261">
+<ele>114.5></ele>
+<accuracy>5.666</accuracy>
+<speed>1.6002156</speed>
+<bearing>134.72568</bearing>
+<bearingAccuracyDegrees>10.0864</bearingAccuracyDegrees>
+<time>1746104866535</time>
+</trkpt>
+<trkpt lat="55.9380288" lon="-4.3198044">
+<ele>114.5></ele>
+<accuracy>5.577</accuracy>
+<speed>1.5787568</speed>
+<bearing>136.8472</bearing>
+<bearingAccuracyDegrees>10.13237</bearingAccuracyDegrees>
+<time>1746104867541</time>
+</trkpt>
+<trkpt lat="55.9380183" lon="-4.3197813">
+<ele>114.5></ele>
+<accuracy>5.561</accuracy>
+<speed>1.5765371</speed>
+<bearing>132.45372</bearing>
+<bearingAccuracyDegrees>9.923084</bearingAccuracyDegrees>
+<time>1746104868539</time>
+</trkpt>
+<trkpt lat="55.9380094" lon="-4.3197544">
+<ele>114.5></ele>
+<accuracy>5.447</accuracy>
+<speed>1.5792309</speed>
+<bearing>130.18365</bearing>
+<bearingAccuracyDegrees>9.836739</bearingAccuracyDegrees>
+<time>1746104869542</time>
+</trkpt>
+<trkpt lat="55.9379987" lon="-4.3197285">
+<ele>114.5></ele>
+<accuracy>5.34</accuracy>
+<speed>1.5425647</speed>
+<bearing>133.51064</bearing>
+<bearingAccuracyDegrees>9.88911</bearingAccuracyDegrees>
+<time>1746104870629</time>
+</trkpt>
+<trkpt lat="55.9379912" lon="-4.3197102">
+<ele>114.5></ele>
+<accuracy>5.289</accuracy>
+<speed>1.5180913</speed>
+<bearing>134.9787</bearing>
+<bearingAccuracyDegrees>9.990041</bearingAccuracyDegrees>
+<time>1746104871547</time>
+</trkpt>
+<trkpt lat="55.937983" lon="-4.3196896">
+<ele>114.5></ele>
+<accuracy>5.199</accuracy>
+<speed>1.4896868</speed>
+<bearing>137.84851</bearing>
+<bearingAccuracyDegrees>10.083731</bearingAccuracyDegrees>
+<time>1746104872549</time>
+</trkpt>
+<trkpt lat="55.9379764" lon="-4.319674">
+<ele>114.5></ele>
+<accuracy>4.661</accuracy>
+<speed>1.4923252</speed>
+<bearing>136.0141</bearing>
+<bearingAccuracyDegrees>9.506011</bearingAccuracyDegrees>
+<time>1746104873552</time>
+</trkpt>
+<trkpt lat="55.9379646" lon="-4.319658">
+<ele>115.0></ele>
+<accuracy>4.052</accuracy>
+<speed>1.4969131</speed>
+<bearing>137.29697</bearing>
+<bearingAccuracyDegrees>10.239783</bearingAccuracyDegrees>
+<time>1746104874554</time>
+</trkpt>
+<trkpt lat="55.9379529" lon="-4.3196399">
+<ele>115.0></ele>
+<accuracy>3.828</accuracy>
+<speed>1.5075368</speed>
+<bearing>138.6247</bearing>
+<bearingAccuracyDegrees>9.925784</bearingAccuracyDegrees>
+<time>1746104875556</time>
+</trkpt>
+<trkpt lat="55.9379411" lon="-4.3196222">
+<ele>115.0></ele>
+<accuracy>3.618</accuracy>
+<speed>1.5313389</speed>
+<bearing>142.6545</bearing>
+<bearingAccuracyDegrees>11.649987</bearingAccuracyDegrees>
+<time>1746104876559</time>
+</trkpt>
+<trkpt lat="55.9379277" lon="-4.3196043">
+<ele>115.0></ele>
+<accuracy>3.455</accuracy>
+<speed>1.5716249</speed>
+<bearing>141.03511</bearing>
+<bearingAccuracyDegrees>11.620362</bearingAccuracyDegrees>
+<time>1746104877561</time>
+</trkpt>
+<trkpt lat="55.9379146" lon="-4.3195864">
+<ele>115.0></ele>
+<accuracy>3.585</accuracy>
+<speed>1.5641806</speed>
+<bearing>141.67867</bearing>
+<bearingAccuracyDegrees>11.655156</bearingAccuracyDegrees>
+<time>1746104878563</time>
+</trkpt>
+<trkpt lat="55.9379013" lon="-4.3195694">
+<ele>115.0></ele>
+<accuracy>3.936</accuracy>
+<speed>1.5734371</speed>
+<bearing>143.3687</bearing>
+<bearingAccuracyDegrees>12.365134</bearingAccuracyDegrees>
+<time>1746104879566</time>
+</trkpt>
+<trkpt lat="55.9378882" lon="-4.3195512">
+<ele>115.0></ele>
+<accuracy>4.248</accuracy>
+<speed>1.5848244</speed>
+<bearing>139.05467</bearing>
+<bearingAccuracyDegrees>12.150623</bearingAccuracyDegrees>
+<time>1746104880568</time>
+</trkpt>
+<trkpt lat="55.9378765" lon="-4.3195306">
+<ele>115.0></ele>
+<accuracy>4.538</accuracy>
+<speed>1.5825882</speed>
+<bearing>138.7483</bearing>
+<bearingAccuracyDegrees>12.322892</bearingAccuracyDegrees>
+<time>1746104881570</time>
+</trkpt>
+<trkpt lat="55.9378642" lon="-4.3195124">
+<ele>115.0></ele>
+<accuracy>4.79</accuracy>
+<speed>1.5617124</speed>
+<bearing>141.50955</bearing>
+<bearingAccuracyDegrees>12.182374</bearingAccuracyDegrees>
+<time>1746104882572</time>
+</trkpt>
+<trkpt lat="55.9378505" lon="-4.3194964">
+<ele>115.0></ele>
+<accuracy>5.004</accuracy>
+<speed>1.5495965</speed>
+<bearing>143.2705</bearing>
+<bearingAccuracyDegrees>12.305644</bearingAccuracyDegrees>
+<time>1746104883575</time>
+</trkpt>
+<trkpt lat="55.9378363" lon="-4.3194857">
+<ele>112.30000305175781></ele>
+<accuracy>5.185</accuracy>
+<speed>1.5386372</speed>
+<bearing>176.56482</bearing>
+<bearingAccuracyDegrees>12.363462</bearingAccuracyDegrees>
+<time>1746104884577</time>
+</trkpt>
+<trkpt lat="55.937821" lon="-4.3194939">
+<ele>112.30000305175781></ele>
+<accuracy>5.354</accuracy>
+<speed>1.5383962</speed>
+<bearing>194.75475</bearing>
+<bearingAccuracyDegrees>12.296713</bearingAccuracyDegrees>
+<time>1746104885524</time>
+</trkpt>
+<trkpt lat="55.9378064" lon="-4.3194986">
+<ele>112.30000305175781></ele>
+<accuracy>5.485</accuracy>
+<speed>1.5429058</speed>
+<bearing>182.34799</bearing>
+<bearingAccuracyDegrees>11.938814</bearingAccuracyDegrees>
+<time>1746104886507</time>
+</trkpt>
+<trkpt lat="55.937792" lon="-4.3195122">
+<ele>112.30000305175781></ele>
+<accuracy>5.349</accuracy>
+<speed>1.5410051</speed>
+<bearing>191.05278</bearing>
+<bearingAccuracyDegrees>10.437036</bearingAccuracyDegrees>
+<time>1746104887509</time>
+</trkpt>
+<trkpt lat="55.9377747" lon="-4.3195255">
+<ele>112.30000305175781></ele>
+<accuracy>5.003</accuracy>
+<speed>1.5522703</speed>
+<bearing>182.00569</bearing>
+<bearingAccuracyDegrees>10.322076</bearingAccuracyDegrees>
+<time>1746104888524</time>
+</trkpt>
+<trkpt lat="55.9377583" lon="-4.3195329">
+<ele>112.30000305175781></ele>
+<accuracy>4.634</accuracy>
+<speed>1.5570087</speed>
+<bearing>183.88782</bearing>
+<bearingAccuracyDegrees>9.854071</bearingAccuracyDegrees>
+<time>1746104889544</time>
+</trkpt>
+<trkpt lat="55.9377409" lon="-4.3195378">
+<ele>112.30000305175781></ele>
+<accuracy>4.075</accuracy>
+<speed>1.5547235</speed>
+<bearing>185.85184</bearing>
+<bearingAccuracyDegrees>9.61519</bearingAccuracyDegrees>
+<time>1746104890545</time>
+</trkpt>
+<trkpt lat="55.9377238" lon="-4.3195442">
+<ele>112.30000305175781></ele>
+<accuracy>3.557</accuracy>
+<speed>1.5697078</speed>
+<bearing>194.07571</bearing>
+<bearingAccuracyDegrees>9.778306</bearingAccuracyDegrees>
+<time>1746104891547</time>
+</trkpt>
+<trkpt lat="55.9377076" lon="-4.3195531">
+<ele>112.30000305175781></ele>
+<accuracy>3.341</accuracy>
+<speed>1.5685954</speed>
+<bearing>182.82758</bearing>
+<bearingAccuracyDegrees>9.579674</bearingAccuracyDegrees>
+<time>1746104892580</time>
+</trkpt>
+<trkpt lat="55.9376928" lon="-4.319548">
+<ele>112.30000305175781></ele>
+<accuracy>3.209</accuracy>
+<speed>1.5468851</speed>
+<bearing>156.47011</bearing>
+<bearingAccuracyDegrees>9.424985</bearingAccuracyDegrees>
+<time>1746104893602</time>
+</trkpt>
+<trkpt lat="55.9376819" lon="-4.3195358">
+<ele>112.30000305175781></ele>
+<accuracy>3.148</accuracy>
+<speed>1.5454664</speed>
+<bearing>149.34418</bearing>
+<bearingAccuracyDegrees>9.186008</bearingAccuracyDegrees>
+<time>1746104894601</time>
+</trkpt>
+<trkpt lat="55.9376718" lon="-4.3195245">
+<ele>112.30000305175781></ele>
+<accuracy>3.078</accuracy>
+<speed>1.5402561</speed>
+<bearing>151.24551</bearing>
+<bearingAccuracyDegrees>9.512734</bearingAccuracyDegrees>
+<time>1746104895503</time>
+</trkpt>
+<trkpt lat="55.9376583" lon="-4.3195108">
+<ele>112.30000305175781></ele>
+<accuracy>3.047</accuracy>
+<speed>1.5393574</speed>
+<bearing>148.31924</bearing>
+<bearingAccuracyDegrees>9.568405</bearingAccuracyDegrees>
+<time>1746104896605</time>
+</trkpt>
+<trkpt lat="55.9376453" lon="-4.3194974">
+<ele>112.30000305175781></ele>
+<accuracy>3.027</accuracy>
+<speed>1.5373523</speed>
+<bearing>149.94649</bearing>
+<bearingAccuracyDegrees>9.283653</bearingAccuracyDegrees>
+<time>1746104897608</time>
+</trkpt>
+<trkpt lat="55.9376317" lon="-4.3194848">
+<ele>112.30000305175781></ele>
+<accuracy>3.019</accuracy>
+<speed>1.5809783</speed>
+<bearing>150.50919</bearing>
+<bearingAccuracyDegrees>9.594107</bearingAccuracyDegrees>
+<time>1746104898510</time>
+</trkpt>
+<trkpt lat="55.9376173" lon="-4.3194712">
+<ele>112.30000305175781></ele>
+<accuracy>3.022</accuracy>
+<speed>1.5607682</speed>
+<bearing>146.29625</bearing>
+<bearingAccuracyDegrees>9.7620735</bearingAccuracyDegrees>
+<time>1746104899612</time>
+</trkpt>
+<trkpt lat="55.9376055" lon="-4.3194594">
+<ele>112.30000305175781></ele>
+<accuracy>3.024</accuracy>
+<speed>1.5400618</speed>
+<bearing>150.47478</bearing>
+<bearingAccuracyDegrees>9.516683</bearingAccuracyDegrees>
+<time>1746104900513</time>
+</trkpt>
+<trkpt lat="55.9375905" lon="-4.3194498">
+<ele>112.30000305175781></ele>
+<accuracy>3.036</accuracy>
+<speed>1.557417</speed>
+<bearing>155.64507</bearing>
+<bearingAccuracyDegrees>9.127157</bearingAccuracyDegrees>
+<time>1746104901617</time>
+</trkpt>
+<trkpt lat="55.9375758" lon="-4.3194415">
+<ele>112.30000305175781></ele>
+<accuracy>3.038</accuracy>
+<speed>1.5690835</speed>
+<bearing>155.92061</bearing>
+<bearingAccuracyDegrees>9.218951</bearingAccuracyDegrees>
+<time>1746104902519</time>
+</trkpt>
+<trkpt lat="55.9375602" lon="-4.3194314">
+<ele>112.30000305175781></ele>
+<accuracy>3.044</accuracy>
+<speed>1.562719</speed>
+<bearing>151.89325</bearing>
+<bearingAccuracyDegrees>9.016031</bearingAccuracyDegrees>
+<time>1746104903521</time>
+</trkpt>
+<trkpt lat="55.9375457" lon="-4.3194192">
+<ele>112.30000305175781></ele>
+<accuracy>3.049</accuracy>
+<speed>1.5579264</speed>
+<bearing>148.5008</bearing>
+<bearingAccuracyDegrees>9.494593</bearingAccuracyDegrees>
+<time>1746104904524</time>
+</trkpt>
+<trkpt lat="55.9375311" lon="-4.3194071">
+<ele>112.30000305175781></ele>
+<accuracy>3.057</accuracy>
+<speed>1.549866</speed>
+<bearing>152.92621</bearing>
+<bearingAccuracyDegrees>9.804453</bearingAccuracyDegrees>
+<time>1746104905526</time>
+</trkpt>
+<trkpt lat="55.9375159" lon="-4.3193963">
+<ele>112.30000305175781></ele>
+<accuracy>3.074</accuracy>
+<speed>1.5309069</speed>
+<bearing>152.353</bearing>
+<bearingAccuracyDegrees>9.619644</bearingAccuracyDegrees>
+<time>1746104906527</time>
+</trkpt>
+<trkpt lat="55.9375022" lon="-4.3193785">
+<ele>112.30000305175781></ele>
+<accuracy>3.099</accuracy>
+<speed>1.5510944</speed>
+<bearing>150.2256</bearing>
+<bearingAccuracyDegrees>9.464932</bearingAccuracyDegrees>
+<time>1746104907531</time>
+</trkpt>
+<trkpt lat="55.9374261" lon="-4.319246">
+<ele>112.30000305175781></ele>
+<accuracy>3.154</accuracy>
+<speed>1.5739464</speed>
+<bearing>99.728226</bearing>
+<bearingAccuracyDegrees>9.455149</bearingAccuracyDegrees>
+<time>1746104913545</time>
+</trkpt>
+<trkpt lat="55.9374239" lon="-4.3192189">
+<ele>112.30000305175781></ele>
+<accuracy>3.158</accuracy>
+<speed>1.5206884</speed>
+<bearing>107.66284</bearing>
+<bearingAccuracyDegrees>9.404591</bearingAccuracyDegrees>
+<time>1746104914546</time>
+</trkpt>
+<trkpt lat="55.9374183" lon="-4.319194">
+<ele>112.30000305175781></ele>
+<accuracy>3.118</accuracy>
+<speed>1.5353884</speed>
+<bearing>101.151955</bearing>
+<bearingAccuracyDegrees>8.940553</bearingAccuracyDegrees>
+<time>1746104915503</time>
+</trkpt>
+<trkpt lat="55.9374152" lon="-4.3191671">
+<ele>112.30000305175781></ele>
+<accuracy>3.089</accuracy>
+<speed>1.5429311</speed>
+<bearing>105.76739</bearing>
+<bearingAccuracyDegrees>8.97213</bearingAccuracyDegrees>
+<time>1746104916528</time>
+</trkpt>
+<trkpt lat="55.9374106" lon="-4.3191402">
+<ele>112.30000305175781></ele>
+<accuracy>3.054</accuracy>
+<speed>1.5257329</speed>
+<bearing>111.36227</bearing>
+<bearingAccuracyDegrees>9.763748</bearingAccuracyDegrees>
+<time>1746104917567</time>
+</trkpt>
+<trkpt lat="55.9374044" lon="-4.3191143">
+<ele>112.30000305175781></ele>
+<accuracy>3.039</accuracy>
+<speed>1.550987</speed>
+<bearing>115.227394</bearing>
+<bearingAccuracyDegrees>9.288492</bearingAccuracyDegrees>
+<time>1746104918580</time>
+</trkpt>
+<trkpt lat="55.9373967" lon="-4.3190889">
+<ele>112.30000305175781></ele>
+<accuracy>3.032</accuracy>
+<speed>1.5456264</speed>
+<bearing>117.71503</bearing>
+<bearingAccuracyDegrees>9.395223</bearingAccuracyDegrees>
+<time>1746104919602</time>
+</trkpt>
+<trkpt lat="55.9373905" lon="-4.3190686">
+<ele>112.30000305175781></ele>
+<accuracy>3.021</accuracy>
+<speed>1.524067</speed>
+<bearing>115.80804</bearing>
+<bearingAccuracyDegrees>9.550153</bearingAccuracyDegrees>
+<time>1746104920561</time>
+</trkpt>
+<trkpt lat="55.937383" lon="-4.3190447">
+<ele>112.30000305175781></ele>
+<accuracy>3.01</accuracy>
+<speed>1.5356956</speed>
+<bearing>110.53772</bearing>
+<bearingAccuracyDegrees>7.154696</bearingAccuracyDegrees>
+<time>1746104921564</time>
+</trkpt>
+<trkpt lat="55.9373788" lon="-4.3190175">
+<ele>112.30000305175781></ele>
+<accuracy>3.009</accuracy>
+<speed>1.5304872</speed>
+<bearing>102.63327</bearing>
+<bearingAccuracyDegrees>8.713533</bearingAccuracyDegrees>
+<time>1746104922566</time>
+</trkpt>
+<trkpt lat="55.937377" lon="-4.3189889">
+<ele>112.30000305175781></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5141344</speed>
+<bearing>95.20392</bearing>
+<bearingAccuracyDegrees>9.089449</bearingAccuracyDegrees>
+<time>1746104923568</time>
+</trkpt>
+<trkpt lat="55.9373777" lon="-4.3189604">
+<ele>112.30000305175781></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5456326</speed>
+<bearing>88.68529</bearing>
+<bearingAccuracyDegrees>9.39354</bearingAccuracyDegrees>
+<time>1746104924570</time>
+</trkpt>
+<trkpt lat="55.9373788" lon="-4.3189311">
+<ele>112.30000305175781></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5404783</speed>
+<bearing>86.108</bearing>
+<bearingAccuracyDegrees>9.541542</bearingAccuracyDegrees>
+<time>1746104925573</time>
+</trkpt>
+<trkpt lat="55.9373796" lon="-4.3189008">
+<ele>112.30000305175781></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5383322</speed>
+<bearing>83.17767</bearing>
+<bearingAccuracyDegrees>10.0439005</bearingAccuracyDegrees>
+<time>1746104926574</time>
+</trkpt>
+<trkpt lat="55.9373817" lon="-4.3188706">
+<ele>112.30000305175781></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5421115</speed>
+<bearing>81.76028</bearing>
+<bearingAccuracyDegrees>9.55006</bearingAccuracyDegrees>
+<time>1746104927578</time>
+</trkpt>
+<trkpt lat="55.9373836" lon="-4.3188409">
+<ele>112.30000305175781></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5555857</speed>
+<bearing>84.66241</bearing>
+<bearingAccuracyDegrees>9.492873</bearingAccuracyDegrees>
+<time>1746104928580</time>
+</trkpt>
+<trkpt lat="55.9373844" lon="-4.3188118">
+<ele>112.30000305175781></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5548025</speed>
+<bearing>88.82857</bearing>
+<bearingAccuracyDegrees>9.395431</bearingAccuracyDegrees>
+<time>1746104929582</time>
+</trkpt>
+<trkpt lat="55.9373828" lon="-4.318782">
+<ele>112.30000305175781></ele>
+<accuracy>3.001</accuracy>
+<speed>1.5549555</speed>
+<bearing>89.54804</bearing>
+<bearingAccuracyDegrees>9.470106</bearingAccuracyDegrees>
+<time>1746104930584</time>
+</trkpt>
+<trkpt lat="55.9373803" lon="-4.3187491">
+<ele>112.30000305175781></ele>
+<accuracy>3.018</accuracy>
+<speed>1.5434741</speed>
+<bearing>87.75348</bearing>
+<bearingAccuracyDegrees>9.456767</bearingAccuracyDegrees>
+<time>1746104931587</time>
+</trkpt>
+<trkpt lat="55.9373796" lon="-4.3187189">
+<ele>112.30000305175781></ele>
+<accuracy>3.033</accuracy>
+<speed>1.5347978</speed>
+<bearing>87.245514</bearing>
+<bearingAccuracyDegrees>9.688396</bearingAccuracyDegrees>
+<time>1746104932545</time>
+</trkpt>
+<trkpt lat="55.9373803" lon="-4.3186914">
+<ele>112.30000305175781></ele>
+<accuracy>3.061</accuracy>
+<speed>1.5242628</speed>
+<bearing>88.26308</bearing>
+<bearingAccuracyDegrees>10.304122</bearingAccuracyDegrees>
+<time>1746104933584</time>
+</trkpt>
+<trkpt lat="55.937381" lon="-4.3186708">
+<ele>112.30000305175781></ele>
+<accuracy>3.092</accuracy>
+<speed>1.4704297</speed>
+<bearing>90.75117</bearing>
+<bearingAccuracyDegrees>10.209292</bearingAccuracyDegrees>
+<time>1746104934594</time>
+</trkpt>
+<trkpt lat="55.9373819" lon="-4.3186536">
+<ele>112.30000305175781></ele>
+<accuracy>3.108</accuracy>
+<speed>1.4264617</speed>
+<bearing>85.9611</bearing>
+<bearingAccuracyDegrees>10.286462</bearingAccuracyDegrees>
+<time>1746104935595</time>
+</trkpt>
+<trkpt lat="55.9373849" lon="-4.3186354">
+<ele>112.30000305175781></ele>
+<accuracy>3.109</accuracy>
+<speed>1.4147444</speed>
+<bearing>81.960236</bearing>
+<bearingAccuracyDegrees>11.600732</bearingAccuracyDegrees>
+<time>1746104936599</time>
+</trkpt>
+<trkpt lat="55.9373873" lon="-4.3186174">
+<ele>112.30000305175781></ele>
+<accuracy>3.116</accuracy>
+<speed>1.4204979</speed>
+<bearing>84.70362</bearing>
+<bearingAccuracyDegrees>11.668135</bearingAccuracyDegrees>
+<time>1746104937601</time>
+</trkpt>
+<trkpt lat="55.9373876" lon="-4.3185972">
+<ele>112.30000305175781></ele>
+<accuracy>3.158</accuracy>
+<speed>1.4133474</speed>
+<bearing>87.579346</bearing>
+<bearingAccuracyDegrees>12.363737</bearingAccuracyDegrees>
+<time>1746104938603</time>
+</trkpt>
+<trkpt lat="55.9373852" lon="-4.3185742">
+<ele>112.30000305175781></ele>
+<accuracy>3.224</accuracy>
+<speed>1.4383972</speed>
+<bearing>90.46433</bearing>
+<bearingAccuracyDegrees>12.034701</bearingAccuracyDegrees>
+<time>1746104939606</time>
+</trkpt>
+<trkpt lat="55.9373844" lon="-4.3185482">
+<ele>112.30000305175781></ele>
+<accuracy>3.361</accuracy>
+<speed>1.4574066</speed>
+<bearing>86.17204</bearing>
+<bearingAccuracyDegrees>12.202349</bearingAccuracyDegrees>
+<time>1746104940608</time>
+</trkpt>
+<trkpt lat="55.9373889" lon="-4.3184431">
+<ele>112.30000305175781></ele>
+<accuracy>4.546</accuracy>
+<speed>1.4798527</speed>
+<bearing>86.633606</bearing>
+<bearingAccuracyDegrees>12.762276</bearingAccuracyDegrees>
+<time>1746104944601</time>
+</trkpt>
+<trkpt lat="55.9373887" lon="-4.3184203">
+<ele>112.30000305175781></ele>
+<accuracy>4.875</accuracy>
+<speed>1.4519117</speed>
+<bearing>89.30511</bearing>
+<bearingAccuracyDegrees>12.693052</bearingAccuracyDegrees>
+<time>1746104945518</time>
+</trkpt>
+<trkpt lat="55.9373886" lon="-4.3183966">
+<ele>112.30000305175781></ele>
+<accuracy>5.164</accuracy>
+<speed>1.4219296</speed>
+<bearing>89.31828</bearing>
+<bearingAccuracyDegrees>12.328963</bearingAccuracyDegrees>
+<time>1746104946522</time>
+</trkpt>
+<trkpt lat="55.9373887" lon="-4.3183711">
+<ele>112.30000305175781></ele>
+<accuracy>5.387</accuracy>
+<speed>1.4241827</speed>
+<bearing>88.681465</bearing>
+<bearingAccuracyDegrees>12.2627535</bearingAccuracyDegrees>
+<time>1746104947524</time>
+</trkpt>
+<trkpt lat="55.9373895" lon="-4.3183454">
+<ele>112.30000305175781></ele>
+<accuracy>5.6</accuracy>
+<speed>1.4527899</speed>
+<bearing>87.0949</bearing>
+<bearingAccuracyDegrees>12.115303</bearingAccuracyDegrees>
+<time>1746104948526</time>
+</trkpt>
+<trkpt lat="55.9373908" lon="-4.3183219">
+<ele>112.30000305175781></ele>
+<accuracy>5.778</accuracy>
+<speed>1.4655124</speed>
+<bearing>86.83967</bearing>
+<bearingAccuracyDegrees>11.767746</bearingAccuracyDegrees>
+<time>1746104949529</time>
+</trkpt>
+<trkpt lat="55.9373913" lon="-4.3182833">
+<ele>112.30000305175781></ele>
+<accuracy>5.88</accuracy>
+<speed>1.4644718</speed>
+<bearing>86.33762</bearing>
+<bearingAccuracyDegrees>11.646647</bearingAccuracyDegrees>
+<time>1746104950531</time>
+</trkpt>
+<trkpt lat="55.9373934" lon="-4.3182601">
+<ele>112.30000305175781></ele>
+<accuracy>5.933</accuracy>
+<speed>1.4780235</speed>
+<bearing>89.39221</bearing>
+<bearingAccuracyDegrees>11.878214</bearingAccuracyDegrees>
+<time>1746104951493</time>
+</trkpt>
+<trkpt lat="55.9373963" lon="-4.3182373">
+<ele>112.30000305175781></ele>
+<accuracy>5.945</accuracy>
+<speed>1.5031607</speed>
+<bearing>64.139946</bearing>
+<bearingAccuracyDegrees>12.678607</bearingAccuracyDegrees>
+<time>1746104952536</time>
+</trkpt>
+<trkpt lat="55.9374007" lon="-4.3182159">
+<ele>112.30000305175781></ele>
+<accuracy>5.885</accuracy>
+<speed>1.4647759</speed>
+<bearing>103.14804</bearing>
+<bearingAccuracyDegrees>12.912693</bearingAccuracyDegrees>
+<time>1746104953538</time>
+</trkpt>
+<trkpt lat="55.9373937" lon="-4.3181967">
+<ele>112.30000305175781></ele>
+<accuracy>5.781</accuracy>
+<speed>1.363327</speed>
+<bearing>128.92387</bearing>
+<bearingAccuracyDegrees>13.102806</bearingAccuracyDegrees>
+<time>1746104954502</time>
+</trkpt>
+<trkpt lat="55.937389" lon="-4.3181672">
+<ele>112.30000305175781></ele>
+<accuracy>5.688</accuracy>
+<speed>1.1864938</speed>
+<bearing>102.08416</bearing>
+<bearingAccuracyDegrees>36.025677</bearingAccuracyDegrees>
+<time>1746104956545</time>
+</trkpt>
+<trkpt lat="55.9373886" lon="-4.3181484">
+<ele>112.30000305175781></ele>
+<accuracy>5.661</accuracy>
+<speed>1.1485211</speed>
+<bearing>99.85757</bearing>
+<bearingAccuracyDegrees>34.748146</bearingAccuracyDegrees>
+<time>1746104957548</time>
+</trkpt>
+<trkpt lat="55.9373872" lon="-4.3181313">
+<ele>112.30000305175781></ele>
+<accuracy>5.73</accuracy>
+<speed>1.078643</speed>
+<bearing>100.94129</bearing>
+<bearingAccuracyDegrees>34.404423</bearingAccuracyDegrees>
+<time>1746104958550</time>
+</trkpt>
+<trkpt lat="55.9373861" lon="-4.3181078">
+<ele>110.25580535806672></ele>
+<accuracy>6.289</accuracy>
+<speed>0.837727</speed>
+<bearing>101.655365</bearing>
+<bearingAccuracyDegrees>34.48646</bearingAccuracyDegrees>
+<time>1746104960554</time>
+</trkpt>
+<trkpt lat="55.9373971" lon="-4.3181086">
+<ele>110.37903237337963></ele>
+<accuracy>6.325</accuracy>
+<speed>0.53943264</speed>
+<bearing>90.94913</bearing>
+<bearingAccuracyDegrees>29.583073</bearingAccuracyDegrees>
+<time>1746104961557</time>
+</trkpt>
+<trkpt lat="55.9374179" lon="-4.3181404">
+<ele>112.30000305175781></ele>
+<accuracy>6.174</accuracy>
+<speed>0.09962524</speed>
+<bearing>0.0</bearing>
+<bearingAccuracyDegrees>0.0</bearingAccuracyDegrees>
+<time>1746104962559</time>
+</trkpt>
+<trkpt lat="55.9374056" lon="-4.3181407">
+<ele>112.30000305175781></ele>
+<accuracy>4.644</accuracy>
+<speed>0.079290316</speed>
+<bearing>0.0</bearing>
+<bearingAccuracyDegrees>0.0</bearingAccuracyDegrees>
+<time>1746104970577</time>
+</trkpt>
+<trkpt lat="55.9374099" lon="-4.3181203">
+<ele>112.30000305175781></ele>
+<accuracy>3.087</accuracy>
+<speed>0.5814122</speed>
+<bearing>97.93861</bearing>
+<bearingAccuracyDegrees>12.200817</bearingAccuracyDegrees>
+<time>1746104981478</time>
+</trkpt>
+<trkpt lat="55.9374083" lon="-4.318104">
+<ele>112.30000305175781></ele>
+<accuracy>16.94</accuracy>
+<speed>0.1275143</speed>
+<bearing>90.155525</bearing>
+<bearingAccuracyDegrees>180.0</bearingAccuracyDegrees>
+<time>1746104982586</time>
+</trkpt>
+<trkpt lat="55.9374085" lon="-4.3180785">
+<ele>112.30000305175781></ele>
+<accuracy>16.833</accuracy>
+<speed>1.3818074</speed>
+<bearing>92.13359</bearing>
+<bearingAccuracyDegrees>81.44753</bearingAccuracyDegrees>
+<time>1746104983653</time>
+</trkpt>
+<trkpt lat="55.937408" lon="-4.3180527">
+<ele>112.30000305175781></ele>
+<accuracy>17.223</accuracy>
+<speed>1.440574</speed>
+<bearing>93.65803</bearing>
+<bearingAccuracyDegrees>79.04277</bearingAccuracyDegrees>
+<time>1746104984590</time>
+</trkpt>
+<trkpt lat="55.9374049" lon="-4.3180105">
+<ele>112.30000305175781></ele>
+<accuracy>15.623</accuracy>
+<speed>1.4556102</speed>
+<bearing>97.397316</bearing>
+<bearingAccuracyDegrees>46.34403</bearingAccuracyDegrees>
+<time>1746104985592</time>
+</trkpt>
+<trkpt lat="55.9374008" lon="-4.3179714">
+<ele>112.30000305175781></ele>
+<accuracy>16.097</accuracy>
+<speed>1.4630619</speed>
+<bearing>99.38646</bearing>
+<bearingAccuracyDegrees>30.838104</bearingAccuracyDegrees>
+<time>1746104986594</time>
+</trkpt>
+<trkpt lat="55.9373922" lon="-4.3178223">
+<ele>112.30000305175781></ele>
+<accuracy>7.395</accuracy>
+<speed>1.5036676</speed>
+<bearing>93.02678</bearing>
+<bearingAccuracyDegrees>14.916745</bearingAccuracyDegrees>
+<time>1746104991503</time>
+</trkpt>
+<trkpt lat="55.9373941" lon="-4.3177725">
+<ele>111.0516525509147></ele>
+<accuracy>6.862</accuracy>
+<speed>1.4955767</speed>
+<bearing>91.88032</bearing>
+<bearingAccuracyDegrees>14.909876</bearingAccuracyDegrees>
+<time>1746104993612</time>
+</trkpt>
+<trkpt lat="55.9373959" lon="-4.3177483">
+<ele>110.94678578121625></ele>
+<accuracy>6.779</accuracy>
+<speed>1.4871657</speed>
+<bearing>92.9191</bearing>
+<bearingAccuracyDegrees>15.086357</bearingAccuracyDegrees>
+<time>1746104994613</time>
+</trkpt>
+<trkpt lat="55.9373948" lon="-4.317712">
+<ele>110.79072280510837></ele>
+<accuracy>6.632</accuracy>
+<speed>1.5007969</speed>
+<bearing>93.41678</bearing>
+<bearingAccuracyDegrees>12.331256</bearingAccuracyDegrees>
+<time>1746104995616</time>
+</trkpt>
+<trkpt lat="55.9373953" lon="-4.3176861">
+<ele>110.70540957542084></ele>
+<accuracy>6.526</accuracy>
+<speed>1.4704915</speed>
+<bearing>91.08176</bearing>
+<bearingAccuracyDegrees>12.632626</bearingAccuracyDegrees>
+<time>1746104996619</time>
+</trkpt>
+<trkpt lat="55.9373975" lon="-4.3176685">
+<ele>110.46820162867198></ele>
+<accuracy>6.377</accuracy>
+<speed>1.4532648</speed>
+<bearing>89.72029</bearing>
+<bearingAccuracyDegrees>12.785493</bearingAccuracyDegrees>
+<time>1746104997521</time>
+</trkpt>
+<trkpt lat="55.9373996" lon="-4.3176487">
+<ele>110.46820162867198></ele>
+<accuracy>6.173</accuracy>
+<speed>1.4577254</speed>
+<bearing>87.405014</bearing>
+<bearingAccuracyDegrees>12.390387</bearingAccuracyDegrees>
+<time>1746104998507</time>
+</trkpt>
+<trkpt lat="55.9374014" lon="-4.3176304">
+<ele>110.58007054139398></ele>
+<accuracy>6.016</accuracy>
+<speed>1.4429556</speed>
+<bearing>85.557205</bearing>
+<bearingAccuracyDegrees>12.864205</bearingAccuracyDegrees>
+<time>1746104999528</time>
+</trkpt>
+<trkpt lat="55.9374234" lon="-4.3175072">
+<ele>109.55228843571793></ele>
+<accuracy>6.641</accuracy>
+<speed>1.4189011</speed>
+<bearing>70.21727</bearing>
+<bearingAccuracyDegrees>13.240821</bearingAccuracyDegrees>
+<time>1746105006542</time>
+</trkpt>
+<trkpt lat="55.9374302" lon="-4.3174919">
+<ele>109.35672284169489></ele>
+<accuracy>6.82</accuracy>
+<speed>1.4352602</speed>
+<bearing>64.9555</bearing>
+<bearingAccuracyDegrees>12.951207</bearingAccuracyDegrees>
+<time>1746105007544</time>
+</trkpt>
+<trkpt lat="55.9374353" lon="-4.317476">
+<ele>107.69999694824219></ele>
+<accuracy>6.935</accuracy>
+<speed>1.4109144</speed>
+<bearing>63.443916</bearing>
+<bearingAccuracyDegrees>12.692745</bearingAccuracyDegrees>
+<time>1746105008547</time>
+</trkpt>
+<trkpt lat="55.9374407" lon="-4.3174594">
+<ele>107.69999694824219></ele>
+<accuracy>6.978</accuracy>
+<speed>1.3968918</speed>
+<bearing>53.08503</bearing>
+<bearingAccuracyDegrees>11.893341</bearingAccuracyDegrees>
+<time>1746105009485</time>
+</trkpt>
+<trkpt lat="55.9374491" lon="-4.317448">
+<ele>107.69999694824219></ele>
+<accuracy>6.968</accuracy>
+<speed>1.3284831</speed>
+<bearing>29.69861</bearing>
+<bearingAccuracyDegrees>11.838304</bearingAccuracyDegrees>
+<time>1746105010551</time>
+</trkpt>
+<trkpt lat="55.9374594" lon="-4.3174442">
+<ele>107.69999694824219></ele>
+<accuracy>6.842</accuracy>
+<speed>1.249763</speed>
+<bearing>22.161634</bearing>
+<bearingAccuracyDegrees>9.993778</bearingAccuracyDegrees>
+<time>1746105011554</time>
+</trkpt>
+<trkpt lat="55.9374683" lon="-4.3174366">
+<ele>107.0999984741211></ele>
+<accuracy>6.698</accuracy>
+<speed>1.1081085</speed>
+<bearing>59.1936</bearing>
+<bearingAccuracyDegrees>9.892016</bearingAccuracyDegrees>
+<time>1746105012556</time>
+</trkpt>
+<trkpt lat="55.9374718" lon="-4.3174218">
+<ele>107.0999984741211></ele>
+<accuracy>6.544</accuracy>
+<speed>1.0392166</speed>
+<bearing>84.21046</bearing>
+<bearingAccuracyDegrees>9.991867</bearingAccuracyDegrees>
+<time>1746105013558</time>
+</trkpt>
+<trkpt lat="55.937471" lon="-4.317455">
+<ele>107.5></ele>
+<accuracy>5.224</accuracy>
+<speed>0.07867217</speed>
+<bearing>0.0</bearing>
+<bearingAccuracyDegrees>0.0</bearingAccuracyDegrees>
+<time>1746105018569</time>
+</trkpt>
+<trkpt lat="55.9374674" lon="-4.317473">
+<ele>107.5></ele>
+<accuracy>4.416</accuracy>
+<speed>0.08236634</speed>
+<bearing>0.0</bearing>
+<bearingAccuracyDegrees>0.0</bearingAccuracyDegrees>
+<time>1746105020473</time>
+</trkpt>
+<trkpt lat="55.9374583" lon="-4.3174197">
+<ele>107.69999694824219></ele>
+<accuracy>3.227</accuracy>
+<speed>0.33976623</speed>
+<bearing>103.685234</bearing>
+<bearingAccuracyDegrees>48.98977</bearingAccuracyDegrees>
+<time>1746105032478</time>
+</trkpt>
+<trkpt lat="55.937454" lon="-4.3174045">
+<ele>107.69999694824219></ele>
+<accuracy>3.386</accuracy>
+<speed>0.3277474</speed>
+<bearing>104.91321</bearing>
+<bearingAccuracyDegrees>35.468483</bearingAccuracyDegrees>
+<time>1746105033479</time>
+</trkpt>
+<trkpt lat="55.937454" lon="-4.3173868">
+<ele>107.5></ele>
+<accuracy>3.493</accuracy>
+<speed>0.48950562</speed>
+<bearing>326.34094</bearing>
+<bearingAccuracyDegrees>26.696304</bearingAccuracyDegrees>
+<time>1746105044479</time>
+</trkpt>
+<trkpt lat="55.9374628" lon="-4.3173708">
+<ele>107.5></ele>
+<accuracy>3.48</accuracy>
+<speed>0.509913</speed>
+<bearing>15.14454</bearing>
+<bearingAccuracyDegrees>29.080729</bearingAccuracyDegrees>
+<time>1746105045479</time>
+</trkpt>
+<trkpt lat="55.9374697" lon="-4.3173484">
+<ele>107.5></ele>
+<accuracy>3.506</accuracy>
+<speed>0.9102007</speed>
+<bearing>72.45509</bearing>
+<bearingAccuracyDegrees>11.058372</bearingAccuracyDegrees>
+<time>1746105046479</time>
+</trkpt>
+<trkpt lat="55.9374719" lon="-4.3170616">
+<ele>107.0999984741211></ele>
+<accuracy>13.056</accuracy>
+<speed>1.440032</speed>
+<bearing>96.70104</bearing>
+<bearingAccuracyDegrees>21.423426</bearingAccuracyDegrees>
+<time>1746105053612</time>
+</trkpt>
+<trkpt lat="55.9374554" lon="-4.317001">
+<ele>107.29328283150105></ele>
+<accuracy>9.767</accuracy>
+<speed>1.4594064</speed>
+<bearing>125.99468</bearing>
+<bearingAccuracyDegrees>12.724099</bearingAccuracyDegrees>
+<time>1746105056619</time>
+</trkpt>
+<trkpt lat="55.9374498" lon="-4.3169846">
+<ele>107.24260746192246></ele>
+<accuracy>8.596</accuracy>
+<speed>1.4641238</speed>
+<bearing>122.33763</bearing>
+<bearingAccuracyDegrees>11.85488</bearingAccuracyDegrees>
+<time>1746105057521</time>
+</trkpt>
+<trkpt lat="55.9374454" lon="-4.3169651">
+<ele>107.19528715216134></ele>
+<accuracy>7.971</accuracy>
+<speed>1.4615359</speed>
+<bearing>100.442894</bearing>
+<bearingAccuracyDegrees>10.130346</bearingAccuracyDegrees>
+<time>1746105058524</time>
+</trkpt>
+<trkpt lat="55.9374488" lon="-4.3169425">
+<ele>107.00132860332687></ele>
+<accuracy>7.067</accuracy>
+<speed>1.477415</speed>
+<bearing>64.81598</bearing>
+<bearingAccuracyDegrees>9.941267</bearingAccuracyDegrees>
+<time>1746105059526</time>
+</trkpt>
+<trkpt lat="55.9374592" lon="-4.3169243">
+<ele>106.9030510084322></ele>
+<accuracy>6.153</accuracy>
+<speed>1.491298</speed>
+<bearing>51.096394</bearing>
+<bearingAccuracyDegrees>9.808728</bearingAccuracyDegrees>
+<time>1746105060528</time>
+</trkpt>
+<trkpt lat="55.9374721" lon="-4.3169067">
+<ele>106.9030510084322></ele>
+<accuracy>5.411</accuracy>
+<speed>1.5025067</speed>
+<bearing>46.66556</bearing>
+<bearingAccuracyDegrees>9.996952</bearingAccuracyDegrees>
+<time>1746105061563</time>
+</trkpt>
+<trkpt lat="55.9374832" lon="-4.3168923">
+<ele>105.69999694824219></ele>
+<accuracy>5.13</accuracy>
+<speed>1.4840096</speed>
+<bearing>46.500553</bearing>
+<bearingAccuracyDegrees>10.136697</bearingAccuracyDegrees>
+<time>1746105062533</time>
+</trkpt>
+<trkpt lat="55.9375138" lon="-4.3168072">
+<ele>105.69999694824219></ele>
+<accuracy>5.075</accuracy>
+<speed>1.4819648</speed>
+<bearing>108.499146</bearing>
+<bearingAccuracyDegrees>12.730328</bearingAccuracyDegrees>
+<time>1746105067545</time>
+</trkpt>
+<trkpt lat="55.9375092" lon="-4.316789">
+<ele>105.69999694824219></ele>
+<accuracy>5.201</accuracy>
+<speed>1.4904758</speed>
+<bearing>113.59017</bearing>
+<bearingAccuracyDegrees>12.419476</bearingAccuracyDegrees>
+<time>1746105068546</time>
+</trkpt>
+<trkpt lat="55.9375" lon="-4.3167941">
+<ele>105.69999694824219></ele>
+<accuracy>4.887</accuracy>
+<speed>1.4697039</speed>
+<bearing>111.60646</bearing>
+<bearingAccuracyDegrees>11.735731</bearingAccuracyDegrees>
+<time>1746105069677</time>
+</trkpt>
+<trkpt lat="55.9374928" lon="-4.3167768">
+<ele>104.30000305175781></ele>
+<accuracy>4.465</accuracy>
+<speed>1.4810112</speed>
+<bearing>110.42251</bearing>
+<bearingAccuracyDegrees>11.725954</bearingAccuracyDegrees>
+<time>1746105070684</time>
+</trkpt>
+<trkpt lat="55.937486" lon="-4.316751">
+<ele>104.30000305175781></ele>
+<accuracy>4.229</accuracy>
+<speed>1.4884753</speed>
+<bearing>110.28118</bearing>
+<bearingAccuracyDegrees>12.205101</bearingAccuracyDegrees>
+<time>1746105071708</time>
+</trkpt>
+<trkpt lat="55.9374803" lon="-4.3167271">
+<ele>104.30000305175781></ele>
+<accuracy>4.067</accuracy>
+<speed>1.5039182</speed>
+<bearing>107.599785</bearing>
+<bearingAccuracyDegrees>11.901518</bearingAccuracyDegrees>
+<time>1746105072700</time>
+</trkpt>
+<trkpt lat="55.9374741" lon="-4.3167012">
+<ele>104.30000305175781></ele>
+<accuracy>4.062</accuracy>
+<speed>1.5154021</speed>
+<bearing>105.76757</bearing>
+<bearingAccuracyDegrees>12.055707</bearingAccuracyDegrees>
+<time>1746105073741</time>
+</trkpt>
+<trkpt lat="55.9374676" lon="-4.316676">
+<ele>104.30000305175781></ele>
+<accuracy>4.333</accuracy>
+<speed>1.5192637</speed>
+<bearing>106.4327</bearing>
+<bearingAccuracyDegrees>11.607798</bearingAccuracyDegrees>
+<time>1746105074763</time>
+</trkpt>
+<trkpt lat="55.9374605" lon="-4.3166498">
+<ele>104.30000305175781></ele>
+<accuracy>4.79</accuracy>
+<speed>1.5095253</speed>
+<bearing>107.72711</bearing>
+<bearingAccuracyDegrees>11.846287</bearingAccuracyDegrees>
+<time>1746105075766</time>
+</trkpt>
+<trkpt lat="55.9374543" lon="-4.3166239">
+<ele>104.30000305175781></ele>
+<accuracy>5.066</accuracy>
+<speed>1.5219716</speed>
+<bearing>105.98558</bearing>
+<bearingAccuracyDegrees>11.97174</bearingAccuracyDegrees>
+<time>1746105076778</time>
+</trkpt>
+<trkpt lat="55.937449" lon="-4.3165964">
+<ele>104.30000305175781></ele>
+<accuracy>5.281</accuracy>
+<speed>1.5404128</speed>
+<bearing>104.83794</bearing>
+<bearingAccuracyDegrees>12.009414</bearingAccuracyDegrees>
+<time>1746105077821</time>
+</trkpt>
+<trkpt lat="55.9374442" lon="-4.3165708">
+<ele>104.30000305175781></ele>
+<accuracy>5.438</accuracy>
+<speed>1.5037458</speed>
+<bearing>103.97127</bearing>
+<bearingAccuracyDegrees>11.752488</bearingAccuracyDegrees>
+<time>1746105078844</time>
+</trkpt>
+<trkpt lat="55.9374389" lon="-4.316546">
+<ele>104.30000305175781></ele>
+<accuracy>5.541</accuracy>
+<speed>1.4744502</speed>
+<bearing>105.87974</bearing>
+<bearingAccuracyDegrees>11.99248</bearingAccuracyDegrees>
+<time>1746105079886</time>
+</trkpt>
+<trkpt lat="55.937434" lon="-4.3165216">
+<ele>104.30000305175781></ele>
+<accuracy>5.622</accuracy>
+<speed>1.4606397</speed>
+<bearing>103.47796</bearing>
+<bearingAccuracyDegrees>11.609527</bearingAccuracyDegrees>
+<time>1746105080902</time>
+</trkpt>
+<trkpt lat="55.9374295" lon="-4.3164989">
+<ele>104.30000305175781></ele>
+<accuracy>5.644</accuracy>
+<speed>1.256292</speed>
+<bearing>105.480675</bearing>
+<bearingAccuracyDegrees>12.279832</bearingAccuracyDegrees>
+<time>1746105081941</time>
+</trkpt>
+<trkpt lat="55.9374305" lon="-4.3164765">
+<ele>104.30000305175781></ele>
+<accuracy>5.463</accuracy>
+<speed>1.291874</speed>
+<bearing>100.38733</bearing>
+<bearingAccuracyDegrees>10.047496</bearingAccuracyDegrees>
+<time>1746105083524</time>
+</trkpt>
+<trkpt lat="55.9374303" lon="-4.31646">
+<ele>104.30000305175781></ele>
+<accuracy>5.187</accuracy>
+<speed>1.3157371</speed>
+<bearing>100.19123</bearing>
+<bearingAccuracyDegrees>9.589097</bearingAccuracyDegrees>
+<time>1746105084549</time>
+</trkpt>
+<trkpt lat="55.9374307" lon="-4.3164405">
+<ele>104.30000305175781></ele>
+<accuracy>4.753</accuracy>
+<speed>1.2529346</speed>
+<bearing>102.81193</bearing>
+<bearingAccuracyDegrees>9.758365</bearingAccuracyDegrees>
+<time>1746105085582</time>
+</trkpt>
+<trkpt lat="55.9374292" lon="-4.3164211">
+<ele>104.30000305175781></ele>
+<accuracy>4.28</accuracy>
+<speed>1.2429956</speed>
+<bearing>103.71846</bearing>
+<bearingAccuracyDegrees>10.127775</bearingAccuracyDegrees>
+<time>1746105086628</time>
+</trkpt>
+<trkpt lat="55.9374286" lon="-4.3164034">
+<ele>104.69999694824219></ele>
+<accuracy>3.762</accuracy>
+<speed>1.2393698</speed>
+<bearing>98.13503</bearing>
+<bearingAccuracyDegrees>9.512606</bearingAccuracyDegrees>
+<time>1746105087592</time>
+</trkpt>
+<trkpt lat="55.9374263" lon="-4.3163817">
+<ele>104.69999694824219></ele>
+<accuracy>3.473</accuracy>
+<speed>1.2747419</speed>
+<bearing>99.64612</bearing>
+<bearingAccuracyDegrees>9.90481</bearingAccuracyDegrees>
+<time>1746105088594</time>
+</trkpt>
+<trkpt lat="55.937423" lon="-4.3163525">
+<ele>104.69999694824219></ele>
+<accuracy>3.295</accuracy>
+<speed>1.3843492</speed>
+<bearing>102.95116</bearing>
+<bearingAccuracyDegrees>9.736732</bearingAccuracyDegrees>
+<time>1746105089596</time>
+</trkpt>
+<trkpt lat="55.9374155" lon="-4.3163236">
+<ele>104.69999694824219></ele>
+<accuracy>3.254</accuracy>
+<speed>1.4044695</speed>
+<bearing>102.46144</bearing>
+<bearingAccuracyDegrees>10.18236</bearingAccuracyDegrees>
+<time>1746105090599</time>
+</trkpt>
+<trkpt lat="55.9374056" lon="-4.3162945">
+<ele>104.69999694824219></ele>
+<accuracy>3.232</accuracy>
+<speed>1.4273883</speed>
+<bearing>105.34758</bearing>
+<bearingAccuracyDegrees>10.218153</bearingAccuracyDegrees>
+<time>1746105091601</time>
+</trkpt>
+<trkpt lat="55.9373961" lon="-4.3162647">
+<ele>103.69999694824219></ele>
+<accuracy>3.283</accuracy>
+<speed>1.430484</speed>
+<bearing>107.13859</bearing>
+<bearingAccuracyDegrees>10.151079</bearingAccuracyDegrees>
+<time>1746105092602</time>
+</trkpt>
+<trkpt lat="55.9373913" lon="-4.3162389">
+<ele>103.69999694824219></ele>
+<accuracy>3.412</accuracy>
+<speed>1.4198985</speed>
+<bearing>108.28549</bearing>
+<bearingAccuracyDegrees>12.310346</bearingAccuracyDegrees>
+<time>1746105093606</time>
+</trkpt>
+<trkpt lat="55.9373859" lon="-4.316213">
+<ele>103.69999694824219></ele>
+<accuracy>3.587</accuracy>
+<speed>1.4367622</speed>
+<bearing>112.167336</bearing>
+<bearingAccuracyDegrees>10.1116905</bearingAccuracyDegrees>
+<time>1746105094508</time>
+</trkpt>
+<trkpt lat="55.9373803" lon="-4.3161853">
+<ele>103.69999694824219></ele>
+<accuracy>3.739</accuracy>
+<speed>1.4526616</speed>
+<bearing>106.577644</bearing>
+<bearingAccuracyDegrees>11.70014</bearingAccuracyDegrees>
+<time>1746105095429</time>
+</trkpt>
+<trkpt lat="55.9373772" lon="-4.31615">
+<ele>103.69999694824219></ele>
+<accuracy>3.978</accuracy>
+<speed>1.5187345</speed>
+<bearing>99.27655</bearing>
+<bearingAccuracyDegrees>11.907083</bearingAccuracyDegrees>
+<time>1746105096446</time>
+</trkpt>
+<trkpt lat="55.9373766" lon="-4.316113">
+<ele>103.69999694824219></ele>
+<accuracy>4.345</accuracy>
+<speed>1.5222651</speed>
+<bearing>101.66253</bearing>
+<bearingAccuracyDegrees>12.025343</bearingAccuracyDegrees>
+<time>1746105097506</time>
+</trkpt>
+<trkpt lat="55.9373748" lon="-4.3160787">
+<ele>103.69999694824219></ele>
+<accuracy>4.566</accuracy>
+<speed>1.5063611</speed>
+<bearing>107.65119</bearing>
+<bearingAccuracyDegrees>11.593258</bearingAccuracyDegrees>
+<time>1746105098544</time>
+</trkpt>
+<trkpt lat="55.9373719" lon="-4.316043">
+<ele>103.69999694824219></ele>
+<accuracy>4.729</accuracy>
+<speed>1.4918315</speed>
+<bearing>104.25482</bearing>
+<bearingAccuracyDegrees>11.752987</bearingAccuracyDegrees>
+<time>1746105099628</time>
+</trkpt>
+<trkpt lat="55.9373694" lon="-4.3160037">
+<ele>103.69999694824219></ele>
+<accuracy>4.746</accuracy>
+<speed>1.5246464</speed>
+<bearing>103.09109</bearing>
+<bearingAccuracyDegrees>9.61089</bearingAccuracyDegrees>
+<time>1746105100686</time>
+</trkpt>
+<trkpt lat="55.9373664" lon="-4.3159704">
+<ele>103.69999694824219></ele>
+<accuracy>4.702</accuracy>
+<speed>1.5110134</speed>
+<bearing>100.283485</bearing>
+<bearingAccuracyDegrees>10.027823</bearingAccuracyDegrees>
+<time>1746105101747</time>
+</trkpt>
+<trkpt lat="55.9373617" lon="-4.3159372">
+<ele>103.69999694824219></ele>
+<accuracy>4.638</accuracy>
+<speed>1.4990143</speed>
+<bearing>110.27896</bearing>
+<bearingAccuracyDegrees>10.095981</bearingAccuracyDegrees>
+<time>1746105102863</time>
+</trkpt>
+<trkpt lat="55.9373557" lon="-4.3159078">
+<ele>103.69999694824219></ele>
+<accuracy>4.543</accuracy>
+<speed>1.4756606</speed>
+<bearing>111.41837</bearing>
+<bearingAccuracyDegrees>10.222405</bearingAccuracyDegrees>
+<time>1746105103924</time>
+</trkpt>
+<trkpt lat="55.93735" lon="-4.3158763">
+<ele>103.69999694824219></ele>
+<accuracy>4.349</accuracy>
+<speed>1.4681572</speed>
+<bearing>106.97537</bearing>
+<bearingAccuracyDegrees>9.867102</bearingAccuracyDegrees>
+<time>1746105105005</time>
+</trkpt>
+<trkpt lat="55.9373452" lon="-4.3158472">
+<ele>103.69999694824219></ele>
+<accuracy>4.123</accuracy>
+<speed>1.4254147</speed>
+<bearing>105.38598</bearing>
+<bearingAccuracyDegrees>9.402914</bearingAccuracyDegrees>
+<time>1746105106086</time>
+</trkpt>
+<trkpt lat="55.9373406" lon="-4.3158239">
+<ele>103.69999694824219></ele>
+<accuracy>3.848</accuracy>
+<speed>1.3822473</speed>
+<bearing>110.50508</bearing>
+<bearingAccuracyDegrees>9.589277</bearingAccuracyDegrees>
+<time>1746105107162</time>
+</trkpt>
+<trkpt lat="55.9373357" lon="-4.3158014">
+<ele>103.69999694824219></ele>
+<accuracy>3.566</accuracy>
+<speed>1.3790317</speed>
+<bearing>107.94191</bearing>
+<bearingAccuracyDegrees>9.6427555</bearingAccuracyDegrees>
+<time>1746105108248</time>
+</trkpt>
+<trkpt lat="55.9373298" lon="-4.3157741">
+<ele>104.30000305175781></ele>
+<accuracy>3.252</accuracy>
+<speed>1.4019208</speed>
+<bearing>109.20335</bearing>
+<bearingAccuracyDegrees>10.08709</bearingAccuracyDegrees>
+<time>1746105109324</time>
+</trkpt>
+<trkpt lat="55.9373231" lon="-4.3157451">
+<ele>104.30000305175781></ele>
+<accuracy>3.154</accuracy>
+<speed>1.4382985</speed>
+<bearing>111.28003</bearing>
+<bearingAccuracyDegrees>10.173842</bearingAccuracyDegrees>
+<time>1746105110388</time>
+</trkpt>
+<trkpt lat="55.9373172" lon="-4.3157148">
+<ele>104.30000305175781></ele>
+<accuracy>3.27</accuracy>
+<speed>1.4315861</speed>
+<bearing>112.08635</bearing>
+<bearingAccuracyDegrees>9.94492</bearingAccuracyDegrees>
+<time>1746105111440</time>
+</trkpt>
+<trkpt lat="55.9373119" lon="-4.3156827">
+<ele>104.30000305175781></ele>
+<accuracy>3.457</accuracy>
+<speed>1.4486363</speed>
+<bearing>109.98759</bearing>
+<bearingAccuracyDegrees>9.7231455</bearingAccuracyDegrees>
+<time>1746105112544</time>
+</trkpt>
+<trkpt lat="55.9373068" lon="-4.3156524">
+<ele>104.30000305175781></ele>
+<accuracy>3.731</accuracy>
+<speed>1.4487907</speed>
+<bearing>108.69359</bearing>
+<bearingAccuracyDegrees>9.733674</bearingAccuracyDegrees>
+<time>1746105113630</time>
+</trkpt>
+<trkpt lat="55.9373039" lon="-4.3156314">
+<ele>104.30000305175781></ele>
+<accuracy>3.922</accuracy>
+<speed>1.4345026</speed>
+<bearing>108.103096</bearing>
+<bearingAccuracyDegrees>10.065385</bearingAccuracyDegrees>
+<time>1746105114555</time>
+</trkpt>
+<trkpt lat="55.9373014" lon="-4.3156084">
+<ele>104.30000305175781></ele>
+<accuracy>4.045</accuracy>
+<speed>1.3928224</speed>
+<bearing>108.53949</bearing>
+<bearingAccuracyDegrees>10.171916</bearingAccuracyDegrees>
+<time>1746105115557</time>
+</trkpt>
+<trkpt lat="55.9372976" lon="-4.3155862">
+<ele>104.30000305175781></ele>
+<accuracy>4.122</accuracy>
+<speed>1.3739405</speed>
+<bearing>111.06925</bearing>
+<bearingAccuracyDegrees>10.425789</bearingAccuracyDegrees>
+<time>1746105116560</time>
+</trkpt>
+<trkpt lat="55.9372935" lon="-4.3155655">
+<ele>103.69999694824219></ele>
+<accuracy>4.2</accuracy>
+<speed>1.3458204</speed>
+<bearing>109.471985</bearing>
+<bearingAccuracyDegrees>9.658175</bearingAccuracyDegrees>
+<time>1746105117561</time>
+</trkpt>
+<trkpt lat="55.9372897" lon="-4.3155451">
+<ele>103.69999694824219></ele>
+<accuracy>4.25</accuracy>
+<speed>1.3480241</speed>
+<bearing>109.96979</bearing>
+<bearingAccuracyDegrees>9.91466</bearingAccuracyDegrees>
+<time>1746105118549</time>
+</trkpt>
+<trkpt lat="55.9372853" lon="-4.3155247">
+<ele>103.69999694824219></ele>
+<accuracy>4.301</accuracy>
+<speed>1.3669415</speed>
+<bearing>111.6514</bearing>
+<bearingAccuracyDegrees>9.455643</bearingAccuracyDegrees>
+<time>1746105119566</time>
+</trkpt>
+<trkpt lat="55.9372805" lon="-4.315504">
+<ele>104.69999694824219></ele>
+<accuracy>4.383</accuracy>
+<speed>1.3644328</speed>
+<bearing>107.64691</bearing>
+<bearingAccuracyDegrees>9.661349</bearingAccuracyDegrees>
+<time>1746105120569</time>
+</trkpt>
+<trkpt lat="55.9372736" lon="-4.3154814">
+<ele>103.69999694824219></ele>
+<accuracy>4.223</accuracy>
+<speed>1.2886544</speed>
+<bearing>105.99392</bearing>
+<bearingAccuracyDegrees>9.246382</bearingAccuracyDegrees>
+<time>1746105121571</time>
+</trkpt>
+<trkpt lat="55.9372664" lon="-4.3154452">
+<ele>105.69999694824219></ele>
+<accuracy>3.898</accuracy>
+<speed>1.3947338</speed>
+<bearing>110.450775</bearing>
+<bearingAccuracyDegrees>9.435979</bearingAccuracyDegrees>
+<time>1746105122574</time>
+</trkpt>
+<trkpt lat="55.9372599" lon="-4.3154175">
+<ele>105.69999694824219></ele>
+<accuracy>3.68</accuracy>
+<speed>1.4580619</speed>
+<bearing>112.51227</bearing>
+<bearingAccuracyDegrees>9.547244</bearingAccuracyDegrees>
+<time>1746105123576</time>
+</trkpt>
+<trkpt lat="55.937254" lon="-4.3153915">
+<ele>105.69999694824219></ele>
+<accuracy>3.497</accuracy>
+<speed>1.4650494</speed>
+<bearing>112.218445</bearing>
+<bearingAccuracyDegrees>9.537878</bearingAccuracyDegrees>
+<time>1746105124500</time>
+</trkpt>
+<trkpt lat="55.9372488" lon="-4.3153631">
+<ele>105.69999694824219></ele>
+<accuracy>3.36</accuracy>
+<speed>1.4491131</speed>
+<bearing>111.624954</bearing>
+<bearingAccuracyDegrees>9.442516</bearingAccuracyDegrees>
+<time>1746105125584</time>
+</trkpt>
+<trkpt lat="55.9372445" lon="-4.3153393">
+<ele>105.69999694824219></ele>
+<accuracy>3.46</accuracy>
+<speed>1.4362308</speed>
+<bearing>110.754135</bearing>
+<bearingAccuracyDegrees>9.421645</bearingAccuracyDegrees>
+<time>1746105126583</time>
+</trkpt>
+<trkpt lat="55.9372416" lon="-4.3153175">
+<ele>104.30000305175781></ele>
+<accuracy>3.736</accuracy>
+<speed>1.3989028</speed>
+<bearing>110.14868</bearing>
+<bearingAccuracyDegrees>9.380852</bearingAccuracyDegrees>
+<time>1746105127586</time>
+</trkpt>
+<trkpt lat="55.937238" lon="-4.3152952">
+<ele>105.98851715041705></ele>
+<accuracy>3.918</accuracy>
+<speed>1.3738383</speed>
+<bearing>109.85524</bearing>
+<bearingAccuracyDegrees>9.402763</bearingAccuracyDegrees>
+<time>1746105128588</time>
+</trkpt>
+<trkpt lat="55.9372347" lon="-4.3152741">
+<ele>106.02283203125394></ele>
+<accuracy>4.089</accuracy>
+<speed>1.3221334</speed>
+<bearing>109.84286</bearing>
+<bearingAccuracyDegrees>9.405725</bearingAccuracyDegrees>
+<time>1746105129589</time>
+</trkpt>
+<trkpt lat="55.9372302" lon="-4.3152518">
+<ele>106.10809990373433></ele>
+<accuracy>4.212</accuracy>
+<speed>1.2877951</speed>
+<bearing>113.198654</bearing>
+<bearingAccuracyDegrees>9.925865</bearingAccuracyDegrees>
+<time>1746105130593</time>
+</trkpt>
+<trkpt lat="55.9372247" lon="-4.3152287">
+<ele>106.18687289414176></ele>
+<accuracy>4.292</accuracy>
+<speed>1.2977227</speed>
+<bearing>110.69278</bearing>
+<bearingAccuracyDegrees>9.929256</bearingAccuracyDegrees>
+<time>1746105131594</time>
+</trkpt>
+<trkpt lat="55.9372199" lon="-4.3152063">
+<ele>106.45932249787464></ele>
+<accuracy>4.391</accuracy>
+<speed>1.3048024</speed>
+<bearing>111.623024</bearing>
+<bearingAccuracyDegrees>10.176805</bearingAccuracyDegrees>
+<time>1746105132597</time>
+</trkpt>
+<trkpt lat="55.9372147" lon="-4.3151834">
+<ele>106.59398900766467></ele>
+<accuracy>4.492</accuracy>
+<speed>1.3310674</speed>
+<bearing>109.4465</bearing>
+<bearingAccuracyDegrees>11.895329</bearingAccuracyDegrees>
+<time>1746105133599</time>
+</trkpt>
+<trkpt lat="55.9372108" lon="-4.3151621">
+<ele>106.59398900766467></ele>
+<accuracy>4.569</accuracy>
+<speed>1.3578997</speed>
+<bearing>106.36456</bearing>
+<bearingAccuracyDegrees>11.777159</bearingAccuracyDegrees>
+<time>1746105134524</time>
+</trkpt>
+<trkpt lat="55.9372076" lon="-4.3151404">
+<ele>106.79469281590504></ele>
+<accuracy>4.684</accuracy>
+<speed>1.3651276</speed>
+<bearing>102.65825</bearing>
+<bearingAccuracyDegrees>10.106759</bearingAccuracyDegrees>
+<time>1746105135547</time>
+</trkpt>
+<trkpt lat="55.9372047" lon="-4.315119">
+<ele>106.84080767135872></ele>
+<accuracy>4.83</accuracy>
+<speed>1.3554622</speed>
+<bearing>104.41063</bearing>
+<bearingAccuracyDegrees>11.731126</bearingAccuracyDegrees>
+<time>1746105136619</time>
+</trkpt>
+<trkpt lat="55.937201" lon="-4.3151017">
+<ele>107.30000305175781></ele>
+<accuracy>4.96</accuracy>
+<speed>1.3468523</speed>
+<bearing>107.60757</bearing>
+<bearingAccuracyDegrees>10.115704</bearingAccuracyDegrees>
+<time>1746105137609</time>
+</trkpt>
+<trkpt lat="55.9371955" lon="-4.3150826">
+<ele>107.30000305175781></ele>
+<accuracy>5.067</accuracy>
+<speed>1.3526946</speed>
+<bearing>108.90997</bearing>
+<bearingAccuracyDegrees>12.320892</bearingAccuracyDegrees>
+<time>1746105138611</time>
+</trkpt>
+<trkpt lat="55.9371907" lon="-4.3150642">
+<ele>107.30000305175781></ele>
+<accuracy>5.163</accuracy>
+<speed>1.3473115</speed>
+<bearing>104.9429</bearing>
+<bearingAccuracyDegrees>12.26996</bearingAccuracyDegrees>
+<time>1746105139514</time>
+</trkpt>
+<trkpt lat="55.9371879" lon="-4.3150442">
+<ele>107.30000305175781></ele>
+<accuracy>5.237</accuracy>
+<speed>1.3364302</speed>
+<bearing>105.66598</bearing>
+<bearingAccuracyDegrees>11.796611</bearingAccuracyDegrees>
+<time>1746105140448</time>
+</trkpt>
+<trkpt lat="55.9371829" lon="-4.3150205">
+<ele>107.30000305175781></ele>
+<accuracy>5.305</accuracy>
+<speed>1.3466252</speed>
+<bearing>106.24517</bearing>
+<bearingAccuracyDegrees>11.863827</bearingAccuracyDegrees>
+<time>1746105141522</time>
+</trkpt>
+<trkpt lat="55.9371785" lon="-4.3150024">
+<ele>107.30000305175781></ele>
+<accuracy>5.288</accuracy>
+<speed>1.2564734</speed>
+<bearing>111.93459</bearing>
+<bearingAccuracyDegrees>12.035384</bearingAccuracyDegrees>
+<time>1746105142624</time>
+</trkpt>
+<trkpt lat="55.937172" lon="-4.3149844">
+<ele>107.30000305175781></ele>
+<accuracy>5.252</accuracy>
+<speed>1.0458722</speed>
+<bearing>113.49653</bearing>
+<bearingAccuracyDegrees>12.445894</bearingAccuracyDegrees>
+<time>1746105143726</time>
+</trkpt>
+<trkpt lat="55.9371677" lon="-4.3149691">
+<ele>107.30000305175781></ele>
+<accuracy>5.185</accuracy>
+<speed>0.9760464</speed>
+<bearing>112.63614</bearing>
+<bearingAccuracyDegrees>12.346049</bearingAccuracyDegrees>
+<time>1746105144800</time>
+</trkpt>
+<trkpt lat="55.9371602" lon="-4.3149485">
+<ele>107.77718904652443></ele>
+<accuracy>5.12</accuracy>
+<speed>0.9816971</speed>
+<bearing>114.08168</bearing>
+<bearingAccuracyDegrees>13.147416</bearingAccuracyDegrees>
+<time>1746105145900</time>
+</trkpt>
+<trkpt lat="55.9371551" lon="-4.3149303">
+<ele>107.85987535238067></ele>
+<accuracy>5.129</accuracy>
+<speed>1.0169346</speed>
+<bearing>109.29054</bearing>
+<bearingAccuracyDegrees>12.46717</bearingAccuracyDegrees>
+<time>1746105146984</time>
+</trkpt>
+<trkpt lat="55.9371511" lon="-4.3149104">
+<ele>108.24114778084777></ele>
+<accuracy>5.17</accuracy>
+<speed>1.0396663</speed>
+<bearing>107.64756</bearing>
+<bearingAccuracyDegrees>12.202427</bearingAccuracyDegrees>
+<time>1746105148069</time>
+</trkpt>
+<trkpt lat="55.9371478" lon="-4.3148923">
+<ele>108.33267669530275></ele>
+<accuracy>5.23</accuracy>
+<speed>1.0484539</speed>
+<bearing>110.2906</bearing>
+<bearingAccuracyDegrees>12.395596</bearingAccuracyDegrees>
+<time>1746105149139</time>
+</trkpt>
+<trkpt lat="55.9371444" lon="-4.3148718">
+<ele>108.34099755401223></ele>
+<accuracy>5.323</accuracy>
+<speed>1.0922235</speed>
+<bearing>110.64133</bearing>
+<bearingAccuracyDegrees>12.445857</bearingAccuracyDegrees>
+<time>1746105150200</time>
+</trkpt>
+<trkpt lat="55.9371399" lon="-4.314842">
+<ele>108.42940717500261></ele>
+<accuracy>5.456</accuracy>
+<speed>1.2939749</speed>
+<bearing>108.888245</bearing>
+<bearingAccuracyDegrees>12.364948</bearingAccuracyDegrees>
+<time>1746105151302</time>
+</trkpt>
+<trkpt lat="55.937138" lon="-4.3148146">
+<ele>108.49909539915978></ele>
+<accuracy>5.544</accuracy>
+<speed>1.347914</speed>
+<bearing>107.62642</bearing>
+<bearingAccuracyDegrees>11.643393</bearingAccuracyDegrees>
+<time>1746105152366</time>
+</trkpt>
+<trkpt lat="55.9371374" lon="-4.3147869">
+<ele>108.5438209748622></ele>
+<accuracy>5.611</accuracy>
+<speed>1.3925338</speed>
+<bearing>107.893715</bearing>
+<bearingAccuracyDegrees>11.878785</bearingAccuracyDegrees>
+<time>1746105153422</time>
+</trkpt>
+<trkpt lat="55.9371367" lon="-4.3147581">
+<ele>108.43392952879998></ele>
+<accuracy>5.668</accuracy>
+<speed>1.4166609</speed>
+<bearing>103.6954</bearing>
+<bearingAccuracyDegrees>12.24781</bearingAccuracyDegrees>
+<time>1746105154483</time>
+</trkpt>
+<trkpt lat="55.9371359" lon="-4.3147301">
+<ele>108.42053338260851></ele>
+<accuracy>5.793</accuracy>
+<speed>1.4081365</speed>
+<bearing>101.73115</bearing>
+<bearingAccuracyDegrees>12.505562</bearingAccuracyDegrees>
+<time>1746105155562</time>
+</trkpt>
+<trkpt lat="55.9371337" lon="-4.3147044">
+<ele>108.45537803938194></ele>
+<accuracy>5.897</accuracy>
+<speed>1.4054275</speed>
+<bearing>101.80516</bearing>
+<bearingAccuracyDegrees>12.95242</bearingAccuracyDegrees>
+<time>1746105156638</time>
+</trkpt>
+<trkpt lat="55.9371318" lon="-4.3146854">
+<ele>108.52558785125915></ele>
+<accuracy>6.0</accuracy>
+<speed>1.3984419</speed>
+<bearing>101.1419</bearing>
+<bearingAccuracyDegrees>12.860997</bearingAccuracyDegrees>
+<time>1746105157556</time>
+</trkpt>
+<trkpt lat="55.9371252" lon="-4.3146636">
+<ele>108.52246740300447></ele>
+<accuracy>6.098</accuracy>
+<speed>1.3537548</speed>
+<bearing>104.6103</bearing>
+<bearingAccuracyDegrees>11.877955</bearingAccuracyDegrees>
+<time>1746105158558</time>
+</trkpt>
+<trkpt lat="55.9371168" lon="-4.314643">
+<ele>108.49881384350347></ele>
+<accuracy>6.111</accuracy>
+<speed>1.2955037</speed>
+<bearing>105.54908</bearing>
+<bearingAccuracyDegrees>12.074415</bearingAccuracyDegrees>
+<time>1746105159561</time>
+</trkpt>
+<trkpt lat="55.9371111" lon="-4.3146215">
+<ele>108.60539848724576></ele>
+<accuracy>6.098</accuracy>
+<speed>1.3377281</speed>
+<bearing>104.98426</bearing>
+<bearingAccuracyDegrees>11.853317</bearingAccuracyDegrees>
+<time>1746105160563</time>
+</trkpt>
+<trkpt lat="55.9371057" lon="-4.314598">
+<ele>108.62204085881638></ele>
+<accuracy>6.071</accuracy>
+<speed>1.3602957</speed>
+<bearing>104.61288</bearing>
+<bearingAccuracyDegrees>12.155839</bearingAccuracyDegrees>
+<time>1746105161565</time>
+</trkpt>
+<trkpt lat="55.9371015" lon="-4.3145741">
+<ele>108.43120440933839></ele>
+<accuracy>6.022</accuracy>
+<speed>1.3670393</speed>
+<bearing>107.64044</bearing>
+<bearingAccuracyDegrees>12.2480545</bearingAccuracyDegrees>
+<time>1746105162568</time>
+</trkpt>
+<trkpt lat="55.9370959" lon="-4.3145497">
+<ele>108.54923072096179></ele>
+<accuracy>6.003</accuracy>
+<speed>1.390218</speed>
+<bearing>106.904236</bearing>
+<bearingAccuracyDegrees>12.375988</bearingAccuracyDegrees>
+<time>1746105163483</time>
+</trkpt>
+<trkpt lat="55.9370909" lon="-4.3145251">
+<ele>107.30000305175781></ele>
+<accuracy>6.019</accuracy>
+<speed>1.360684</speed>
+<bearing>106.63037</bearing>
+<bearingAccuracyDegrees>12.213154</bearingAccuracyDegrees>
+<time>1746105164548</time>
+</trkpt>
+<trkpt lat="55.9370882" lon="-4.3145021">
+<ele>107.30000305175781></ele>
+<accuracy>6.05</accuracy>
+<speed>1.3700842</speed>
+<bearing>104.91055</bearing>
+<bearingAccuracyDegrees>12.348771</bearingAccuracyDegrees>
+<time>1746105165608</time>
+</trkpt>
+<trkpt lat="55.9370858" lon="-4.3144817">
+<ele>107.30000305175781></ele>
+<accuracy>6.09</accuracy>
+<speed>1.4135449</speed>
+<bearing>104.70729</bearing>
+<bearingAccuracyDegrees>12.763632</bearingAccuracyDegrees>
+<time>1746105166577</time>
+</trkpt>
+<trkpt lat="55.9370813" lon="-4.3144597">
+<ele>107.30000305175781></ele>
+<accuracy>6.131</accuracy>
+<speed>1.4034101</speed>
+<bearing>108.756</bearing>
+<bearingAccuracyDegrees>13.168096</bearingAccuracyDegrees>
+<time>1746105167579</time>
+</trkpt>
+<trkpt lat="55.9370788" lon="-4.3144432">
+<ele>107.30000305175781></ele>
+<accuracy>6.16</accuracy>
+<speed>1.3376834</speed>
+<bearing>108.983795</bearing>
+<bearingAccuracyDegrees>13.09385</bearingAccuracyDegrees>
+<time>1746105168481</time>
+</trkpt>
+<trkpt lat="55.9370731" lon="-4.314409">
+<ele>107.30000305175781></ele>
+<accuracy>6.161</accuracy>
+<speed>1.3119829</speed>
+<bearing>106.70396</bearing>
+<bearingAccuracyDegrees>12.351751</bearingAccuracyDegrees>
+<time>1746105169583</time>
+</trkpt>
+<trkpt lat="55.9370699" lon="-4.314388">
+<ele>107.30000305175781></ele>
+<accuracy>6.156</accuracy>
+<speed>1.3418703</speed>
+<bearing>102.46991</bearing>
+<bearingAccuracyDegrees>12.681088</bearingAccuracyDegrees>
+<time>1746105170585</time>
+</trkpt>
+<trkpt lat="55.9370662" lon="-4.3143646">
+<ele>107.30000305175781></ele>
+<accuracy>6.175</accuracy>
+<speed>1.3907019</speed>
+<bearing>102.58385</bearing>
+<bearingAccuracyDegrees>13.193757</bearingAccuracyDegrees>
+<time>1746105171589</time>
+</trkpt>
+<trkpt lat="55.9370618" lon="-4.3143394">
+<ele>107.53925052447845></ele>
+<accuracy>6.232</accuracy>
+<speed>1.4325453</speed>
+<bearing>101.542885</bearing>
+<bearingAccuracyDegrees>13.453848</bearingAccuracyDegrees>
+<time>1746105172591</time>
+</trkpt>
+<trkpt lat="55.937056" lon="-4.3143155">
+<ele>107.53925052447845></ele>
+<accuracy>6.256</accuracy>
+<speed>1.4114996</speed>
+<bearing>107.69256</bearing>
+<bearingAccuracyDegrees>12.667591</bearingAccuracyDegrees>
+<time>1746105173512</time>
+</trkpt>
+<trkpt lat="55.9370503" lon="-4.3142945">
+<ele>107.49221340477075></ele>
+<accuracy>6.398</accuracy>
+<speed>1.3553205</speed>
+<bearing>109.21948</bearing>
+<bearingAccuracyDegrees>12.449808</bearingAccuracyDegrees>
+<time>1746105174530</time>
+</trkpt>
+<trkpt lat="55.937045" lon="-4.3142733">
+<ele>107.45084694972184></ele>
+<accuracy>6.533</accuracy>
+<speed>1.3240215</speed>
+<bearing>107.3809</bearing>
+<bearingAccuracyDegrees>12.830288</bearingAccuracyDegrees>
+<time>1746105175582</time>
+</trkpt>
+<trkpt lat="55.9370437" lon="-4.3142433">
+<ele>107.64675359214007></ele>
+<accuracy>6.577</accuracy>
+<speed>1.3379223</speed>
+<bearing>104.67119</bearing>
+<bearingAccuracyDegrees>11.815039</bearingAccuracyDegrees>
+<time>1746105176623</time>
+</trkpt>
+<trkpt lat="55.9370413" lon="-4.3142162">
+<ele>107.54743188500564></ele>
+<accuracy>6.504</accuracy>
+<speed>1.3919563</speed>
+<bearing>104.8151</bearing>
+<bearingAccuracyDegrees>10.115701</bearingAccuracyDegrees>
+<time>1746105177603</time>
+</trkpt>
+<trkpt lat="55.9370361" lon="-4.3141861">
+<ele>107.33093668148473></ele>
+<accuracy>6.371</accuracy>
+<speed>1.4586426</speed>
+<bearing>103.60188</bearing>
+<bearingAccuracyDegrees>10.4668665</bearingAccuracyDegrees>
+<time>1746105178605</time>
+</trkpt>
+<trkpt lat="55.9370318" lon="-4.3141567">
+<ele>107.2773767454072></ele>
+<accuracy>6.181</accuracy>
+<speed>1.4208814</speed>
+<bearing>106.204056</bearing>
+<bearingAccuracyDegrees>10.041182</bearingAccuracyDegrees>
+<time>1746105179607</time>
+</trkpt>
+<trkpt lat="55.9370266" lon="-4.3141262">
+<ele>107.15725810168588></ele>
+<accuracy>5.972</accuracy>
+<speed>1.4382935</speed>
+<bearing>107.78132</bearing>
+<bearingAccuracyDegrees>10.077773</bearingAccuracyDegrees>
+<time>1746105180609</time>
+</trkpt>
+<trkpt lat="55.9370222" lon="-4.3140967">
+<ele>107.03246128783726></ele>
+<accuracy>5.729</accuracy>
+<speed>1.4508057</speed>
+<bearing>105.5506</bearing>
+<bearingAccuracyDegrees>11.3155365</bearingAccuracyDegrees>
+<time>1746105181511</time>
+</trkpt>
+<trkpt lat="55.9370202" lon="-4.3140663">
+<ele>106.90669089932543></ele>
+<accuracy>5.583</accuracy>
+<speed>1.4504713</speed>
+<bearing>105.21874</bearing>
+<bearingAccuracyDegrees>11.552215</bearingAccuracyDegrees>
+<time>1746105182507</time>
+</trkpt>
+<trkpt lat="55.9370147" lon="-4.3140312">
+<ele>106.88386840685112></ele>
+<accuracy>5.458</accuracy>
+<speed>1.485615</speed>
+<bearing>104.56116</bearing>
+<bearingAccuracyDegrees>10.244994</bearingAccuracyDegrees>
+<time>1746105183617</time>
+</trkpt>
+<trkpt lat="55.9370112" lon="-4.3139974">
+<ele>106.82355145667557></ele>
+<accuracy>5.407</accuracy>
+<speed>1.4915264</speed>
+<bearing>101.99159</bearing>
+<bearingAccuracyDegrees>10.230892</bearingAccuracyDegrees>
+<time>1746105184519</time>
+</trkpt>
+<trkpt lat="55.9370083" lon="-4.3139672">
+<ele>106.82355145667557></ele>
+<accuracy>5.392</accuracy>
+<speed>1.4818661</speed>
+<bearing>102.87708</bearing>
+<bearingAccuracyDegrees>9.902035</bearingAccuracyDegrees>
+<time>1746105185464</time>
+</trkpt>
+<trkpt lat="55.9370055" lon="-4.3139351">
+<ele>106.68160030360316></ele>
+<accuracy>5.385</accuracy>
+<speed>1.4867226</speed>
+<bearing>101.22442</bearing>
+<bearingAccuracyDegrees>9.897711</bearingAccuracyDegrees>
+<time>1746105186546</time>
+</trkpt>
+<trkpt lat="55.9370034" lon="-4.3139081">
+<ele>106.59684670293817></ele>
+<accuracy>5.441</accuracy>
+<speed>1.4821812</speed>
+<bearing>102.869156</bearing>
+<bearingAccuracyDegrees>10.43426</bearingAccuracyDegrees>
+<time>1746105187544</time>
+</trkpt>
+<trkpt lat="55.937001" lon="-4.3138845">
+<ele>104.9000015258789></ele>
+<accuracy>5.487</accuracy>
+<speed>1.4758497</speed>
+<bearing>104.42106</bearing>
+<bearingAccuracyDegrees>11.5091305</bearingAccuracyDegrees>
+<time>1746105188528</time>
+</trkpt>
+<trkpt lat="55.9369975" lon="-4.3138591">
+<ele>104.9000015258789></ele>
+<accuracy>5.483</accuracy>
+<speed>1.4635794</speed>
+<bearing>104.28396</bearing>
+<bearingAccuracyDegrees>11.487373</bearingAccuracyDegrees>
+<time>1746105189626</time>
+</trkpt>
+<trkpt lat="55.936996" lon="-4.3138416">
+<ele>104.9000015258789></ele>
+<accuracy>5.507</accuracy>
+<speed>1.437352</speed>
+<bearing>104.878525</bearing>
+<bearingAccuracyDegrees>9.949336</bearingAccuracyDegrees>
+<time>1746105190533</time>
+</trkpt>
+<trkpt lat="55.9369947" lon="-4.3138157">
+<ele>104.5></ele>
+<accuracy>5.552</accuracy>
+<speed>1.4269179</speed>
+<bearing>104.14041</bearing>
+<bearingAccuracyDegrees>11.9668</bearingAccuracyDegrees>
+<time>1746105191535</time>
+</trkpt>
+<trkpt lat="55.9369915" lon="-4.3137932">
+<ele>104.5></ele>
+<accuracy>5.604</accuracy>
+<speed>1.4336994</speed>
+<bearing>103.62911</bearing>
+<bearingAccuracyDegrees>11.6926985</bearingAccuracyDegrees>
+<time>1746105192537</time>
+</trkpt>
+<trkpt lat="55.9369887" lon="-4.3137698">
+<ele>104.5></ele>
+<accuracy>5.67</accuracy>
+<speed>1.4517617</speed>
+<bearing>101.47661</bearing>
+<bearingAccuracyDegrees>12.435484</bearingAccuracyDegrees>
+<time>1746105193540</time>
+</trkpt>
+<trkpt lat="55.9369858" lon="-4.3137475">
+<ele>104.5></ele>
+<accuracy>5.765</accuracy>
+<speed>1.4596556</speed>
+<bearing>101.82417</bearing>
+<bearingAccuracyDegrees>11.910357</bearingAccuracyDegrees>
+<time>1746105194542</time>
+</trkpt>
+<trkpt lat="55.936967" lon="-4.3136489">
+<ele>104.4000015258789></ele>
+<accuracy>5.978</accuracy>
+<speed>1.490509</speed>
+<bearing>105.5276</bearing>
+<bearingAccuracyDegrees>12.254671</bearingAccuracyDegrees>
+<time>1746105198626</time>
+</trkpt>
+<trkpt lat="55.9369633" lon="-4.3136267">
+<ele>104.4000015258789></ele>
+<accuracy>5.997</accuracy>
+<speed>1.4799751</speed>
+<bearing>106.42176</bearing>
+<bearingAccuracyDegrees>12.061134</bearingAccuracyDegrees>
+<time>1746105199554</time>
+</trkpt>
+<trkpt lat="55.9369601" lon="-4.3136059">
+<ele>104.4000015258789></ele>
+<accuracy>5.98</accuracy>
+<speed>1.4785783</speed>
+<bearing>103.00055</bearing>
+<bearingAccuracyDegrees>12.054218</bearingAccuracyDegrees>
+<time>1746105200456</time>
+</trkpt>
+<trkpt lat="55.9369671" lon="-4.3135718">
+<ele>104.4000015258789></ele>
+<accuracy>6.313</accuracy>
+<speed>1.4713956</speed>
+<bearing>102.64659</bearing>
+<bearingAccuracyDegrees>12.381665</bearingAccuracyDegrees>
+<time>1746105201559</time>
+</trkpt>
+<trkpt lat="55.936965" lon="-4.3135456">
+<ele>104.4000015258789></ele>
+<accuracy>6.462</accuracy>
+<speed>1.4851296</speed>
+<bearing>102.13201</bearing>
+<bearingAccuracyDegrees>12.502268</bearingAccuracyDegrees>
+<time>1746105202560</time>
+</trkpt>
+<trkpt lat="55.9369626" lon="-4.3135174">
+<ele>104.4000015258789></ele>
+<accuracy>6.554</accuracy>
+<speed>1.5171815</speed>
+<bearing>99.50509</bearing>
+<bearingAccuracyDegrees>11.704394</bearingAccuracyDegrees>
+<time>1746105203564</time>
+</trkpt>
+<trkpt lat="55.9369615" lon="-4.3134883">
+<ele>104.4000015258789></ele>
+<accuracy>6.646</accuracy>
+<speed>1.5465189</speed>
+<bearing>100.82028</bearing>
+<bearingAccuracyDegrees>11.84596</bearingAccuracyDegrees>
+<time>1746105204565</time>
+</trkpt>
+<trkpt lat="55.9369605" lon="-4.3134586">
+<ele>104.4000015258789></ele>
+<accuracy>6.679</accuracy>
+<speed>1.5594699</speed>
+<bearing>100.08384</bearing>
+<bearingAccuracyDegrees>10.206271</bearingAccuracyDegrees>
+<time>1746105205567</time>
+</trkpt>
+<trkpt lat="55.9369588" lon="-4.3134295">
+<ele>104.4000015258789></ele>
+<accuracy>6.548</accuracy>
+<speed>1.5639436</speed>
+<bearing>101.758675</bearing>
+<bearingAccuracyDegrees>10.155212</bearingAccuracyDegrees>
+<time>1746105206571</time>
+</trkpt>
+<trkpt lat="55.9369557" lon="-4.3134008">
+<ele>104.4000015258789></ele>
+<accuracy>6.352</accuracy>
+<speed>1.5708876</speed>
+<bearing>102.31261</bearing>
+<bearingAccuracyDegrees>11.810332</bearingAccuracyDegrees>
+<time>1746105207573</time>
+</trkpt>
+<trkpt lat="55.9369535" lon="-4.3133715">
+<ele>102.74211234732934></ele>
+<accuracy>6.189</accuracy>
+<speed>1.5744325</speed>
+<bearing>101.06277</bearing>
+<bearingAccuracyDegrees>10.15475</bearingAccuracyDegrees>
+<time>1746105208575</time>
+</trkpt>
+<trkpt lat="55.93695" lon="-4.3133472">
+<ele>102.53630426115338></ele>
+<accuracy>6.011</accuracy>
+<speed>1.5329435</speed>
+<bearing>107.864685</bearing>
+<bearingAccuracyDegrees>10.604212</bearingAccuracyDegrees>
+<time>1746105209578</time>
+</trkpt>
+<trkpt lat="55.9369459" lon="-4.3133283">
+<ele>102.12936028671035></ele>
+<accuracy>5.843</accuracy>
+<speed>1.4954656</speed>
+<bearing>104.001724</bearing>
+<bearingAccuracyDegrees>11.584085</bearingAccuracyDegrees>
+<time>1746105210580</time>
+</trkpt>
+<trkpt lat="55.9369439" lon="-4.3133102">
+<ele>101.94801133787496></ele>
+<accuracy>5.684</accuracy>
+<speed>1.4928946</speed>
+<bearing>102.25</bearing>
+<bearingAccuracyDegrees>10.290685</bearingAccuracyDegrees>
+<time>1746105211582</time>
+</trkpt>
+<trkpt lat="55.9369487" lon="-4.313289">
+<ele>101.55823362185686></ele>
+<accuracy>5.498</accuracy>
+<speed>1.4811411</speed>
+<bearing>99.57489</bearing>
+<bearingAccuracyDegrees>11.801514</bearingAccuracyDegrees>
+<time>1746105212585</time>
+</trkpt>
+<trkpt lat="55.9369549" lon="-4.313268">
+<ele>101.17681073135795></ele>
+<accuracy>5.422</accuracy>
+<speed>1.4128832</speed>
+<bearing>100.22217</bearing>
+<bearingAccuracyDegrees>12.419196</bearingAccuracyDegrees>
+<time>1746105213587</time>
+</trkpt>
+<trkpt lat="55.9369519" lon="-4.3132527">
+<ele>100.92478990141139></ele>
+<accuracy>5.371</accuracy>
+<speed>1.3820434</speed>
+<bearing>94.87362</bearing>
+<bearingAccuracyDegrees>12.861914</bearingAccuracyDegrees>
+<time>1746105214589</time>
+</trkpt>
+<trkpt lat="55.9369503" lon="-4.3132358">
+<ele>100.75747293480306></ele>
+<accuracy>5.412</accuracy>
+<speed>1.1434001</speed>
+<bearing>70.75348</bearing>
+<bearingAccuracyDegrees>12.565801</bearingAccuracyDegrees>
+<time>1746105215785</time>
+</trkpt>
+<trkpt lat="55.93696" lon="-4.3132306">
+<ele>100.67656130084893></ele>
+<accuracy>5.506</accuracy>
+<speed>1.0560682</speed>
+<bearing>359.62424</bearing>
+<bearingAccuracyDegrees>13.126317</bearingAccuracyDegrees>
+<time>1746105217189</time>
+</trkpt>
+<trkpt lat="55.9369896" lon="-4.3132395">
+<ele>100.37420233070516></ele>
+<accuracy>5.508</accuracy>
+<speed>1.1999099</speed>
+<bearing>345.74222</bearing>
+<bearingAccuracyDegrees>15.08636</bearingAccuracyDegrees>
+<time>1746105218605</time>
+</trkpt>
+<trkpt lat="55.9370046" lon="-4.3132451">
+<ele>100.08821139583434></ele>
+<accuracy>5.545</accuracy>
+<speed>1.3015766</speed>
+<bearing>343.4492</bearing>
+<bearingAccuracyDegrees>15.736267</bearingAccuracyDegrees>
+<time>1746105219644</time>
+</trkpt>
+<trkpt lat="55.9370132" lon="-4.3132506">
+<ele>98.4000015258789></ele>
+<accuracy>5.539</accuracy>
+<speed>1.2074763</speed>
+<bearing>344.25867</bearing>
+<bearingAccuracyDegrees>15.499441</bearingAccuracyDegrees>
+<time>1746105220690</time>
+</trkpt>
+<trkpt lat="55.9370245" lon="-4.3132558">
+<ele>98.4000015258789></ele>
+<accuracy>5.421</accuracy>
+<speed>1.0722065</speed>
+<bearing>345.63455</bearing>
+<bearingAccuracyDegrees>16.123682</bearingAccuracyDegrees>
+<time>1746105222608</time>
+</trkpt>
+<trkpt lat="55.9370342" lon="-4.3132548">
+<ele>98.4000015258789></ele>
+<accuracy>5.266</accuracy>
+<speed>0.96069896</speed>
+<bearing>351.67545</bearing>
+<bearingAccuracyDegrees>15.635228</bearingAccuracyDegrees>
+<time>1746105224613</time>
+</trkpt>
+<trkpt lat="55.9370371" lon="-4.3132392">
+<ele>97.0></ele>
+<accuracy>4.491</accuracy>
+<speed>0.23614965</speed>
+<bearing>5.9051642</bearing>
+<bearingAccuracyDegrees>9.584625</bearingAccuracyDegrees>
+<time>1746105228522</time>
+</trkpt>
+<trkpt lat="55.9370472" lon="-4.313241">
+<ele>97.0></ele>
+<accuracy>3.662</accuracy>
+<speed>0.029784506</speed>
+<bearing>0.0</bearing>
+<bearingAccuracyDegrees>0.0</bearingAccuracyDegrees>
+<time>1746105231502</time>
+</trkpt>
+<trkpt lat="55.937063" lon="-4.3132389">
+<ele>97.0></ele>
+<accuracy>3.577</accuracy>
+<speed>0.07351443</speed>
+<bearing>0.0</bearing>
+<bearingAccuracyDegrees>0.0</bearingAccuracyDegrees>
+<time>1746105233045</time>
+</trkpt>
+<trkpt lat="55.9370751" lon="-4.3132319">
+<ele>97.0></ele>
+<accuracy>3.518</accuracy>
+<speed>0.11229385</speed>
+<bearing>21.858572</bearing>
+<bearingAccuracyDegrees>12.084182</bearingAccuracyDegrees>
+<time>1746105234230</time>
+</trkpt>
+<trkpt lat="55.9370838" lon="-4.3132253">
+<ele>97.0></ele>
+<accuracy>3.501</accuracy>
+<speed>0.1499595</speed>
+<bearing>22.077923</bearing>
+<bearingAccuracyDegrees>9.04786</bearingAccuracyDegrees>
+<time>1746105235241</time>
+</trkpt>
+<trkpt lat="55.9371078" lon="-4.313201">
+<ele>97.0></ele>
+<accuracy>3.483</accuracy>
+<speed>1.0940106</speed>
+<bearing>23.257223</bearing>
+<bearingAccuracyDegrees>3.968311</bearingAccuracyDegrees>
+<time>1746105236316</time>
+</trkpt>
+<trkpt lat="55.937134" lon="-4.313178">
+<ele>97.0></ele>
+<accuracy>3.352</accuracy>
+<speed>1.3576256</speed>
+<bearing>23.885927</bearing>
+<bearingAccuracyDegrees>6.2727118</bearingAccuracyDegrees>
+<time>1746105237306</time>
+</trkpt>
+<trkpt lat="55.9371579" lon="-4.3131578">
+<ele>97.0></ele>
+<accuracy>3.178</accuracy>
+<speed>1.4324028</speed>
+<bearing>24.847013</bearing>
+<bearingAccuracyDegrees>6.1812077</bearingAccuracyDegrees>
+<time>1746105238227</time>
+</trkpt>
+<trkpt lat="55.9371765" lon="-4.3131438">
+<ele>97.0></ele>
+<accuracy>3.124</accuracy>
+<speed>1.4748536</speed>
+<bearing>26.01088</bearing>
+<bearingAccuracyDegrees>6.9683123</bearingAccuracyDegrees>
+<time>1746105239200</time>
+</trkpt>
+<trkpt lat="55.9371953" lon="-4.3131303">
+<ele>97.0></ele>
+<accuracy>3.046</accuracy>
+<speed>1.4529867</speed>
+<bearing>27.9666</bearing>
+<bearingAccuracyDegrees>9.272861</bearingAccuracyDegrees>
+<time>1746105240279</time>
+</trkpt>
+<trkpt lat="55.937212" lon="-4.3131233">
+<ele>97.0></ele>
+<accuracy>3.068</accuracy>
+<speed>1.366603</speed>
+<bearing>25.664562</bearing>
+<bearingAccuracyDegrees>9.921512</bearingAccuracyDegrees>
+<time>1746105241285</time>
+</trkpt>
+<trkpt lat="55.9372306" lon="-4.3131187">
+<ele>97.0></ele>
+<accuracy>3.197</accuracy>
+<speed>1.3270973</speed>
+<bearing>25.642483</bearing>
+<bearingAccuracyDegrees>9.922127</bearingAccuracyDegrees>
+<time>1746105242387</time>
+</trkpt>
+<trkpt lat="55.9372469" lon="-4.3131159">
+<ele>97.0></ele>
+<accuracy>3.407</accuracy>
+<speed>1.3197557</speed>
+<bearing>21.558922</bearing>
+<bearingAccuracyDegrees>9.953097</bearingAccuracyDegrees>
+<time>1746105243402</time>
+</trkpt>
+<trkpt lat="55.9372672" lon="-4.3131144">
+<ele>97.0></ele>
+<accuracy>3.686</accuracy>
+<speed>1.2780035</speed>
+<bearing>19.613605</bearing>
+<bearingAccuracyDegrees>9.604689</bearingAccuracyDegrees>
+<time>1746105244422</time>
+</trkpt>
+<trkpt lat="55.9372839" lon="-4.3131114">
+<ele>97.0></ele>
+<accuracy>3.93</accuracy>
+<speed>1.1902094</speed>
+<bearing>19.946451</bearing>
+<bearingAccuracyDegrees>9.995052</bearingAccuracyDegrees>
+<time>1746105245444</time>
+</trkpt>
+<trkpt lat="55.9372969" lon="-4.3131112">
+<ele>97.0></ele>
+<accuracy>4.152</accuracy>
+<speed>1.1307404</speed>
+<bearing>14.790661</bearing>
+<bearingAccuracyDegrees>9.593934</bearingAccuracyDegrees>
+<time>1746105246468</time>
+</trkpt>
+<trkpt lat="55.9373099" lon="-4.3131131">
+<ele>97.0></ele>
+<accuracy>4.313</accuracy>
+<speed>1.0707113</speed>
+<bearing>12.178231</bearing>
+<bearingAccuracyDegrees>9.844477</bearingAccuracyDegrees>
+<time>1746105247567</time>
+</trkpt>
+<trkpt lat="55.93732" lon="-4.3131138">
+<ele>97.0></ele>
+<accuracy>4.389</accuracy>
+<speed>1.0659064</speed>
+<bearing>12.532485</bearing>
+<bearingAccuracyDegrees>9.98332</bearingAccuracyDegrees>
+<time>1746105248568</time>
+</trkpt>
+<trkpt lat="55.9373295" lon="-4.3131164">
+<ele>97.0></ele>
+<accuracy>4.556</accuracy>
+<speed>0.677897</speed>
+<bearing>9.443544</bearing>
+<bearingAccuracyDegrees>9.475356</bearingAccuracyDegrees>
+<time>1746105249946</time>
+</trkpt>
+<trkpt lat="55.9373442" lon="-4.3131169">
+<ele>97.0></ele>
+<accuracy>4.818</accuracy>
+<speed>0.8899596</speed>
+<bearing>15.660947</bearing>
+<bearingAccuracyDegrees>10.164308</bearingAccuracyDegrees>
+<time>1746105251469</time>
+</trkpt>
+<trkpt lat="55.9373628" lon="-4.313118">
+<ele>97.0></ele>
+<accuracy>5.059</accuracy>
+<speed>1.0871801</speed>
+<bearing>17.279583</bearing>
+<bearingAccuracyDegrees>11.317829</bearingAccuracyDegrees>
+<time>1746105252500</time>
+</trkpt>
+<trkpt lat="55.937387" lon="-4.3131178">
+<ele>97.0></ele>
+<accuracy>5.094</accuracy>
+<speed>1.2654078</speed>
+<bearing>13.534209</bearing>
+<bearingAccuracyDegrees>11.719638</bearingAccuracyDegrees>
+<time>1746105253544</time>
+</trkpt>
+<trkpt lat="55.9374099" lon="-4.3131194">
+<ele>97.0></ele>
+<accuracy>5.01</accuracy>
+<speed>1.3206325</speed>
+<bearing>11.221251</bearing>
+<bearingAccuracyDegrees>9.877109</bearingAccuracyDegrees>
+<time>1746105254586</time>
+</trkpt>
+<trkpt lat="55.9374283" lon="-4.3131206">
+<ele>97.0></ele>
+<accuracy>4.838</accuracy>
+<speed>1.3376772</speed>
+<bearing>12.335452</bearing>
+<bearingAccuracyDegrees>9.809486</bearingAccuracyDegrees>
+<time>1746105255585</time>
+</trkpt>
+<trkpt lat="55.937448" lon="-4.3131195">
+<ele>97.0></ele>
+<accuracy>4.584</accuracy>
+<speed>1.3933618</speed>
+<bearing>10.65932</bearing>
+<bearingAccuracyDegrees>10.172571</bearingAccuracyDegrees>
+<time>1746105256588</time>
+</trkpt>
+<trkpt lat="55.9374671" lon="-4.3131208">
+<ele>97.0></ele>
+<accuracy>4.55</accuracy>
+<speed>1.4018607</speed>
+<bearing>11.706222</bearing>
+<bearingAccuracyDegrees>9.279851</bearingAccuracyDegrees>
+<time>1746105257590</time>
+</trkpt>
+<trkpt lat="55.9374861" lon="-4.3131194">
+<ele>97.0></ele>
+<accuracy>4.589</accuracy>
+<speed>1.4036567</speed>
+<bearing>12.917525</bearing>
+<bearingAccuracyDegrees>9.271038</bearingAccuracyDegrees>
+<time>1746105258593</time>
+</trkpt>
+<trkpt lat="55.9375062" lon="-4.3131191">
+<ele>97.0></ele>
+<accuracy>4.665</accuracy>
+<speed>1.4519717</speed>
+<bearing>7.5138817</bearing>
+<bearingAccuracyDegrees>9.186604</bearingAccuracyDegrees>
+<time>1746105259594</time>
+</trkpt>
+<trkpt lat="55.9375274" lon="-4.3131195">
+<ele>97.0></ele>
+<accuracy>4.696</accuracy>
+<speed>1.48419</speed>
+<bearing>5.674085</bearing>
+<bearingAccuracyDegrees>8.657446</bearingAccuracyDegrees>
+<time>1746105260596</time>
+</trkpt>
+<trkpt lat="55.9375491" lon="-4.3131184">
+<ele>97.0></ele>
+<accuracy>4.683</accuracy>
+<speed>1.5063188</speed>
+<bearing>4.469653</bearing>
+<bearingAccuracyDegrees>9.320667</bearingAccuracyDegrees>
+<time>1746105261600</time>
+</trkpt>
+<trkpt lat="55.9375707" lon="-4.3131148">
+<ele>97.0></ele>
+<accuracy>4.63</accuracy>
+<speed>1.4935802</speed>
+<bearing>5.797682</bearing>
+<bearingAccuracyDegrees>9.399191</bearingAccuracyDegrees>
+<time>1746105262602</time>
+</trkpt>
+<trkpt lat="55.9375907" lon="-4.3131113">
+<ele>97.0></ele>
+<accuracy>4.579</accuracy>
+<speed>1.4762664</speed>
+<bearing>7.5991654</bearing>
+<bearingAccuracyDegrees>9.31298</bearingAccuracyDegrees>
+<time>1746105263546</time>
+</trkpt>
+<trkpt lat="55.9376104" lon="-4.313107">
+<ele>97.0></ele>
+<accuracy>4.586</accuracy>
+<speed>1.4697952</speed>
+<bearing>7.1570687</bearing>
+<bearingAccuracyDegrees>9.4356365</bearingAccuracyDegrees>
+<time>1746105264600</time>
+</trkpt>
+<trkpt lat="55.9376268" lon="-4.3131061">
+<ele>97.0></ele>
+<accuracy>4.66</accuracy>
+<speed>1.4457064</speed>
+<bearing>1.7767799</bearing>
+<bearingAccuracyDegrees>9.582346</bearingAccuracyDegrees>
+<time>1746105265609</time>
+</trkpt>
+<trkpt lat="55.9376419" lon="-4.3131092">
+<ele>97.0></ele>
+<accuracy>4.748</accuracy>
+<speed>1.386558</speed>
+<bearing>358.68283</bearing>
+<bearingAccuracyDegrees>9.784047</bearingAccuracyDegrees>
+<time>1746105266511</time>
+</trkpt>
+<trkpt lat="55.9376594" lon="-4.3131099">
+<ele>96.0999984741211></ele>
+<accuracy>4.827</accuracy>
+<speed>1.3764387</speed>
+<bearing>3.4263747</bearing>
+<bearingAccuracyDegrees>10.077023</bearingAccuracyDegrees>
+<time>1746105267614</time>
+</trkpt>
+<trkpt lat="55.9377254" lon="-4.3131027">
+<ele>96.0999984741211></ele>
+<accuracy>4.885</accuracy>
+<speed>1.3226091</speed>
+<bearing>3.7846973</bearing>
+<bearingAccuracyDegrees>11.421766</bearingAccuracyDegrees>
+<time>1746105271523</time>
+</trkpt>
+<trkpt lat="55.9377446" lon="-4.3130979">
+<ele>97.0></ele>
+<accuracy>4.546</accuracy>
+<speed>1.2967883</speed>
+<bearing>4.379877</bearing>
+<bearingAccuracyDegrees>9.518652</bearingAccuracyDegrees>
+<time>1746105272588</time>
+</trkpt>
+<trkpt lat="55.9377566" lon="-4.3130931">
+<ele>97.0></ele>
+<accuracy>4.24</accuracy>
+<speed>1.2718312</speed>
+<bearing>9.057256</bearing>
+<bearingAccuracyDegrees>9.340615</bearingAccuracyDegrees>
+<time>1746105273527</time>
+</trkpt>
+<trkpt lat="55.9377721" lon="-4.3130861">
+<ele>97.0></ele>
+<accuracy>3.793</accuracy>
+<speed>1.294219</speed>
+<bearing>8.143747</bearing>
+<bearingAccuracyDegrees>9.721211</bearingAccuracyDegrees>
+<time>1746105274530</time>
+</trkpt>
+<trkpt lat="55.9377878" lon="-4.3130821">
+<ele>97.0></ele>
+<accuracy>3.636</accuracy>
+<speed>1.303106</speed>
+<bearing>5.222347</bearing>
+<bearingAccuracyDegrees>9.20895</bearingAccuracyDegrees>
+<time>1746105275467</time>
+</trkpt>
+<trkpt lat="55.9378061" lon="-4.3130754">
+<ele>97.0></ele>
+<accuracy>3.166</accuracy>
+<speed>1.3099478</speed>
+<bearing>9.414484</bearing>
+<bearingAccuracyDegrees>9.277967</bearingAccuracyDegrees>
+<time>1746105276610</time>
+</trkpt>
+<trkpt lat="55.9378196" lon="-4.3130678">
+<ele>97.0></ele>
+<accuracy>3.108</accuracy>
+<speed>1.326502</speed>
+<bearing>7.726271</bearing>
+<bearingAccuracyDegrees>9.073644</bearingAccuracyDegrees>
+<time>1746105277536</time>
+</trkpt>
+<trkpt lat="55.9378322" lon="-4.3130632">
+<ele>97.0></ele>
+<accuracy>3.042</accuracy>
+<speed>1.3330637</speed>
+<bearing>7.994445</bearing>
+<bearingAccuracyDegrees>9.438058</bearingAccuracyDegrees>
+<time>1746105278538</time>
+</trkpt>
+<trkpt lat="55.9378466" lon="-4.313054">
+<ele>97.0></ele>
+<accuracy>3.029</accuracy>
+<speed>1.3437136</speed>
+<bearing>13.342261</bearing>
+<bearingAccuracyDegrees>9.754184</bearingAccuracyDegrees>
+<time>1746105279542</time>
+</trkpt>
+<trkpt lat="55.9378592" lon="-4.3130449">
+<ele>97.0></ele>
+<accuracy>3.006</accuracy>
+<speed>1.3588221</speed>
+<bearing>19.68147</bearing>
+<bearingAccuracyDegrees>10.10969</bearingAccuracyDegrees>
+<time>1746105280487</time>
+</trkpt>
+<trkpt lat="55.9378756" lon="-4.313034">
+<ele>97.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3842988</speed>
+<bearing>18.936378</bearing>
+<bearingAccuracyDegrees>9.85612</bearingAccuracyDegrees>
+<time>1746105281631</time>
+</trkpt>
+<trkpt lat="55.9378891" lon="-4.3130296">
+<ele>97.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3917542</speed>
+<bearing>17.854498</bearing>
+<bearingAccuracyDegrees>9.604893</bearingAccuracyDegrees>
+<time>1746105282549</time>
+</trkpt>
+<trkpt lat="55.9379018" lon="-4.3130258">
+<ele>97.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3508267</speed>
+<bearing>16.094189</bearing>
+<bearingAccuracyDegrees>9.684256</bearingAccuracyDegrees>
+<time>1746105283551</time>
+</trkpt>
+<trkpt lat="55.9379154" lon="-4.313014">
+<ele>97.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3377689</speed>
+<bearing>14.748563</bearing>
+<bearingAccuracyDegrees>9.945794</bearingAccuracyDegrees>
+<time>1746105284553</time>
+</trkpt>
+<trkpt lat="55.9379294" lon="-4.313003">
+<ele>97.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.346796</speed>
+<bearing>14.457975</bearing>
+<bearingAccuracyDegrees>9.505071</bearingAccuracyDegrees>
+<time>1746105285556</time>
+</trkpt>
+<trkpt lat="55.9379386" lon="-4.3129975">
+<ele>97.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.2907543</speed>
+<bearing>13.633807</bearing>
+<bearingAccuracyDegrees>10.030598</bearingAccuracyDegrees>
+<time>1746105286482</time>
+</trkpt>
+<trkpt lat="55.9379492" lon="-4.3129954">
+<ele>98.9240717492318></ele>
+<accuracy>3.0</accuracy>
+<speed>1.2950562</speed>
+<bearing>9.755611</bearing>
+<bearingAccuracyDegrees>9.839677</bearingAccuracyDegrees>
+<time>1746105287852</time>
+</trkpt>
+<trkpt lat="55.9379627" lon="-4.3129925">
+<ele>99.57357751906223></ele>
+<accuracy>3.0</accuracy>
+<speed>1.2576439</speed>
+<bearing>14.301025</bearing>
+<bearingAccuracyDegrees>9.958476</bearingAccuracyDegrees>
+<time>1746105289365</time>
+</trkpt>
+<trkpt lat="55.9379727" lon="-4.3129847">
+<ele>100.09053760123516></ele>
+<accuracy>3.0</accuracy>
+<speed>1.2416244</speed>
+<bearing>10.675459</bearing>
+<bearingAccuracyDegrees>12.38111</bearingAccuracyDegrees>
+<time>1746105290567</time>
+</trkpt>
+<trkpt lat="55.9379814" lon="-4.3129786">
+<ele>100.55782140129844></ele>
+<accuracy>3.004</accuracy>
+<speed>1.1678609</speed>
+<bearing>14.552609</bearing>
+<bearingAccuracyDegrees>11.38153</bearingAccuracyDegrees>
+<time>1746105292571</time>
+</trkpt>
+<trkpt lat="55.9379905" lon="-4.3129728">
+<ele>100.5></ele>
+<accuracy>3.004</accuracy>
+<speed>0.7451158</speed>
+<bearing>11.31724</bearing>
+<bearingAccuracyDegrees>12.379954</bearingAccuracyDegrees>
+<time>1746105296423</time>
+</trkpt>
+<trkpt lat="55.9379999" lon="-4.3129726">
+<ele>101.81437154311845></ele>
+<accuracy>3.0</accuracy>
+<speed>0.78188413</speed>
+<bearing>8.861492</bearing>
+<bearingAccuracyDegrees>10.055193</bearingAccuracyDegrees>
+<time>1746105299532</time>
+</trkpt>
+<trkpt lat="55.938015" lon="-4.3129783">
+<ele>102.43702567419169></ele>
+<accuracy>3.0</accuracy>
+<speed>1.0479354</speed>
+<bearing>358.82434</bearing>
+<bearingAccuracyDegrees>11.877272</bearingAccuracyDegrees>
+<time>1746105301592</time>
+</trkpt>
+<trkpt lat="55.9380275" lon="-4.3129816">
+<ele>102.43702567419169></ele>
+<accuracy>3.0</accuracy>
+<speed>1.1108111</speed>
+<bearing>4.0108805</bearing>
+<bearingAccuracyDegrees>11.711548</bearingAccuracyDegrees>
+<time>1746105302623</time>
+</trkpt>
+<trkpt lat="55.9380389" lon="-4.3129838">
+<ele>102.91309718892487></ele>
+<accuracy>3.0</accuracy>
+<speed>0.9511811</speed>
+<bearing>354.08173</bearing>
+<bearingAccuracyDegrees>11.811546</bearingAccuracyDegrees>
+<time>1746105305544</time>
+</trkpt>
+<trkpt lat="55.9380532" lon="-4.3129865">
+<ele>103.12734576755264></ele>
+<accuracy>3.0</accuracy>
+<speed>1.0247768</speed>
+<bearing>350.56378</bearing>
+<bearingAccuracyDegrees>11.970357</bearingAccuracyDegrees>
+<time>1746105307380</time>
+</trkpt>
+<trkpt lat="55.9380642" lon="-4.3129881">
+<ele>103.28534597812578></ele>
+<accuracy>3.0</accuracy>
+<speed>1.0029616</speed>
+<bearing>351.91858</bearing>
+<bearingAccuracyDegrees>10.296754</bearingAccuracyDegrees>
+<time>1746105308562</time>
+</trkpt>
+<trkpt lat="55.9380764" lon="-4.3129867">
+<ele>103.24506494936153></ele>
+<accuracy>3.0</accuracy>
+<speed>1.0216551</speed>
+<bearing>351.55206</bearing>
+<bearingAccuracyDegrees>10.399174</bearingAccuracyDegrees>
+<time>1746105309612</time>
+</trkpt>
+<trkpt lat="55.9380872" lon="-4.3129822">
+<ele>103.16710175313128></ele>
+<accuracy>3.0</accuracy>
+<speed>1.0815947</speed>
+<bearing>352.02765</bearing>
+<bearingAccuracyDegrees>9.789491</bearingAccuracyDegrees>
+<time>1746105310967</time>
+</trkpt>
+<trkpt lat="55.9381044" lon="-4.31298">
+<ele>102.80848015345416></ele>
+<accuracy>3.0</accuracy>
+<speed>1.1607296</speed>
+<bearing>351.24692</bearing>
+<bearingAccuracyDegrees>9.415417</bearingAccuracyDegrees>
+<time>1746105312122</time>
+</trkpt>
+<trkpt lat="55.9381257" lon="-4.3129815">
+<ele>102.58358636768897></ele>
+<accuracy>3.0</accuracy>
+<speed>1.2539705</speed>
+<bearing>348.63528</bearing>
+<bearingAccuracyDegrees>9.420693</bearingAccuracyDegrees>
+<time>1746105313263</time>
+</trkpt>
+<trkpt lat="55.9381457" lon="-4.3129875">
+<ele>102.43926836636138></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3025322</speed>
+<bearing>348.24127</bearing>
+<bearingAccuracyDegrees>9.037402</bearingAccuracyDegrees>
+<time>1746105314385</time>
+</trkpt>
+<trkpt lat="55.9381656" lon="-4.3129941">
+<ele>102.73603439356425></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3493598</speed>
+<bearing>348.87747</bearing>
+<bearingAccuracyDegrees>7.3000865</bearingAccuracyDegrees>
+<time>1746105315489</time>
+</trkpt>
+<trkpt lat="55.938186" lon="-4.3130016">
+<ele>102.91534632582399></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4060115</speed>
+<bearing>342.0495</bearing>
+<bearingAccuracyDegrees>6.9580665</bearingAccuracyDegrees>
+<time>1746105316581</time>
+</trkpt>
+<trkpt lat="55.9382045" lon="-4.3130081">
+<ele>103.26670460435574></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4585944</speed>
+<bearing>341.55225</bearing>
+<bearingAccuracyDegrees>8.735921</bearingAccuracyDegrees>
+<time>1746105317530</time>
+</trkpt>
+<trkpt lat="55.9382226" lon="-4.3130145">
+<ele>103.47258678675755></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4511462</speed>
+<bearing>343.64316</bearing>
+<bearingAccuracyDegrees>7.2120867</bearingAccuracyDegrees>
+<time>1746105318633</time>
+</trkpt>
+<trkpt lat="55.9382358" lon="-4.313022">
+<ele>103.63816939710682></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4356025</speed>
+<bearing>344.27634</bearing>
+<bearingAccuracyDegrees>8.764101</bearingAccuracyDegrees>
+<time>1746105319535</time>
+</trkpt>
+<trkpt lat="55.93825" lon="-4.3130291">
+<ele>103.65347138298502></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4453664</speed>
+<bearing>345.14017</bearing>
+<bearingAccuracyDegrees>7.2211695</bearingAccuracyDegrees>
+<time>1746105320537</time>
+</trkpt>
+<trkpt lat="55.9382616" lon="-4.3130364">
+<ele>103.65347138298502></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4076087</speed>
+<bearing>343.0217</bearing>
+<bearingAccuracyDegrees>9.011858</bearingAccuracyDegrees>
+<time>1746105321461</time>
+</trkpt>
+<trkpt lat="55.9382745" lon="-4.3130462">
+<ele>103.7572014290433></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4062922</speed>
+<bearing>340.9992</bearing>
+<bearingAccuracyDegrees>8.953626</bearingAccuracyDegrees>
+<time>1746105322524</time>
+</trkpt>
+<trkpt lat="55.9382896" lon="-4.3130572">
+<ele>104.16233954182364></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4211282</speed>
+<bearing>339.0308</bearing>
+<bearingAccuracyDegrees>9.296422</bearingAccuracyDegrees>
+<time>1746105323615</time>
+</trkpt>
+<trkpt lat="55.938302" lon="-4.313069">
+<ele>104.37976932937354></ele>
+<accuracy>3.001</accuracy>
+<speed>1.4335853</speed>
+<bearing>336.77832</bearing>
+<bearingAccuracyDegrees>9.386083</bearingAccuracyDegrees>
+<time>1746105324547</time>
+</trkpt>
+<trkpt lat="55.9383177" lon="-4.3130795">
+<ele>104.50088954242446></ele>
+<accuracy>3.001</accuracy>
+<speed>1.4409174</speed>
+<bearing>337.71304</bearing>
+<bearingAccuracyDegrees>9.545267</bearingAccuracyDegrees>
+<time>1746105325548</time>
+</trkpt>
+<trkpt lat="55.9383316" lon="-4.3130892">
+<ele>104.67362216191447></ele>
+<accuracy>3.001</accuracy>
+<speed>1.4221628</speed>
+<bearing>332.65762</bearing>
+<bearingAccuracyDegrees>9.2245035</bearingAccuracyDegrees>
+<time>1746105326551</time>
+</trkpt>
+<trkpt lat="55.9383442" lon="-4.3130997">
+<ele>104.75055887759066></ele>
+<accuracy>3.001</accuracy>
+<speed>1.4166085</speed>
+<bearing>335.00113</bearing>
+<bearingAccuracyDegrees>8.964383</bearingAccuracyDegrees>
+<time>1746105327553</time>
+</trkpt>
+<trkpt lat="55.9383578" lon="-4.3131075">
+<ele>104.75055887759066></ele>
+<accuracy>3.001</accuracy>
+<speed>1.4205712</speed>
+<bearing>339.70114</bearing>
+<bearingAccuracyDegrees>9.428659</bearingAccuracyDegrees>
+<time>1746105328510</time>
+</trkpt>
+<trkpt lat="55.9383729" lon="-4.3131157">
+<ele>104.64817471888254></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4388918</speed>
+<bearing>341.5356</bearing>
+<bearingAccuracyDegrees>9.120334</bearingAccuracyDegrees>
+<time>1746105329562</time>
+</trkpt>
+<trkpt lat="55.9383864" lon="-4.3131228">
+<ele>104.80304854603187></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4226538</speed>
+<bearing>340.90594</bearing>
+<bearingAccuracyDegrees>9.430069</bearingAccuracyDegrees>
+<time>1746105330560</time>
+</trkpt>
+<trkpt lat="55.9383994" lon="-4.3131327">
+<ele>104.98850662731694></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4123764</speed>
+<bearing>335.42392</bearing>
+<bearingAccuracyDegrees>9.042527</bearingAccuracyDegrees>
+<time>1746105331563</time>
+</trkpt>
+<trkpt lat="55.9384118" lon="-4.3131439">
+<ele>104.8597554510497></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4072866</speed>
+<bearing>331.73175</bearing>
+<bearingAccuracyDegrees>9.790548</bearingAccuracyDegrees>
+<time>1746105332565</time>
+</trkpt>
+<trkpt lat="55.9384228" lon="-4.3131548">
+<ele>104.83948090477452></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3889673</speed>
+<bearing>335.5944</bearing>
+<bearingAccuracyDegrees>9.341482</bearingAccuracyDegrees>
+<time>1746105333568</time>
+</trkpt>
+<trkpt lat="55.9384351" lon="-4.3131615">
+<ele>104.94977692791541></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3571795</speed>
+<bearing>340.97403</bearing>
+<bearingAccuracyDegrees>9.205801</bearingAccuracyDegrees>
+<time>1746105334569</time>
+</trkpt>
+<trkpt lat="55.9384495" lon="-4.3131672">
+<ele>104.94977692791541></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3656342</speed>
+<bearing>342.46234</bearing>
+<bearingAccuracyDegrees>9.025891</bearingAccuracyDegrees>
+<time>1746105335546</time>
+</trkpt>
+<trkpt lat="55.9384658" lon="-4.313177">
+<ele>105.01216018681794></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4185</speed>
+<bearing>339.8154</bearing>
+<bearingAccuracyDegrees>9.623037</bearingAccuracyDegrees>
+<time>1746105336611</time>
+</trkpt>
+<trkpt lat="55.9384779" lon="-4.3131876">
+<ele>105.11485281745361></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4089768</speed>
+<bearing>341.0115</bearing>
+<bearingAccuracyDegrees>9.721437</bearingAccuracyDegrees>
+<time>1746105337577</time>
+</trkpt>
+<trkpt lat="55.9384894" lon="-4.3131963">
+<ele>105.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3964303</speed>
+<bearing>337.43597</bearing>
+<bearingAccuracyDegrees>9.769471</bearingAccuracyDegrees>
+<time>1746105338479</time>
+</trkpt>
+<trkpt lat="55.9385015" lon="-4.3132074">
+<ele>105.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3864952</speed>
+<bearing>330.4868</bearing>
+<bearingAccuracyDegrees>9.932312</bearingAccuracyDegrees>
+<time>1746105339582</time>
+</trkpt>
+<trkpt lat="55.9385135" lon="-4.3132155">
+<ele>105.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.408063</speed>
+<bearing>332.68445</bearing>
+<bearingAccuracyDegrees>9.436447</bearingAccuracyDegrees>
+<time>1746105340584</time>
+</trkpt>
+<trkpt lat="55.9385277" lon="-4.3132236">
+<ele>105.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4284599</speed>
+<bearing>335.3871</bearing>
+<bearingAccuracyDegrees>9.295635</bearingAccuracyDegrees>
+<time>1746105341585</time>
+</trkpt>
+<trkpt lat="55.9385434" lon="-4.3132318">
+<ele>105.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4337124</speed>
+<bearing>340.5685</bearing>
+<bearingAccuracyDegrees>9.340226</bearingAccuracyDegrees>
+<time>1746105342541</time>
+</trkpt>
+<trkpt lat="55.9385596" lon="-4.3132425">
+<ele>104.82356081206827></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4384743</speed>
+<bearing>334.37402</bearing>
+<bearingAccuracyDegrees>9.467853</bearingAccuracyDegrees>
+<time>1746105343648</time>
+</trkpt>
+<trkpt lat="55.9385711" lon="-4.3132522">
+<ele>104.8594316055115></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4438004</speed>
+<bearing>336.47223</bearing>
+<bearingAccuracyDegrees>8.909385</bearingAccuracyDegrees>
+<time>1746105344593</time>
+</trkpt>
+<trkpt lat="55.9385848" lon="-4.3132619">
+<ele>104.89114359098778></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4529892</speed>
+<bearing>337.88553</bearing>
+<bearingAccuracyDegrees>9.303099</bearingAccuracyDegrees>
+<time>1746105345596</time>
+</trkpt>
+<trkpt lat="55.9385983" lon="-4.3132719">
+<ele>104.89894163811562></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4440606</speed>
+<bearing>336.27963</bearing>
+<bearingAccuracyDegrees>9.636729</bearingAccuracyDegrees>
+<time>1746105346598</time>
+</trkpt>
+<trkpt lat="55.9386127" lon="-4.3132814">
+<ele>104.99775024869993></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4540435</speed>
+<bearing>337.43744</bearing>
+<bearingAccuracyDegrees>9.464665</bearingAccuracyDegrees>
+<time>1746105347600</time>
+</trkpt>
+<trkpt lat="55.9386267" lon="-4.3132901">
+<ele>104.93877465167267></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4646974</speed>
+<bearing>339.73276</bearing>
+<bearingAccuracyDegrees>9.396201</bearingAccuracyDegrees>
+<time>1746105348603</time>
+</trkpt>
+<trkpt lat="55.9386395" lon="-4.3132974">
+<ele>104.9179800547997></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4339281</speed>
+<bearing>339.45663</bearing>
+<bearingAccuracyDegrees>9.828687</bearingAccuracyDegrees>
+<time>1746105349605</time>
+</trkpt>
+<trkpt lat="55.9387085" lon="-4.3133351">
+<ele>105.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4749541</speed>
+<bearing>340.06693</bearing>
+<bearingAccuracyDegrees>9.108805</bearingAccuracyDegrees>
+<time>1746105354620</time>
+</trkpt>
+<trkpt lat="55.9387248" lon="-4.3133448">
+<ele>105.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5168675</speed>
+<bearing>340.8544</bearing>
+<bearingAccuracyDegrees>7.128248</bearingAccuracyDegrees>
+<time>1746105355660</time>
+</trkpt>
+<trkpt lat="55.9387396" lon="-4.313354">
+<ele>105.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5348032</speed>
+<bearing>341.47345</bearing>
+<bearingAccuracyDegrees>8.931562</bearingAccuracyDegrees>
+<time>1746105356621</time>
+</trkpt>
+<trkpt lat="55.9387748" lon="-4.3133798">
+<ele>105.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4495525</speed>
+<bearing>342.27988</bearing>
+<bearingAccuracyDegrees>9.128197</bearingAccuracyDegrees>
+<time>1746105359528</time>
+</trkpt>
+<trkpt lat="55.9387863" lon="-4.3133849">
+<ele>105.19999694824219></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3587567</speed>
+<bearing>342.51978</bearing>
+<bearingAccuracyDegrees>8.988478</bearingAccuracyDegrees>
+<time>1746105361332</time>
+</trkpt>
+<trkpt lat="55.9387978" lon="-4.3133884">
+<ele>105.19999694824219></ele>
+<accuracy>3.0</accuracy>
+<speed>1.2852278</speed>
+<bearing>346.13852</bearing>
+<bearingAccuracyDegrees>9.860986</bearingAccuracyDegrees>
+<time>1746105362427</time>
+</trkpt>
+<trkpt lat="55.9388114" lon="-4.3133961">
+<ele>105.19999694824219></ele>
+<accuracy>3.023</accuracy>
+<speed>1.2975776</speed>
+<bearing>341.93707</bearing>
+<bearingAccuracyDegrees>9.631581</bearingAccuracyDegrees>
+<time>1746105363462</time>
+</trkpt>
+<trkpt lat="55.9388269" lon="-4.3134074">
+<ele>105.19999694824219></ele>
+<accuracy>3.106</accuracy>
+<speed>1.3888992</speed>
+<bearing>339.0766</bearing>
+<bearingAccuracyDegrees>9.839199</bearingAccuracyDegrees>
+<time>1746105364483</time>
+</trkpt>
+<trkpt lat="55.9388421" lon="-4.3134193">
+<ele>105.19999694824219></ele>
+<accuracy>3.25</accuracy>
+<speed>1.4131409</speed>
+<bearing>337.86298</bearing>
+<bearingAccuracyDegrees>9.81726</bearingAccuracyDegrees>
+<time>1746105365514</time>
+</trkpt>
+<trkpt lat="55.9388565" lon="-4.3134285">
+<ele>105.19999694824219></ele>
+<accuracy>3.519</accuracy>
+<speed>1.4244986</speed>
+<bearing>337.28</bearing>
+<bearingAccuracyDegrees>10.071996</bearingAccuracyDegrees>
+<time>1746105366529</time>
+</trkpt>
+<trkpt lat="55.938869" lon="-4.3134372">
+<ele>105.19999694824219></ele>
+<accuracy>3.751</accuracy>
+<speed>1.3765557</speed>
+<bearing>338.37912</bearing>
+<bearingAccuracyDegrees>9.923287</bearingAccuracyDegrees>
+<time>1746105367571</time>
+</trkpt>
+<trkpt lat="55.9388837" lon="-4.3134475">
+<ele>105.19999694824219></ele>
+<accuracy>3.942</accuracy>
+<speed>1.382833</speed>
+<bearing>341.97165</bearing>
+<bearingAccuracyDegrees>9.936282</bearingAccuracyDegrees>
+<time>1746105368601</time>
+</trkpt>
+<trkpt lat="55.9388978" lon="-4.3134584">
+<ele>105.19999694824219></ele>
+<accuracy>4.08</accuracy>
+<speed>1.4116939</speed>
+<bearing>341.5792</bearing>
+<bearingAccuracyDegrees>10.286844</bearingAccuracyDegrees>
+<time>1746105369551</time>
+</trkpt>
+<trkpt lat="55.9389132" lon="-4.3134701">
+<ele>105.19999694824219></ele>
+<accuracy>4.207</accuracy>
+<speed>1.431091</speed>
+<bearing>337.33743</bearing>
+<bearingAccuracyDegrees>12.006532</bearingAccuracyDegrees>
+<time>1746105370554</time>
+</trkpt>
+<trkpt lat="55.938927" lon="-4.3134836">
+<ele>105.19999694824219></ele>
+<accuracy>4.371</accuracy>
+<speed>1.4242221</speed>
+<bearing>337.2473</bearing>
+<bearingAccuracyDegrees>11.60862</bearingAccuracyDegrees>
+<time>1746105371555</time>
+</trkpt>
+<trkpt lat="55.9389424" lon="-4.3134952">
+<ele>105.19999694824219></ele>
+<accuracy>4.45</accuracy>
+<speed>1.44951</speed>
+<bearing>341.06143</bearing>
+<bearingAccuracyDegrees>12.0316725</bearingAccuracyDegrees>
+<time>1746105372558</time>
+</trkpt>
+<trkpt lat="55.9389584" lon="-4.3135048">
+<ele>105.19999694824219></ele>
+<accuracy>4.521</accuracy>
+<speed>1.4683707</speed>
+<bearing>341.5111</bearing>
+<bearingAccuracyDegrees>9.963975</bearingAccuracyDegrees>
+<time>1746105373561</time>
+</trkpt>
+<trkpt lat="55.9389744" lon="-4.3135141">
+<ele>105.19999694824219></ele>
+<accuracy>4.604</accuracy>
+<speed>1.4795784</speed>
+<bearing>343.93057</bearing>
+<bearingAccuracyDegrees>11.402232</bearingAccuracyDegrees>
+<time>1746105374563</time>
+</trkpt>
+<trkpt lat="55.9389898" lon="-4.313527">
+<ele>105.19999694824219></ele>
+<accuracy>4.696</accuracy>
+<speed>1.4535753</speed>
+<bearing>341.77567</bearing>
+<bearingAccuracyDegrees>10.182824</bearingAccuracyDegrees>
+<time>1746105375565</time>
+</trkpt>
+<trkpt lat="55.9390043" lon="-4.3135366">
+<ele>105.2735745829259></ele>
+<accuracy>4.743</accuracy>
+<speed>1.4539338</speed>
+<bearing>340.87744</bearing>
+<bearingAccuracyDegrees>9.760843</bearingAccuracyDegrees>
+<time>1746105376568</time>
+</trkpt>
+<trkpt lat="55.9390181" lon="-4.3135436">
+<ele>105.53160514666511></ele>
+<accuracy>4.757</accuracy>
+<speed>1.4543527</speed>
+<bearing>339.3693</bearing>
+<bearingAccuracyDegrees>9.899667</bearingAccuracyDegrees>
+<time>1746105377570</time>
+</trkpt>
+<trkpt lat="55.9390316" lon="-4.3135514">
+<ele>105.53160514666511></ele>
+<accuracy>4.739</accuracy>
+<speed>1.4557939</speed>
+<bearing>339.49658</bearing>
+<bearingAccuracyDegrees>9.997566</bearingAccuracyDegrees>
+<time>1746105378484</time>
+</trkpt>
+<trkpt lat="55.9390492" lon="-4.3135491">
+<ele>105.45570240876204></ele>
+<accuracy>4.464</accuracy>
+<speed>1.4536293</speed>
+<bearing>344.342</bearing>
+<bearingAccuracyDegrees>9.164866</bearingAccuracyDegrees>
+<time>1746105379530</time>
+</trkpt>
+<trkpt lat="55.939065" lon="-4.3135487">
+<ele>105.40059536126114></ele>
+<accuracy>4.098</accuracy>
+<speed>1.4428976</speed>
+<bearing>346.6726</bearing>
+<bearingAccuracyDegrees>8.857257</bearingAccuracyDegrees>
+<time>1746105380578</time>
+</trkpt>
+<trkpt lat="55.9390763" lon="-4.3135503">
+<ele>105.0></ele>
+<accuracy>3.918</accuracy>
+<speed>1.4531038</speed>
+<bearing>346.10342</bearing>
+<bearingAccuracyDegrees>8.96845</bearingAccuracyDegrees>
+<time>1746105381479</time>
+</trkpt>
+<trkpt lat="55.9390909" lon="-4.3135555">
+<ele>105.0></ele>
+<accuracy>3.387</accuracy>
+<speed>1.463585</speed>
+<bearing>343.3631</bearing>
+<bearingAccuracyDegrees>9.071849</bearingAccuracyDegrees>
+<time>1746105382582</time>
+</trkpt>
+<trkpt lat="55.9391035" lon="-4.3135623">
+<ele>105.0></ele>
+<accuracy>3.161</accuracy>
+<speed>1.4712712</speed>
+<bearing>344.91333</bearing>
+<bearingAccuracyDegrees>9.472097</bearingAccuracyDegrees>
+<time>1746105383583</time>
+</trkpt>
+<trkpt lat="55.9391198" lon="-4.313571">
+<ele>105.0></ele>
+<accuracy>3.044</accuracy>
+<speed>1.5104635</speed>
+<bearing>348.8841</bearing>
+<bearingAccuracyDegrees>9.369063</bearingAccuracyDegrees>
+<time>1746105384585</time>
+</trkpt>
+<trkpt lat="55.9391364" lon="-4.313579">
+<ele>105.0></ele>
+<accuracy>3.009</accuracy>
+<speed>1.529026</speed>
+<bearing>346.04544</bearing>
+<bearingAccuracyDegrees>9.271915</bearingAccuracyDegrees>
+<time>1746105385589</time>
+</trkpt>
+<trkpt lat="55.9391524" lon="-4.3135898">
+<ele>105.0></ele>
+<accuracy>3.002</accuracy>
+<speed>1.5229201</speed>
+<bearing>342.89627</bearing>
+<bearingAccuracyDegrees>9.379971</bearingAccuracyDegrees>
+<time>1746105386591</time>
+</trkpt>
+<trkpt lat="55.9391664" lon="-4.3136003">
+<ele>105.0></ele>
+<accuracy>3.01</accuracy>
+<speed>1.4787196</speed>
+<bearing>341.3462</bearing>
+<bearingAccuracyDegrees>9.24317</bearingAccuracyDegrees>
+<time>1746105387593</time>
+</trkpt>
+<trkpt lat="55.9391804" lon="-4.3136082">
+<ele>105.0></ele>
+<accuracy>3.02</accuracy>
+<speed>1.4627331</speed>
+<bearing>340.25845</bearing>
+<bearingAccuracyDegrees>10.067414</bearingAccuracyDegrees>
+<time>1746105388595</time>
+</trkpt>
+<trkpt lat="55.9391961" lon="-4.3136141">
+<ele>105.19999694824219></ele>
+<accuracy>3.041</accuracy>
+<speed>1.4741461</speed>
+<bearing>340.48526</bearing>
+<bearingAccuracyDegrees>11.51986</bearingAccuracyDegrees>
+<time>1746105389597</time>
+</trkpt>
+<trkpt lat="55.9392113" lon="-4.313623">
+<ele>105.19999694824219></ele>
+<accuracy>3.064</accuracy>
+<speed>1.4802831</speed>
+<bearing>344.845</bearing>
+<bearingAccuracyDegrees>10.137173</bearingAccuracyDegrees>
+<time>1746105390504</time>
+</trkpt>
+<trkpt lat="55.9392294" lon="-4.3136302">
+<ele>105.19999694824219></ele>
+<accuracy>3.119</accuracy>
+<speed>1.4791322</speed>
+<bearing>346.10208</bearing>
+<bearingAccuracyDegrees>10.1742935</bearingAccuracyDegrees>
+<time>1746105391528</time>
+</trkpt>
+<trkpt lat="55.9392476" lon="-4.3136373">
+<ele>105.19999694824219></ele>
+<accuracy>3.186</accuracy>
+<speed>1.486722</speed>
+<bearing>340.1111</bearing>
+<bearingAccuracyDegrees>9.405289</bearingAccuracyDegrees>
+<time>1746105392571</time>
+</trkpt>
+<trkpt lat="55.9392635" lon="-4.3136449">
+<ele>105.19999694824219></ele>
+<accuracy>3.238</accuracy>
+<speed>1.4660752</speed>
+<bearing>335.5677</bearing>
+<bearingAccuracyDegrees>9.223193</bearingAccuracyDegrees>
+<time>1746105393641</time>
+</trkpt>
+<trkpt lat="55.9393101" lon="-4.3136748">
+<ele>105.19999694824219></ele>
+<accuracy>3.108</accuracy>
+<speed>1.4598942</speed>
+<bearing>342.02707</bearing>
+<bearingAccuracyDegrees>8.646704</bearingAccuracyDegrees>
+<time>1746105397617</time>
+</trkpt>
+<trkpt lat="55.9393345" lon="-4.3136989">
+<ele>105.19999694824219></ele>
+<accuracy>3.01</accuracy>
+<speed>1.4546863</speed>
+<bearing>335.28516</bearing>
+<bearingAccuracyDegrees>8.630557</bearingAccuracyDegrees>
+<time>1746105399521</time>
+</trkpt>
+<trkpt lat="55.9393476" lon="-4.3137119">
+<ele>105.19999694824219></ele>
+<accuracy>3.007</accuracy>
+<speed>1.4617466</speed>
+<bearing>337.66425</bearing>
+<bearingAccuracyDegrees>9.099257</bearingAccuracyDegrees>
+<time>1746105400523</time>
+</trkpt>
+<trkpt lat="55.9393637" lon="-4.3137277">
+<ele>105.19999694824219></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4938532</speed>
+<bearing>338.83923</bearing>
+<bearingAccuracyDegrees>9.189209</bearingAccuracyDegrees>
+<time>1746105401526</time>
+</trkpt>
+<trkpt lat="55.9393802" lon="-4.3137375">
+<ele>105.19999694824219></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5093496</speed>
+<bearing>338.7877</bearing>
+<bearingAccuracyDegrees>8.832353</bearingAccuracyDegrees>
+<time>1746105402464</time>
+</trkpt>
+<trkpt lat="55.9393966" lon="-4.3137466">
+<ele>105.19999694824219></ele>
+<accuracy>3.001</accuracy>
+<speed>1.5174236</speed>
+<bearing>335.1223</bearing>
+<bearingAccuracyDegrees>8.954637</bearingAccuracyDegrees>
+<time>1746105403462</time>
+</trkpt>
+<trkpt lat="55.9394137" lon="-4.3137585">
+<ele>105.19999694824219></ele>
+<accuracy>3.001</accuracy>
+<speed>1.5089979</speed>
+<bearing>335.5012</bearing>
+<bearingAccuracyDegrees>9.029942</bearingAccuracyDegrees>
+<time>1746105404525</time>
+</trkpt>
+<trkpt lat="55.9394285" lon="-4.313769">
+<ele>105.19999694824219></ele>
+<accuracy>3.004</accuracy>
+<speed>1.4999241</speed>
+<bearing>336.2016</bearing>
+<bearingAccuracyDegrees>9.172818</bearingAccuracyDegrees>
+<time>1746105405549</time>
+</trkpt>
+<trkpt lat="55.9394413" lon="-4.3137775">
+<ele>104.3695407132868></ele>
+<accuracy>3.013</accuracy>
+<speed>1.5020909</speed>
+<bearing>339.45718</bearing>
+<bearingAccuracyDegrees>9.172859</bearingAccuracyDegrees>
+<time>1746105406536</time>
+</trkpt>
+<trkpt lat="55.9394546" lon="-4.3137847">
+<ele>104.436279186082></ele>
+<accuracy>3.023</accuracy>
+<speed>1.5180597</speed>
+<bearing>341.95963</bearing>
+<bearingAccuracyDegrees>8.708006</bearingAccuracyDegrees>
+<time>1746105407539</time>
+</trkpt>
+<trkpt lat="55.9394675" lon="-4.3137898">
+<ele>104.21380002378106></ele>
+<accuracy>3.035</accuracy>
+<speed>1.5220952</speed>
+<bearing>341.5284</bearing>
+<bearingAccuracyDegrees>9.020106</bearingAccuracyDegrees>
+<time>1746105408541</time>
+</trkpt>
+<trkpt lat="55.9394814" lon="-4.313799">
+<ele>104.00134463314363></ele>
+<accuracy>3.054</accuracy>
+<speed>1.5495144</speed>
+<bearing>336.1838</bearing>
+<bearingAccuracyDegrees>9.099921</bearingAccuracyDegrees>
+<time>1746105409544</time>
+</trkpt>
+<trkpt lat="55.9394957" lon="-4.3138117">
+<ele>105.0></ele>
+<accuracy>3.116</accuracy>
+<speed>1.5709822</speed>
+<bearing>333.26074</bearing>
+<bearingAccuracyDegrees>9.725378</bearingAccuracyDegrees>
+<time>1746105410546</time>
+</trkpt>
+<trkpt lat="55.9395109" lon="-4.3138242">
+<ele>105.0></ele>
+<accuracy>3.233</accuracy>
+<speed>1.5817592</speed>
+<bearing>337.54</bearing>
+<bearingAccuracyDegrees>9.416168</bearingAccuracyDegrees>
+<time>1746105411549</time>
+</trkpt>
+<trkpt lat="55.9395263" lon="-4.3138327">
+<ele>105.0></ele>
+<accuracy>3.422</accuracy>
+<speed>1.5576912</speed>
+<bearing>347.42264</bearing>
+<bearingAccuracyDegrees>10.109824</bearingAccuracyDegrees>
+<time>1746105412551</time>
+</trkpt>
+<trkpt lat="55.9395419" lon="-4.3138361">
+<ele>105.0></ele>
+<accuracy>3.679</accuracy>
+<speed>1.5197057</speed>
+<bearing>351.22342</bearing>
+<bearingAccuracyDegrees>10.252923</bearingAccuracyDegrees>
+<time>1746105413553</time>
+</trkpt>
+<trkpt lat="55.9395571" lon="-4.3138384">
+<ele>105.0></ele>
+<accuracy>3.929</accuracy>
+<speed>1.4606931</speed>
+<bearing>352.04614</bearing>
+<bearingAccuracyDegrees>12.049022</bearingAccuracyDegrees>
+<time>1746105414568</time>
+</trkpt>
+<trkpt lat="55.9395715" lon="-4.3138389">
+<ele>105.0></ele>
+<accuracy>4.199</accuracy>
+<speed>1.4267678</speed>
+<bearing>359.5062</bearing>
+<bearingAccuracyDegrees>11.801091</bearingAccuracyDegrees>
+<time>1746105415580</time>
+</trkpt>
+<trkpt lat="55.9395848" lon="-4.3138367">
+<ele>105.0></ele>
+<accuracy>4.472</accuracy>
+<speed>1.4041872</speed>
+<bearing>2.6848438</bearing>
+<bearingAccuracyDegrees>12.084597</bearingAccuracyDegrees>
+<time>1746105416612</time>
+</trkpt>
+<trkpt lat="55.9395965" lon="-4.3138361">
+<ele>105.0></ele>
+<accuracy>4.724</accuracy>
+<speed>1.4065646</speed>
+<bearing>352.10968</bearing>
+<bearingAccuracyDegrees>11.372476</bearingAccuracyDegrees>
+<time>1746105417563</time>
+</trkpt>
+<trkpt lat="55.9396117" lon="-4.3138402">
+<ele>103.5243368116423></ele>
+<accuracy>4.934</accuracy>
+<speed>1.4233545</speed>
+<bearing>340.783</bearing>
+<bearingAccuracyDegrees>9.950722</bearingAccuracyDegrees>
+<time>1746105418564</time>
+</trkpt>
+<trkpt lat="55.9396266" lon="-4.3138492">
+<ele>103.50001348301967></ele>
+<accuracy>5.08</accuracy>
+<speed>1.4213345</speed>
+<bearing>334.13013</bearing>
+<bearingAccuracyDegrees>9.744462</bearingAccuracyDegrees>
+<time>1746105419567</time>
+</trkpt>
+<trkpt lat="55.9396393" lon="-4.3138608">
+<ele>103.22142075215743></ele>
+<accuracy>5.157</accuracy>
+<speed>1.4955988</speed>
+<bearing>335.24283</bearing>
+<bearingAccuracyDegrees>11.906233</bearingAccuracyDegrees>
+<time>1746105420570</time>
+</trkpt>
+<trkpt lat="55.9396518" lon="-4.3138713">
+<ele>102.99065301064877></ele>
+<accuracy>5.202</accuracy>
+<speed>1.4453716</speed>
+<bearing>333.78598</bearing>
+<bearingAccuracyDegrees>10.180676</bearingAccuracyDegrees>
+<time>1746105421571</time>
+</trkpt>
+<trkpt lat="55.9396671" lon="-4.3138823">
+<ele>102.72433715461878></ele>
+<accuracy>5.212</accuracy>
+<speed>1.4775188</speed>
+<bearing>331.57672</bearing>
+<bearingAccuracyDegrees>10.097602</bearingAccuracyDegrees>
+<time>1746105422573</time>
+</trkpt>
+<trkpt lat="55.939686" lon="-4.3138951">
+<ele>102.72433715461878></ele>
+<accuracy>5.224</accuracy>
+<speed>1.5883696</speed>
+<bearing>338.01117</bearing>
+<bearingAccuracyDegrees>9.905662</bearingAccuracyDegrees>
+<time>1746105423538</time>
+</trkpt>
+<trkpt lat="55.9397049" lon="-4.3139007">
+<ele>101.0999984741211></ele>
+<accuracy>5.247</accuracy>
+<speed>1.6081961</speed>
+<bearing>356.41263</bearing>
+<bearingAccuracyDegrees>10.0616865</bearingAccuracyDegrees>
+<time>1746105424522</time>
+</trkpt>
+<trkpt lat="55.9397254" lon="-4.313895">
+<ele>101.0999984741211></ele>
+<accuracy>5.281</accuracy>
+<speed>1.5897274</speed>
+<bearing>7.2155066</bearing>
+<bearingAccuracyDegrees>9.68871</bearingAccuracyDegrees>
+<time>1746105425587</time>
+</trkpt>
+<trkpt lat="55.9397424" lon="-4.3138875">
+<ele>101.0999984741211></ele>
+<accuracy>5.295</accuracy>
+<speed>1.5508159</speed>
+<bearing>8.2536745</bearing>
+<bearingAccuracyDegrees>9.865271</bearingAccuracyDegrees>
+<time>1746105426638</time>
+</trkpt>
+<trkpt lat="55.9397557" lon="-4.3138825">
+<ele>101.0999984741211></ele>
+<accuracy>5.297</accuracy>
+<speed>1.5044106</speed>
+<bearing>8.513726</bearing>
+<bearingAccuracyDegrees>10.276158</bearingAccuracyDegrees>
+<time>1746105427586</time>
+</trkpt>
+<trkpt lat="55.93977" lon="-4.3138766">
+<ele>101.0999984741211></ele>
+<accuracy>5.292</accuracy>
+<speed>1.4723761</speed>
+<bearing>10.860273</bearing>
+<bearingAccuracyDegrees>11.730612</bearingAccuracyDegrees>
+<time>1746105428588</time>
+</trkpt>
+<trkpt lat="55.9397834" lon="-4.3138713">
+<ele>101.0999984741211></ele>
+<accuracy>5.214</accuracy>
+<speed>1.4527359</speed>
+<bearing>8.536559</bearing>
+<bearingAccuracyDegrees>11.779098</bearingAccuracyDegrees>
+<time>1746105429591</time>
+</trkpt>
+<trkpt lat="55.9397968" lon="-4.3138664">
+<ele>101.0></ele>
+<accuracy>5.182</accuracy>
+<speed>1.4302001</speed>
+<bearing>10.390033</bearing>
+<bearingAccuracyDegrees>12.183613</bearingAccuracyDegrees>
+<time>1746105430593</time>
+</trkpt>
+<trkpt lat="55.9398089" lon="-4.3138603">
+<ele>101.0></ele>
+<accuracy>5.172</accuracy>
+<speed>1.4124432</speed>
+<bearing>14.896919</bearing>
+<bearingAccuracyDegrees>12.139147</bearingAccuracyDegrees>
+<time>1746105431595</time>
+</trkpt>
+<trkpt lat="55.9398208" lon="-4.3138523">
+<ele>101.0></ele>
+<accuracy>5.166</accuracy>
+<speed>1.4226468</speed>
+<bearing>15.851709</bearing>
+<bearingAccuracyDegrees>12.308515</bearingAccuracyDegrees>
+<time>1746105432597</time>
+</trkpt>
+<trkpt lat="55.9398326" lon="-4.3138466">
+<ele>101.0></ele>
+<accuracy>5.189</accuracy>
+<speed>1.4174865</speed>
+<bearing>15.337751</bearing>
+<bearingAccuracyDegrees>12.626431</bearingAccuracyDegrees>
+<time>1746105433600</time>
+</trkpt>
+<trkpt lat="55.939844" lon="-4.3138455">
+<ele>101.0></ele>
+<accuracy>5.237</accuracy>
+<speed>1.3862404</speed>
+<bearing>7.3366885</bearing>
+<bearingAccuracyDegrees>12.612739</bearingAccuracyDegrees>
+<time>1746105434602</time>
+</trkpt>
+<trkpt lat="55.9398542" lon="-4.3138473">
+<ele>101.0></ele>
+<accuracy>5.272</accuracy>
+<speed>1.3470343</speed>
+<bearing>355.42682</bearing>
+<bearingAccuracyDegrees>12.985677</bearingAccuracyDegrees>
+<time>1746105435508</time>
+</trkpt>
+<trkpt lat="55.9398659" lon="-4.3138523">
+<ele>101.0999984741211></ele>
+<accuracy>5.312</accuracy>
+<speed>1.3609204</speed>
+<bearing>346.2426</bearing>
+<bearingAccuracyDegrees>11.839329</bearingAccuracyDegrees>
+<time>1746105436539</time>
+</trkpt>
+<trkpt lat="55.9398794" lon="-4.3138598">
+<ele>101.0999984741211></ele>
+<accuracy>5.301</accuracy>
+<speed>1.3667858</speed>
+<bearing>343.14145</bearing>
+<bearingAccuracyDegrees>11.776874</bearingAccuracyDegrees>
+<time>1746105437603</time>
+</trkpt>
+<trkpt lat="55.9398918" lon="-4.3138703">
+<ele>101.0999984741211></ele>
+<accuracy>5.258</accuracy>
+<speed>1.341674</speed>
+<bearing>341.30432</bearing>
+<bearingAccuracyDegrees>12.332356</bearingAccuracyDegrees>
+<time>1746105438624</time>
+</trkpt>
+<trkpt lat="55.9399009" lon="-4.3138763">
+<ele>101.0999984741211></ele>
+<accuracy>5.191</accuracy>
+<speed>1.3166524</speed>
+<bearing>343.73758</bearing>
+<bearingAccuracyDegrees>11.938989</bearingAccuracyDegrees>
+<time>1746105439614</time>
+</trkpt>
+<trkpt lat="55.9399102" lon="-4.3138798">
+<ele>101.0></ele>
+<accuracy>5.085</accuracy>
+<speed>1.342057</speed>
+<bearing>341.96558</bearing>
+<bearingAccuracyDegrees>12.251808</bearingAccuracyDegrees>
+<time>1746105440516</time>
+</trkpt>
+<trkpt lat="55.9399196" lon="-4.313888">
+<ele>101.0></ele>
+<accuracy>4.813</accuracy>
+<speed>0.8483309</speed>
+<bearing>336.4806</bearing>
+<bearingAccuracyDegrees>9.937101</bearingAccuracyDegrees>
+<time>1746105442283</time>
+</trkpt>
+<trkpt lat="55.9399278" lon="-4.3138955">
+<ele>101.0></ele>
+<accuracy>4.762</accuracy>
+<speed>1.0189496</speed>
+<bearing>337.40396</bearing>
+<bearingAccuracyDegrees>9.724464</bearingAccuracyDegrees>
+<time>1746105443623</time>
+</trkpt>
+<trkpt lat="55.9399406" lon="-4.3139041">
+<ele>101.0></ele>
+<accuracy>4.731</accuracy>
+<speed>1.0225927</speed>
+<bearing>338.77158</bearing>
+<bearingAccuracyDegrees>10.5641985</bearingAccuracyDegrees>
+<time>1746105445437</time>
+</trkpt>
+<trkpt lat="55.9399554" lon="-4.3139157">
+<ele>101.0></ele>
+<accuracy>4.829</accuracy>
+<speed>1.0634067</speed>
+<bearing>337.60284</bearing>
+<bearingAccuracyDegrees>12.759358</bearingAccuracyDegrees>
+<time>1746105446441</time>
+</trkpt>
+<trkpt lat="55.9399707" lon="-4.3139231">
+<ele>101.0></ele>
+<accuracy>4.938</accuracy>
+<speed>1.2494394</speed>
+<bearing>339.9322</bearing>
+<bearingAccuracyDegrees>10.285346</bearingAccuracyDegrees>
+<time>1746105447483</time>
+</trkpt>
+<trkpt lat="55.9399886" lon="-4.3139314">
+<ele>101.0></ele>
+<accuracy>4.976</accuracy>
+<speed>1.3802705</speed>
+<bearing>343.52393</bearing>
+<bearingAccuracyDegrees>11.833028</bearingAccuracyDegrees>
+<time>1746105448528</time>
+</trkpt>
+<trkpt lat="55.9400045" lon="-4.3139379">
+<ele>101.0></ele>
+<accuracy>4.927</accuracy>
+<speed>1.2605467</speed>
+<bearing>338.67676</bearing>
+<bearingAccuracyDegrees>11.950942</bearingAccuracyDegrees>
+<time>1746105449562</time>
+</trkpt>
+<trkpt lat="55.9400189" lon="-4.3139477">
+<ele>101.0></ele>
+<accuracy>4.895</accuracy>
+<speed>1.2885011</speed>
+<bearing>334.08475</bearing>
+<bearingAccuracyDegrees>11.895203</bearingAccuracyDegrees>
+<time>1746105450539</time>
+</trkpt>
+<trkpt lat="55.9400415" lon="-4.3139714">
+<ele>101.0></ele>
+<accuracy>4.57</accuracy>
+<speed>1.3873103</speed>
+<bearing>333.18622</bearing>
+<bearingAccuracyDegrees>10.157042</bearingAccuracyDegrees>
+<time>1746105451541</time>
+</trkpt>
+<trkpt lat="55.9400591" lon="-4.3139863">
+<ele>101.0></ele>
+<accuracy>4.375</accuracy>
+<speed>1.4405462</speed>
+<bearing>335.78702</bearing>
+<bearingAccuracyDegrees>12.223273</bearingAccuracyDegrees>
+<time>1746105452544</time>
+</trkpt>
+<trkpt lat="55.9400762" lon="-4.3139982">
+<ele>101.0></ele>
+<accuracy>4.307</accuracy>
+<speed>1.4948025</speed>
+<bearing>336.18024</bearing>
+<bearingAccuracyDegrees>12.464897</bearingAccuracyDegrees>
+<time>1746105453546</time>
+</trkpt>
+<trkpt lat="55.9400931" lon="-4.3140087">
+<ele>101.0></ele>
+<accuracy>4.327</accuracy>
+<speed>1.5190849</speed>
+<bearing>334.9925</bearing>
+<bearingAccuracyDegrees>12.269718</bearingAccuracyDegrees>
+<time>1746105454548</time>
+</trkpt>
+<trkpt lat="55.9401095" lon="-4.3140179">
+<ele>101.0></ele>
+<accuracy>4.397</accuracy>
+<speed>1.5453985</speed>
+<bearing>335.05533</bearing>
+<bearingAccuracyDegrees>12.061498</bearingAccuracyDegrees>
+<time>1746105455549</time>
+</trkpt>
+<trkpt lat="55.9401255" lon="-4.3140263">
+<ele>101.0></ele>
+<accuracy>4.589</accuracy>
+<speed>1.550116</speed>
+<bearing>334.71725</bearing>
+<bearingAccuracyDegrees>10.387973</bearingAccuracyDegrees>
+<time>1746105456553</time>
+</trkpt>
+<trkpt lat="55.9401427" lon="-4.3140344">
+<ele>101.0></ele>
+<accuracy>4.762</accuracy>
+<speed>1.5579361</speed>
+<bearing>338.14124</bearing>
+<bearingAccuracyDegrees>9.936174</bearingAccuracyDegrees>
+<time>1746105457554</time>
+</trkpt>
+<trkpt lat="55.9401612" lon="-4.3140435">
+<ele>101.0></ele>
+<accuracy>4.87</accuracy>
+<speed>1.5749192</speed>
+<bearing>340.05112</bearing>
+<bearingAccuracyDegrees>10.194569</bearingAccuracyDegrees>
+<time>1746105458557</time>
+</trkpt>
+<trkpt lat="55.9401788" lon="-4.3140533">
+<ele>101.0></ele>
+<accuracy>4.913</accuracy>
+<speed>1.5666212</speed>
+<bearing>340.61307</bearing>
+<bearingAccuracyDegrees>9.831296</bearingAccuracyDegrees>
+<time>1746105459560</time>
+</trkpt>
+<trkpt lat="55.9401958" lon="-4.3140614">
+<ele>101.0></ele>
+<accuracy>4.897</accuracy>
+<speed>1.5479236</speed>
+<bearing>341.69733</bearing>
+<bearingAccuracyDegrees>9.287957</bearingAccuracyDegrees>
+<time>1746105460562</time>
+</trkpt>
+<trkpt lat="55.9402108" lon="-4.3140681">
+<ele>101.0></ele>
+<accuracy>4.827</accuracy>
+<speed>1.5099224</speed>
+<bearing>342.34146</bearing>
+<bearingAccuracyDegrees>9.678516</bearingAccuracyDegrees>
+<time>1746105461563</time>
+</trkpt>
+<trkpt lat="55.940225" lon="-4.3140741">
+<ele>101.0></ele>
+<accuracy>4.744</accuracy>
+<speed>1.4902798</speed>
+<bearing>342.7678</bearing>
+<bearingAccuracyDegrees>9.890328</bearingAccuracyDegrees>
+<time>1746105462567</time>
+</trkpt>
+<trkpt lat="55.9402367" lon="-4.3140788">
+<ele>101.0></ele>
+<accuracy>4.709</accuracy>
+<speed>1.4456276</speed>
+<bearing>344.57886</bearing>
+<bearingAccuracyDegrees>11.582305</bearingAccuracyDegrees>
+<time>1746105463542</time>
+</trkpt>
+<trkpt lat="55.9402413" lon="-4.3140631">
+<ele>101.0></ele>
+<accuracy>4.291</accuracy>
+<speed>1.1174514</speed>
+<bearing>347.55948</bearing>
+<bearingAccuracyDegrees>9.236383</bearingAccuracyDegrees>
+<time>1746105465145</time>
+</trkpt>
+<trkpt lat="55.9402573" lon="-4.3140697">
+<ele>101.0></ele>
+<accuracy>3.953</accuracy>
+<speed>1.3547302</speed>
+<bearing>345.00232</bearing>
+<bearingAccuracyDegrees>10.230093</bearingAccuracyDegrees>
+<time>1746105466170</time>
+</trkpt>
+<trkpt lat="55.9402783" lon="-4.3140865">
+<ele>101.0></ele>
+<accuracy>3.632</accuracy>
+<speed>1.3194841</speed>
+<bearing>341.51688</bearing>
+<bearingAccuracyDegrees>9.945075</bearingAccuracyDegrees>
+<time>1746105467200</time>
+</trkpt>
+<trkpt lat="55.9402996" lon="-4.3141011">
+<ele>101.0></ele>
+<accuracy>3.3</accuracy>
+<speed>1.3924651</speed>
+<bearing>342.35397</bearing>
+<bearingAccuracyDegrees>9.363889</bearingAccuracyDegrees>
+<time>1746105468262</time>
+</trkpt>
+<trkpt lat="55.940319" lon="-4.314113">
+<ele>101.0></ele>
+<accuracy>3.028</accuracy>
+<speed>1.4468975</speed>
+<bearing>342.43866</bearing>
+<bearingAccuracyDegrees>8.975741</bearingAccuracyDegrees>
+<time>1746105469305</time>
+</trkpt>
+<trkpt lat="55.9403347" lon="-4.3141262">
+<ele>101.19999694824219></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4509573</speed>
+<bearing>342.4295</bearing>
+<bearingAccuracyDegrees>8.880448</bearingAccuracyDegrees>
+<time>1746105470349</time>
+</trkpt>
+<trkpt lat="55.9403505" lon="-4.3141384">
+<ele>101.19999694824219></ele>
+<accuracy>3.021</accuracy>
+<speed>1.456572</speed>
+<bearing>341.02744</bearing>
+<bearingAccuracyDegrees>8.707676</bearingAccuracyDegrees>
+<time>1746105471438</time>
+</trkpt>
+<trkpt lat="55.9403656" lon="-4.3141507">
+<ele>101.19999694824219></ele>
+<accuracy>3.099</accuracy>
+<speed>1.4590193</speed>
+<bearing>338.68106</bearing>
+<bearingAccuracyDegrees>9.300132</bearingAccuracyDegrees>
+<time>1746105472464</time>
+</trkpt>
+<trkpt lat="55.9403798" lon="-4.3141623">
+<ele>101.19999694824219></ele>
+<accuracy>3.269</accuracy>
+<speed>1.4370017</speed>
+<bearing>337.9766</bearing>
+<bearingAccuracyDegrees>9.78908</bearingAccuracyDegrees>
+<time>1746105473504</time>
+</trkpt>
+<trkpt lat="55.9403937" lon="-4.3141717">
+<ele>101.19999694824219></ele>
+<accuracy>3.481</accuracy>
+<speed>1.3994985</speed>
+<bearing>338.68695</bearing>
+<bearingAccuracyDegrees>9.9631195</bearingAccuracyDegrees>
+<time>1746105474566</time>
+</trkpt>
+<trkpt lat="55.9404089" lon="-4.3141812">
+<ele>101.0></ele>
+<accuracy>3.782</accuracy>
+<speed>1.4280144</speed>
+<bearing>339.3038</bearing>
+<bearingAccuracyDegrees>9.773954</bearingAccuracyDegrees>
+<time>1746105475635</time>
+</trkpt>
+<trkpt lat="55.9404215" lon="-4.3141895">
+<ele>103.0></ele>
+<accuracy>3.975</accuracy>
+<speed>1.4462552</speed>
+<bearing>342.38196</bearing>
+<bearingAccuracyDegrees>9.648327</bearingAccuracyDegrees>
+<time>1746105476599</time>
+</trkpt>
+<trkpt lat="55.9404363" lon="-4.314196">
+<ele>103.0></ele>
+<accuracy>4.113</accuracy>
+<speed>1.465329</speed>
+<bearing>342.59998</bearing>
+<bearingAccuracyDegrees>10.421096</bearingAccuracyDegrees>
+<time>1746105477601</time>
+</trkpt>
+<trkpt lat="55.9404498" lon="-4.3142011">
+<ele>103.0></ele>
+<accuracy>4.237</accuracy>
+<speed>1.4497348</speed>
+<bearing>338.628</bearing>
+<bearingAccuracyDegrees>11.841583</bearingAccuracyDegrees>
+<time>1746105478604</time>
+</trkpt>
+<trkpt lat="55.9404623" lon="-4.3142053">
+<ele>103.0></ele>
+<accuracy>4.35</accuracy>
+<speed>1.4348838</speed>
+<bearing>343.73175</bearing>
+<bearingAccuracyDegrees>10.171999</bearingAccuracyDegrees>
+<time>1746105479606</time>
+</trkpt>
+<trkpt lat="55.9404742" lon="-4.3142045">
+<ele>103.0></ele>
+<accuracy>4.448</accuracy>
+<speed>1.4133627</speed>
+<bearing>347.24512</bearing>
+<bearingAccuracyDegrees>10.269164</bearingAccuracyDegrees>
+<time>1746105480508</time>
+</trkpt>
+<trkpt lat="55.9404863" lon="-4.3142042">
+<ele>103.0></ele>
+<accuracy>4.493</accuracy>
+<speed>1.4025698</speed>
+<bearing>347.79227</bearing>
+<bearingAccuracyDegrees>11.968811</bearingAccuracyDegrees>
+<time>1746105481463</time>
+</trkpt>
+<trkpt lat="55.9404964" lon="-4.3141957">
+<ele>103.0></ele>
+<accuracy>4.177</accuracy>
+<speed>1.3625541</speed>
+<bearing>346.18274</bearing>
+<bearingAccuracyDegrees>9.999556</bearingAccuracyDegrees>
+<time>1746105483568</time>
+</trkpt>
+<trkpt lat="55.9405092" lon="-4.3142044">
+<ele>103.0></ele>
+<accuracy>3.812</accuracy>
+<speed>1.32237</speed>
+<bearing>342.96683</bearing>
+<bearingAccuracyDegrees>9.50324</bearingAccuracyDegrees>
+<time>1746105485161</time>
+</trkpt>
+<trkpt lat="55.9405219" lon="-4.3142141">
+<ele>103.0></ele>
+<accuracy>3.503</accuracy>
+<speed>1.3458194</speed>
+<bearing>341.3813</bearing>
+<bearingAccuracyDegrees>9.572616</bearingAccuracyDegrees>
+<time>1746105486183</time>
+</trkpt>
+<trkpt lat="55.9405343" lon="-4.3142244">
+<ele>102.9000015258789></ele>
+<accuracy>3.236</accuracy>
+<speed>1.3477597</speed>
+<bearing>340.5133</bearing>
+<bearingAccuracyDegrees>9.660238</bearingAccuracyDegrees>
+<time>1746105487246</time>
+</trkpt>
+<trkpt lat="55.9405441" lon="-4.3142311">
+<ele>102.9000015258789></ele>
+<accuracy>3.143</accuracy>
+<speed>1.3110877</speed>
+<bearing>341.3394</bearing>
+<bearingAccuracyDegrees>9.739445</bearingAccuracyDegrees>
+<time>1746105488288</time>
+</trkpt>
+<trkpt lat="55.9405548" lon="-4.3142387">
+<ele>102.9000015258789></ele>
+<accuracy>3.1</accuracy>
+<speed>1.2144378</speed>
+<bearing>340.22287</bearing>
+<bearingAccuracyDegrees>10.0490465</bearingAccuracyDegrees>
+<time>1746105489322</time>
+</trkpt>
+<trkpt lat="55.9405687" lon="-4.3142473">
+<ele>102.9000015258789></ele>
+<accuracy>3.103</accuracy>
+<speed>1.0788621</speed>
+<bearing>343.34958</bearing>
+<bearingAccuracyDegrees>9.743874</bearingAccuracyDegrees>
+<time>1746105490363</time>
+</trkpt>
+<trkpt lat="55.9405847" lon="-4.3142577">
+<ele>102.9000015258789></ele>
+<accuracy>3.107</accuracy>
+<speed>1.1971674</speed>
+<bearing>342.27325</bearing>
+<bearingAccuracyDegrees>9.527</bearingAccuracyDegrees>
+<time>1746105491430</time>
+</trkpt>
+<trkpt lat="55.9406002" lon="-4.3142691">
+<ele>102.9000015258789></ele>
+<accuracy>3.096</accuracy>
+<speed>1.1888888</speed>
+<bearing>337.80948</bearing>
+<bearingAccuracyDegrees>9.266456</bearingAccuracyDegrees>
+<time>1746105492451</time>
+</trkpt>
+<trkpt lat="55.9406116" lon="-4.3142796">
+<ele>102.9000015258789></ele>
+<accuracy>3.115</accuracy>
+<speed>1.1411098</speed>
+<bearing>336.4208</bearing>
+<bearingAccuracyDegrees>9.286495</bearingAccuracyDegrees>
+<time>1746105493483</time>
+</trkpt>
+<trkpt lat="55.9406234" lon="-4.3142899">
+<ele>102.9000015258789></ele>
+<accuracy>3.214</accuracy>
+<speed>1.1437631</speed>
+<bearing>333.52267</bearing>
+<bearingAccuracyDegrees>10.2594185</bearingAccuracyDegrees>
+<time>1746105494543</time>
+</trkpt>
+<trkpt lat="55.9406358" lon="-4.3143049">
+<ele>102.9000015258789></ele>
+<accuracy>3.364</accuracy>
+<speed>1.1778868</speed>
+<bearing>327.5374</bearing>
+<bearingAccuracyDegrees>11.766057</bearingAccuracyDegrees>
+<time>1746105495585</time>
+</trkpt>
+<trkpt lat="55.9406499" lon="-4.3143232">
+<ele>102.9000015258789></ele>
+<accuracy>3.574</accuracy>
+<speed>1.2917955</speed>
+<bearing>331.2188</bearing>
+<bearingAccuracyDegrees>10.347652</bearingAccuracyDegrees>
+<time>1746105496545</time>
+</trkpt>
+<trkpt lat="55.9406669" lon="-4.3143399">
+<ele>102.9000015258789></ele>
+<accuracy>3.933</accuracy>
+<speed>1.38147</speed>
+<bearing>335.837</bearing>
+<bearingAccuracyDegrees>11.845908</bearingAccuracyDegrees>
+<time>1746105497547</time>
+</trkpt>
+<trkpt lat="55.9406857" lon="-4.314354">
+<ele>102.9000015258789></ele>
+<accuracy>4.234</accuracy>
+<speed>1.423666</speed>
+<bearing>337.21317</bearing>
+<bearingAccuracyDegrees>10.70163</bearingAccuracyDegrees>
+<time>1746105498550</time>
+</trkpt>
+<trkpt lat="55.9407036" lon="-4.3143664">
+<ele>102.9000015258789></ele>
+<accuracy>4.381</accuracy>
+<speed>1.430216</speed>
+<bearing>338.49664</bearing>
+<bearingAccuracyDegrees>10.314948</bearingAccuracyDegrees>
+<time>1746105499552</time>
+</trkpt>
+<trkpt lat="55.9407219" lon="-4.3143809">
+<ele>102.9000015258789></ele>
+<accuracy>4.542</accuracy>
+<speed>1.474413</speed>
+<bearing>333.43796</bearing>
+<bearingAccuracyDegrees>9.954141</bearingAccuracyDegrees>
+<time>1746105500554</time>
+</trkpt>
+<trkpt lat="55.9407399" lon="-4.3144007">
+<ele>102.9000015258789></ele>
+<accuracy>4.606</accuracy>
+<speed>1.5019454</speed>
+<bearing>328.33765</bearing>
+<bearingAccuracyDegrees>9.525796</bearingAccuracyDegrees>
+<time>1746105501556</time>
+</trkpt>
+<trkpt lat="55.9407562" lon="-4.3144185">
+<ele>102.9000015258789></ele>
+<accuracy>4.591</accuracy>
+<speed>1.5171539</speed>
+<bearing>334.46964</bearing>
+<bearingAccuracyDegrees>9.571665</bearingAccuracyDegrees>
+<time>1746105502559</time>
+</trkpt>
+<trkpt lat="55.9407723" lon="-4.3144323">
+<ele>102.9000015258789></ele>
+<accuracy>4.532</accuracy>
+<speed>1.4880062</speed>
+<bearing>333.9049</bearing>
+<bearingAccuracyDegrees>10.0302725</bearingAccuracyDegrees>
+<time>1746105503561</time>
+</trkpt>
+<trkpt lat="55.9407892" lon="-4.3144451">
+<ele>102.9000015258789></ele>
+<accuracy>4.468</accuracy>
+<speed>1.5064429</speed>
+<bearing>332.06058</bearing>
+<bearingAccuracyDegrees>10.028615</bearingAccuracyDegrees>
+<time>1746105504562</time>
+</trkpt>
+<trkpt lat="55.9408124" lon="-4.3144517">
+<ele>102.9000015258789></ele>
+<accuracy>4.277</accuracy>
+<speed>1.5077356</speed>
+<bearing>335.6841</bearing>
+<bearingAccuracyDegrees>8.671726</bearingAccuracyDegrees>
+<time>1746105505467</time>
+</trkpt>
+<trkpt lat="55.9408338" lon="-4.3144605">
+<ele>102.9000015258789></ele>
+<accuracy>3.939</accuracy>
+<speed>1.4862493</speed>
+<bearing>336.3153</bearing>
+<bearingAccuracyDegrees>7.1043353</bearingAccuracyDegrees>
+<time>1746105506534</time>
+</trkpt>
+<trkpt lat="55.9408509" lon="-4.3144679">
+<ele>102.9000015258789></ele>
+<accuracy>3.653</accuracy>
+<speed>1.4521087</speed>
+<bearing>334.23416</bearing>
+<bearingAccuracyDegrees>9.673324</bearingAccuracyDegrees>
+<time>1746105507563</time>
+</trkpt>
+<trkpt lat="55.9408673" lon="-4.3144738">
+<ele>102.9000015258789></ele>
+<accuracy>3.37</accuracy>
+<speed>1.4451146</speed>
+<bearing>337.36234</bearing>
+<bearingAccuracyDegrees>9.406556</bearingAccuracyDegrees>
+<time>1746105508626</time>
+</trkpt>
+<trkpt lat="55.9408783" lon="-4.3144701">
+<ele>102.9000015258789></ele>
+<accuracy>3.085</accuracy>
+<speed>1.4390303</speed>
+<bearing>341.78873</bearing>
+<bearingAccuracyDegrees>10.364977</bearingAccuracyDegrees>
+<time>1746105509575</time>
+</trkpt>
+<trkpt lat="55.9408899" lon="-4.3144679">
+<ele>102.9000015258789></ele>
+<accuracy>3.011</accuracy>
+<speed>1.4360868</speed>
+<bearing>343.4054</bearing>
+<bearingAccuracyDegrees>12.027276</bearingAccuracyDegrees>
+<time>1746105510577</time>
+</trkpt>
+<trkpt lat="55.9409003" lon="-4.3144635">
+<ele>102.9000015258789></ele>
+<accuracy>3.005</accuracy>
+<speed>1.4304751</speed>
+<bearing>345.67117</bearing>
+<bearingAccuracyDegrees>11.8618355</bearingAccuracyDegrees>
+<time>1746105511580</time>
+</trkpt>
+<trkpt lat="55.9409094" lon="-4.3144618">
+<ele>102.9000015258789></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4081985</speed>
+<bearing>346.6024</bearing>
+<bearingAccuracyDegrees>11.9585905</bearingAccuracyDegrees>
+<time>1746105512582</time>
+</trkpt>
+<trkpt lat="55.9409194" lon="-4.3144633">
+<ele>103.0></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4116213</speed>
+<bearing>347.64053</bearing>
+<bearingAccuracyDegrees>12.014959</bearingAccuracyDegrees>
+<time>1746105513584</time>
+</trkpt>
+<trkpt lat="55.9409333" lon="-4.3144688">
+<ele>103.0></ele>
+<accuracy>3.042</accuracy>
+<speed>1.3974175</speed>
+<bearing>346.14816</bearing>
+<bearingAccuracyDegrees>12.251442</bearingAccuracyDegrees>
+<time>1746105514585</time>
+</trkpt>
+<trkpt lat="55.9409465" lon="-4.3144745">
+<ele>103.0></ele>
+<accuracy>3.184</accuracy>
+<speed>1.3972038</speed>
+<bearing>344.73254</bearing>
+<bearingAccuracyDegrees>12.406372</bearingAccuracyDegrees>
+<time>1746105515589</time>
+</trkpt>
+<trkpt lat="55.9409578" lon="-4.3144802">
+<ele>103.0></ele>
+<accuracy>3.33</accuracy>
+<speed>1.3874857</speed>
+<bearing>346.39883</bearing>
+<bearingAccuracyDegrees>12.558712</bearingAccuracyDegrees>
+<time>1746105516503</time>
+</trkpt>
+<trkpt lat="55.9409703" lon="-4.3144845">
+<ele>103.0></ele>
+<accuracy>3.601</accuracy>
+<speed>1.3864976</speed>
+<bearing>347.00024</bearing>
+<bearingAccuracyDegrees>12.36191</bearingAccuracyDegrees>
+<time>1746105517547</time>
+</trkpt>
+<trkpt lat="55.9409833" lon="-4.3144884">
+<ele>103.0></ele>
+<accuracy>4.079</accuracy>
+<speed>1.3786597</speed>
+<bearing>349.27048</bearing>
+<bearingAccuracyDegrees>12.460768</bearingAccuracyDegrees>
+<time>1746105518614</time>
+</trkpt>
+<trkpt lat="55.9409936" lon="-4.3144915">
+<ele>103.0></ele>
+<accuracy>4.403</accuracy>
+<speed>1.3720875</speed>
+<bearing>349.01044</bearing>
+<bearingAccuracyDegrees>12.621354</bearingAccuracyDegrees>
+<time>1746105519598</time>
+</trkpt>
+<trkpt lat="55.9410059" lon="-4.3144974">
+<ele>103.0></ele>
+<accuracy>4.635</accuracy>
+<speed>1.3984454</speed>
+<bearing>346.23434</bearing>
+<bearingAccuracyDegrees>12.552831</bearingAccuracyDegrees>
+<time>1746105520600</time>
+</trkpt>
+<trkpt lat="55.941017" lon="-4.3145069">
+<ele>103.0></ele>
+<accuracy>4.866</accuracy>
+<speed>1.4182146</speed>
+<bearing>342.63422</bearing>
+<bearingAccuracyDegrees>12.509827</bearingAccuracyDegrees>
+<time>1746105521603</time>
+</trkpt>
+<trkpt lat="55.9410274" lon="-4.3145156">
+<ele>103.0></ele>
+<accuracy>5.019</accuracy>
+<speed>1.4035554</speed>
+<bearing>345.04892</bearing>
+<bearingAccuracyDegrees>11.981052</bearingAccuracyDegrees>
+<time>1746105522605</time>
+</trkpt>
+<trkpt lat="55.9410373" lon="-4.3145213">
+<ele>103.0></ele>
+<accuracy>5.154</accuracy>
+<speed>1.4036117</speed>
+<bearing>346.7631</bearing>
+<bearingAccuracyDegrees>11.530243</bearingAccuracyDegrees>
+<time>1746105523507</time>
+</trkpt>
+<trkpt lat="55.9410634" lon="-4.3145344">
+<ele>103.0></ele>
+<accuracy>5.267</accuracy>
+<speed>1.424587</speed>
+<bearing>342.92233</bearing>
+<bearingAccuracyDegrees>10.061374</bearingAccuracyDegrees>
+<time>1746105524610</time>
+</trkpt>
+<trkpt lat="55.9410743" lon="-4.3145421">
+<ele>103.0></ele>
+<accuracy>5.348</accuracy>
+<speed>1.4104601</speed>
+<bearing>342.65298</bearing>
+<bearingAccuracyDegrees>10.143963</bearingAccuracyDegrees>
+<time>1746105525611</time>
+</trkpt>
+<trkpt lat="55.9410855" lon="-4.3145491">
+<ele>103.0></ele>
+<accuracy>5.401</accuracy>
+<speed>1.4267697</speed>
+<bearing>343.0948</bearing>
+<bearingAccuracyDegrees>10.108929</bearingAccuracyDegrees>
+<time>1746105526614</time>
+</trkpt>
+<trkpt lat="55.9410981" lon="-4.314555">
+<ele>103.0></ele>
+<accuracy>5.429</accuracy>
+<speed>1.4393792</speed>
+<bearing>341.94415</bearing>
+<bearingAccuracyDegrees>10.056256</bearingAccuracyDegrees>
+<time>1746105527615</time>
+</trkpt>
+<trkpt lat="55.9411116" lon="-4.3145641">
+<ele>103.0></ele>
+<accuracy>5.461</accuracy>
+<speed>1.4538949</speed>
+<bearing>342.4729</bearing>
+<bearingAccuracyDegrees>10.263917</bearingAccuracyDegrees>
+<time>1746105528517</time>
+</trkpt>
+<trkpt lat="55.9411667" lon="-4.3146028">
+<ele>103.0></ele>
+<accuracy>5.425</accuracy>
+<speed>1.4763312</speed>
+<bearing>343.23026</bearing>
+<bearingAccuracyDegrees>12.224351</bearingAccuracyDegrees>
+<time>1746105532590</time>
+</trkpt>
+<trkpt lat="55.9411811" lon="-4.3146087">
+<ele>103.0></ele>
+<accuracy>5.394</accuracy>
+<speed>1.4724945</speed>
+<bearing>343.81927</bearing>
+<bearingAccuracyDegrees>12.175443</bearingAccuracyDegrees>
+<time>1746105533631</time>
+</trkpt>
+<trkpt lat="55.941192" lon="-4.3146161">
+<ele>103.0></ele>
+<accuracy>5.33</accuracy>
+<speed>1.4407048</speed>
+<bearing>342.16397</bearing>
+<bearingAccuracyDegrees>11.763837</bearingAccuracyDegrees>
+<time>1746105534532</time>
+</trkpt>
+<trkpt lat="55.9412027" lon="-4.3146222">
+<ele>103.19999694824219></ele>
+<accuracy>5.261</accuracy>
+<speed>1.4498644</speed>
+<bearing>343.1758</bearing>
+<bearingAccuracyDegrees>11.646304</bearingAccuracyDegrees>
+<time>1746105535434</time>
+</trkpt>
+<trkpt lat="55.9412235" lon="-4.3146358">
+<ele>103.19999694824219></ele>
+<accuracy>5.158</accuracy>
+<speed>1.460251</speed>
+<bearing>340.4559</bearing>
+<bearingAccuracyDegrees>10.13043</bearingAccuracyDegrees>
+<time>1746105536537</time>
+</trkpt>
+<trkpt lat="55.9412373" lon="-4.3146447">
+<ele>103.19999694824219></ele>
+<accuracy>5.08</accuracy>
+<speed>1.469235</speed>
+<bearing>340.05716</bearing>
+<bearingAccuracyDegrees>11.5332775</bearingAccuracyDegrees>
+<time>1746105537539</time>
+</trkpt>
+<trkpt lat="55.9412509" lon="-4.3146528">
+<ele>103.19999694824219></ele>
+<accuracy>5.032</accuracy>
+<speed>1.4631996</speed>
+<bearing>338.98865</bearing>
+<bearingAccuracyDegrees>10.282037</bearingAccuracyDegrees>
+<time>1746105538542</time>
+</trkpt>
+<trkpt lat="55.9412642" lon="-4.3146612">
+<ele>103.19999694824219></ele>
+<accuracy>5.004</accuracy>
+<speed>1.4652623</speed>
+<bearing>341.20096</bearing>
+<bearingAccuracyDegrees>11.857104</bearingAccuracyDegrees>
+<time>1746105539544</time>
+</trkpt>
+<trkpt lat="55.9412773" lon="-4.314667">
+<ele>103.0></ele>
+<accuracy>5.015</accuracy>
+<speed>1.4481207</speed>
+<bearing>343.02728</bearing>
+<bearingAccuracyDegrees>12.546293</bearingAccuracyDegrees>
+<time>1746105540546</time>
+</trkpt>
+<trkpt lat="55.941291" lon="-4.3146718">
+<ele>103.0></ele>
+<accuracy>5.045</accuracy>
+<speed>1.4406306</speed>
+<bearing>343.8923</bearing>
+<bearingAccuracyDegrees>11.953752</bearingAccuracyDegrees>
+<time>1746105541547</time>
+</trkpt>
+<trkpt lat="55.9413027" lon="-4.3146772">
+<ele>103.0></ele>
+<accuracy>5.072</accuracy>
+<speed>1.4058025</speed>
+<bearing>341.53824</bearing>
+<bearingAccuracyDegrees>12.59225</bearingAccuracyDegrees>
+<time>1746105542503</time>
+</trkpt>
+<trkpt lat="55.9413111" lon="-4.3146838">
+<ele>103.0></ele>
+<accuracy>5.058</accuracy>
+<speed>1.2056829</speed>
+<bearing>341.91748</bearing>
+<bearingAccuracyDegrees>12.061998</bearingAccuracyDegrees>
+<time>1746105543526</time>
+</trkpt>
+<trkpt lat="55.9413195" lon="-4.3146931">
+<ele>103.0></ele>
+<accuracy>4.923</accuracy>
+<speed>0.8291164</speed>
+<bearing>334.9938</bearing>
+<bearingAccuracyDegrees>12.308556</bearingAccuracyDegrees>
+<time>1746105545112</time>
+</trkpt>
+<trkpt lat="55.9413247" lon="-4.3147076">
+<ele>103.30000305175781></ele>
+<accuracy>4.703</accuracy>
+<speed>0.72193706</speed>
+<bearing>299.0624</bearing>
+<bearingAccuracyDegrees>12.925018</bearingAccuracyDegrees>
+<time>1746105547165</time>
+</trkpt>
+<trkpt lat="55.9413285" lon="-4.3147239">
+<ele>103.30000305175781></ele>
+<accuracy>4.623</accuracy>
+<speed>0.6671725</speed>
+<bearing>286.29932</bearing>
+<bearingAccuracyDegrees>12.356933</bearingAccuracyDegrees>
+<time>1746105548188</time>
+</trkpt>
+<trkpt lat="55.9413341" lon="-4.3147491">
+<ele>103.30000305175781></ele>
+<accuracy>4.575</accuracy>
+<speed>0.78601897</speed>
+<bearing>282.35147</bearing>
+<bearingAccuracyDegrees>11.98231</bearingAccuracyDegrees>
+<time>1746105549270</time>
+</trkpt>
+<trkpt lat="55.941341" lon="-4.3147828">
+<ele>103.30000305175781></ele>
+<accuracy>4.537</accuracy>
+<speed>1.0994532</speed>
+<bearing>278.57245</bearing>
+<bearingAccuracyDegrees>12.585636</bearingAccuracyDegrees>
+<time>1746105550415</time>
+</trkpt>
+<trkpt lat="55.9413477" lon="-4.314816">
+<ele>103.0></ele>
+<accuracy>4.528</accuracy>
+<speed>1.2389582</speed>
+<bearing>293.18073</bearing>
+<bearingAccuracyDegrees>11.99262</bearingAccuracyDegrees>
+<time>1746105551522</time>
+</trkpt>
+<trkpt lat="55.9413589" lon="-4.3148433">
+<ele>103.0></ele>
+<accuracy>4.538</accuracy>
+<speed>1.2901437</speed>
+<bearing>321.4339</bearing>
+<bearingAccuracyDegrees>12.246475</bearingAccuracyDegrees>
+<time>1746105552588</time>
+</trkpt>
+<trkpt lat="55.9413718" lon="-4.3148607">
+<ele>103.0></ele>
+<accuracy>4.588</accuracy>
+<speed>1.2872435</speed>
+<bearing>332.2508</bearing>
+<bearingAccuracyDegrees>12.745884</bearingAccuracyDegrees>
+<time>1746105553610</time>
+</trkpt>
+<trkpt lat="55.9413821" lon="-4.3148715">
+<ele>103.0></ele>
+<accuracy>4.686</accuracy>
+<speed>1.2285094</speed>
+<bearing>332.2551</bearing>
+<bearingAccuracyDegrees>12.647004</bearingAccuracyDegrees>
+<time>1746105554578</time>
+</trkpt>
+<trkpt lat="55.9413916" lon="-4.3148842">
+<ele>103.0></ele>
+<accuracy>4.838</accuracy>
+<speed>1.2148632</speed>
+<bearing>333.93317</bearing>
+<bearingAccuracyDegrees>12.802396</bearingAccuracyDegrees>
+<time>1746105555580</time>
+</trkpt>
+<trkpt lat="55.9414017" lon="-4.3148958">
+<ele>103.5999984741211></ele>
+<accuracy>4.979</accuracy>
+<speed>1.1990676</speed>
+<bearing>334.9984</bearing>
+<bearingAccuracyDegrees>13.120453</bearingAccuracyDegrees>
+<time>1746105556582</time>
+</trkpt>
+<trkpt lat="55.9414103" lon="-4.3149023">
+<ele>103.5999984741211></ele>
+<accuracy>5.072</accuracy>
+<speed>1.1706516</speed>
+<bearing>335.60538</bearing>
+<bearingAccuracyDegrees>12.93879</bearingAccuracyDegrees>
+<time>1746105557585</time>
+</trkpt>
+<trkpt lat="55.9414201" lon="-4.3149088">
+<ele>103.5999984741211></ele>
+<accuracy>4.877</accuracy>
+<speed>1.1777387</speed>
+<bearing>340.47934</bearing>
+<bearingAccuracyDegrees>11.997296</bearingAccuracyDegrees>
+<time>1746105558588</time>
+</trkpt>
+<trkpt lat="55.9414656" lon="-4.3149077">
+<ele>103.5999984741211></ele>
+<accuracy>3.435</accuracy>
+<speed>1.063238</speed>
+<bearing>30.208004</bearing>
+<bearingAccuracyDegrees>9.990065</bearingAccuracyDegrees>
+<time>1746105562597</time>
+</trkpt>
+<trkpt lat="55.9414754" lon="-4.3148993">
+<ele>103.5999984741211></ele>
+<accuracy>3.273</accuracy>
+<speed>1.0974866</speed>
+<bearing>36.336113</bearing>
+<bearingAccuracyDegrees>10.069454</bearingAccuracyDegrees>
+<time>1746105563599</time>
+</trkpt>
+<trkpt lat="55.9414877" lon="-4.3148933">
+<ele>103.5999984741211></ele>
+<accuracy>3.24</accuracy>
+<speed>1.1476802</speed>
+<bearing>33.877186</bearing>
+<bearingAccuracyDegrees>10.279552</bearingAccuracyDegrees>
+<time>1746105564601</time>
+</trkpt>
+<trkpt lat="55.9415026" lon="-4.3148932">
+<ele>103.5></ele>
+<accuracy>3.219</accuracy>
+<speed>1.1972605</speed>
+<bearing>28.665134</bearing>
+<bearingAccuracyDegrees>9.309793</bearingAccuracyDegrees>
+<time>1746105565604</time>
+</trkpt>
+<trkpt lat="55.9415132" lon="-4.3148843">
+<ele>103.5></ele>
+<accuracy>3.26</accuracy>
+<speed>1.2375927</speed>
+<bearing>26.102468</bearing>
+<bearingAccuracyDegrees>9.862312</bearingAccuracyDegrees>
+<time>1746105566509</time>
+</trkpt>
+<trkpt lat="55.9415302" lon="-4.3148749">
+<ele>103.5></ele>
+<accuracy>3.461</accuracy>
+<speed>1.3547516</speed>
+<bearing>20.202576</bearing>
+<bearingAccuracyDegrees>9.0669775</bearingAccuracyDegrees>
+<time>1746105567582</time>
+</trkpt>
+<trkpt lat="55.941547" lon="-4.3148684">
+<ele>103.5></ele>
+<accuracy>3.682</accuracy>
+<speed>1.415577</speed>
+<bearing>11.120566</bearing>
+<bearingAccuracyDegrees>9.360539</bearingAccuracyDegrees>
+<time>1746105568611</time>
+</trkpt>
+<trkpt lat="55.941565" lon="-4.3148678">
+<ele>103.5></ele>
+<accuracy>3.948</accuracy>
+<speed>1.4234173</speed>
+<bearing>354.28067</bearing>
+<bearingAccuracyDegrees>9.895346</bearingAccuracyDegrees>
+<time>1746105569613</time>
+</trkpt>
+<trkpt lat="55.9415832" lon="-4.3148739">
+<ele>103.5></ele>
+<accuracy>4.203</accuracy>
+<speed>1.4796901</speed>
+<bearing>355.30475</bearing>
+<bearingAccuracyDegrees>9.894795</bearingAccuracyDegrees>
+<time>1746105570607</time>
+</trkpt>
+<trkpt lat="55.9416011" lon="-4.3148792">
+<ele>103.5></ele>
+<accuracy>4.442</accuracy>
+<speed>1.4866648</speed>
+<bearing>339.51416</bearing>
+<bearingAccuracyDegrees>10.067172</bearingAccuracyDegrees>
+<time>1746105571650</time>
+</trkpt>
+<trkpt lat="55.9416154" lon="-4.314894">
+<ele>103.5></ele>
+<accuracy>4.588</accuracy>
+<speed>1.5004853</speed>
+<bearing>316.39328</bearing>
+<bearingAccuracyDegrees>11.59689</bearingAccuracyDegrees>
+<time>1746105572620</time>
+</trkpt>
+<trkpt lat="55.941628" lon="-4.3149176">
+<ele>103.5></ele>
+<accuracy>4.866</accuracy>
+<speed>1.5209354</speed>
+<bearing>305.57874</bearing>
+<bearingAccuracyDegrees>12.276422</bearingAccuracyDegrees>
+<time>1746105573622</time>
+</trkpt>
+<trkpt lat="55.9416404" lon="-4.3149492">
+<ele>103.5></ele>
+<accuracy>5.154</accuracy>
+<speed>1.5466571</speed>
+<bearing>300.44992</bearing>
+<bearingAccuracyDegrees>12.32506</bearingAccuracyDegrees>
+<time>1746105574828</time>
+</trkpt>
+<trkpt lat="55.9416491" lon="-4.3149749">
+<ele>103.5></ele>
+<accuracy>5.429</accuracy>
+<speed>1.5403488</speed>
+<bearing>295.56604</bearing>
+<bearingAccuracyDegrees>12.956364</bearingAccuracyDegrees>
+<time>1746105575870</time>
+</trkpt>
+<trkpt lat="55.9416959" lon="-4.3151049">
+<ele>103.5></ele>
+<accuracy>6.229</accuracy>
+<speed>1.4940312</speed>
+<bearing>298.4546</bearing>
+<bearingAccuracyDegrees>13.43227</bearingAccuracyDegrees>
+<time>1746105581142</time>
+</trkpt>
+<trkpt lat="55.9417044" lon="-4.3151273">
+<ele>103.5></ele>
+<accuracy>6.229</accuracy>
+<speed>1.5104306</speed>
+<bearing>301.226</bearing>
+<bearingAccuracyDegrees>12.2793</bearingAccuracyDegrees>
+<time>1746105582224</time>
+</trkpt>
+<trkpt lat="55.9417147" lon="-4.3151397">
+<ele>103.5></ele>
+<accuracy>6.143</accuracy>
+<speed>1.4861206</speed>
+<bearing>300.68765</bearing>
+<bearingAccuracyDegrees>12.290529</bearingAccuracyDegrees>
+<time>1746105583269</time>
+</trkpt>
+<trkpt lat="55.9417303" lon="-4.3151408">
+<ele>103.5></ele>
+<accuracy>5.993</accuracy>
+<speed>1.5037122</speed>
+<bearing>302.97513</bearing>
+<bearingAccuracyDegrees>10.01391</bearingAccuracyDegrees>
+<time>1746105584310</time>
+</trkpt>
+<trkpt lat="55.9417461" lon="-4.3151557">
+<ele>103.5></ele>
+<accuracy>5.736</accuracy>
+<speed>1.4442469</speed>
+<bearing>306.64355</bearing>
+<bearingAccuracyDegrees>9.798293</bearingAccuracyDegrees>
+<time>1746105585419</time>
+</trkpt>
+<trkpt lat="55.9417651" lon="-4.3151838">
+<ele>103.5></ele>
+<accuracy>5.297</accuracy>
+<speed>1.3970977</speed>
+<bearing>312.29315</bearing>
+<bearingAccuracyDegrees>9.885034</bearingAccuracyDegrees>
+<time>1746105586525</time>
+</trkpt>
+<trkpt lat="55.941845" lon="-4.3153127">
+<ele>103.5999984741211></ele>
+<accuracy>3.419</accuracy>
+<speed>0.9264684</speed>
+<bearing>312.39755</bearing>
+<bearingAccuracyDegrees>12.790115</bearingAccuracyDegrees>
+<time>1746105595604</time>
+</trkpt>
+<trkpt lat="55.941851" lon="-4.3153276">
+<ele>103.5></ele>
+<accuracy>3.74</accuracy>
+<speed>0.93174136</speed>
+<bearing>313.7133</bearing>
+<bearingAccuracyDegrees>12.853492</bearingAccuracyDegrees>
+<time>1746105597377</time>
+</trkpt>
+<trkpt lat="55.9418598" lon="-4.3153484">
+<ele>103.5></ele>
+<accuracy>4.047</accuracy>
+<speed>0.96013665</speed>
+<bearing>311.94012</bearing>
+<bearingAccuracyDegrees>12.468703</bearingAccuracyDegrees>
+<time>1746105598584</time>
+</trkpt>
+<trkpt lat="55.9418652" lon="-4.3153638">
+<ele>103.5></ele>
+<accuracy>4.212</accuracy>
+<speed>1.0084392</speed>
+<bearing>309.14426</bearing>
+<bearingAccuracyDegrees>12.407691</bearingAccuracyDegrees>
+<time>1746105599582</time>
+</trkpt>
+<trkpt lat="55.9418748" lon="-4.3153831">
+<ele>103.5></ele>
+<accuracy>4.307</accuracy>
+<speed>1.1637834</speed>
+<bearing>316.2339</bearing>
+<bearingAccuracyDegrees>9.906204</bearingAccuracyDegrees>
+<time>1746105600584</time>
+</trkpt>
+<trkpt lat="55.9418855" lon="-4.3154026">
+<ele>103.5></ele>
+<accuracy>4.417</accuracy>
+<speed>1.2476498</speed>
+<bearing>310.2688</bearing>
+<bearingAccuracyDegrees>9.9094305</bearingAccuracyDegrees>
+<time>1746105601550</time>
+</trkpt>
+<trkpt lat="55.9418943" lon="-4.3154241">
+<ele>105.27465653603623></ele>
+<accuracy>4.548</accuracy>
+<speed>1.2523913</speed>
+<bearing>309.86026</bearing>
+<bearingAccuracyDegrees>9.987451</bearingAccuracyDegrees>
+<time>1746105602589</time>
+</trkpt>
+<trkpt lat="55.9419026" lon="-4.3154481">
+<ele>105.46168629838304></ele>
+<accuracy>4.658</accuracy>
+<speed>1.2894272</speed>
+<bearing>321.69247</bearing>
+<bearingAccuracyDegrees>9.897398</bearingAccuracyDegrees>
+<time>1746105603591</time>
+</trkpt>
+<trkpt lat="55.941913" lon="-4.3154627">
+<ele>105.46168629838304></ele>
+<accuracy>4.731</accuracy>
+<speed>1.2730527</speed>
+<bearing>349.3124</bearing>
+<bearingAccuracyDegrees>9.775664</bearingAccuracyDegrees>
+<time>1746105604508</time>
+</trkpt>
+<trkpt lat="55.9419247" lon="-4.3154684">
+<ele>105.65405869328846></ele>
+<accuracy>4.864</accuracy>
+<speed>1.2755342</speed>
+<bearing>3.8040152</bearing>
+<bearingAccuracyDegrees>9.906212</bearingAccuracyDegrees>
+<time>1746105605550</time>
+</trkpt>
+<trkpt lat="55.9419352" lon="-4.3154693">
+<ele>105.9324975154159></ele>
+<accuracy>4.933</accuracy>
+<speed>1.2733886</speed>
+<bearing>5.1720653</bearing>
+<bearingAccuracyDegrees>9.646319</bearingAccuracyDegrees>
+<time>1746105606598</time>
+</trkpt>
+<trkpt lat="55.9419488" lon="-4.3154698">
+<ele>105.9652539765579></ele>
+<accuracy>4.933</accuracy>
+<speed>1.313855</speed>
+<bearing>12.027842</bearing>
+<bearingAccuracyDegrees>9.839199</bearingAccuracyDegrees>
+<time>1746105607600</time>
+</trkpt>
+<trkpt lat="55.9419586" lon="-4.3154606">
+<ele>105.97689865890071></ele>
+<accuracy>4.932</accuracy>
+<speed>1.3258445</speed>
+<bearing>30.144098</bearing>
+<bearingAccuracyDegrees>11.818284</bearingAccuracyDegrees>
+<time>1746105608602</time>
+</trkpt>
+<trkpt lat="55.9419632" lon="-4.3154405">
+<ele>106.3828905557767></ele>
+<accuracy>4.917</accuracy>
+<speed>1.2532554</speed>
+<bearing>56.12948</bearing>
+<bearingAccuracyDegrees>12.069881</bearingAccuracyDegrees>
+<time>1746105609605</time>
+</trkpt>
+<trkpt lat="55.9419629" lon="-4.3154143">
+<ele>106.3828905557767></ele>
+<accuracy>4.885</accuracy>
+<speed>1.2011136</speed>
+<bearing>75.18501</bearing>
+<bearingAccuracyDegrees>12.09181</bearingAccuracyDegrees>
+<time>1746105610607</time>
+</trkpt>
+<trkpt lat="55.9419596" lon="-4.3153896">
+<ele>106.3828905557767></ele>
+<accuracy>4.856</accuracy>
+<speed>1.2003949</speed>
+<bearing>91.39708</bearing>
+<bearingAccuracyDegrees>12.805139</bearingAccuracyDegrees>
+<time>1746105611541</time>
+</trkpt>
+<trkpt lat="55.9419541" lon="-4.3153643">
+<ele>105.95402111596111></ele>
+<accuracy>4.865</accuracy>
+<speed>1.1828599</speed>
+<bearing>103.39703</bearing>
+<bearingAccuracyDegrees>12.770618</bearingAccuracyDegrees>
+<time>1746105612612</time>
+</trkpt>
+<trkpt lat="55.9419485" lon="-4.315341">
+<ele>106.09056633211323></ele>
+<accuracy>4.827</accuracy>
+<speed>1.2034382</speed>
+<bearing>103.72959</bearing>
+<bearingAccuracyDegrees>13.1650505</bearingAccuracyDegrees>
+<time>1746105613614</time>
+</trkpt>
+<trkpt lat="55.9419448" lon="-4.3153182">
+<ele>105.88850848875727></ele>
+<accuracy>4.752</accuracy>
+<speed>1.1806974</speed>
+<bearing>103.38307</bearing>
+<bearingAccuracyDegrees>14.813957</bearingAccuracyDegrees>
+<time>1746105614615</time>
+</trkpt>
+<trkpt lat="55.9419381" lon="-4.315281">
+<ele>105.90407871099715></ele>
+<accuracy>4.447</accuracy>
+<speed>1.1829879</speed>
+<bearing>107.25741</bearing>
+<bearingAccuracyDegrees>13.309579</bearingAccuracyDegrees>
+<time>1746105615518</time>
+</trkpt>
+<trkpt lat="55.941935" lon="-4.3152546">
+<ele>105.90407871099715></ele>
+<accuracy>4.273</accuracy>
+<speed>1.203667</speed>
+<bearing>106.24665</bearing>
+<bearingAccuracyDegrees>12.999462</bearingAccuracyDegrees>
+<time>1746105616425</time>
+</trkpt>
+<trkpt lat="55.941934" lon="-4.315231">
+<ele>105.89991920954046></ele>
+<accuracy>3.928</accuracy>
+<speed>1.199765</speed>
+<bearing>105.435684</bearing>
+<bearingAccuracyDegrees>12.609468</bearingAccuracyDegrees>
+<time>1746105617546</time>
+</trkpt>
+<trkpt lat="55.9419336" lon="-4.3152111">
+<ele>106.00113675881923></ele>
+<accuracy>3.316</accuracy>
+<speed>1.0730796</speed>
+<bearing>101.54603</bearing>
+<bearingAccuracyDegrees>12.925761</bearingAccuracyDegrees>
+<time>1746105619229</time>
+</trkpt>
+<trkpt lat="55.9419316" lon="-4.3151878">
+<ele>106.0283940340695></ele>
+<accuracy>3.187</accuracy>
+<speed>1.0764741</speed>
+<bearing>98.97605</bearing>
+<bearingAccuracyDegrees>15.679677</bearingAccuracyDegrees>
+<time>1746105621625</time>
+</trkpt>
+<trkpt lat="55.9419268" lon="-4.3151705">
+<ele>106.22586809417338></ele>
+<accuracy>3.234</accuracy>
+<speed>1.0409054</speed>
+<bearing>103.79416</bearing>
+<bearingAccuracyDegrees>13.128439</bearingAccuracyDegrees>
+<time>1746105623209</time>
+</trkpt>
+<trkpt lat="55.9419241" lon="-4.3151541">
+<ele>106.25498462549741></ele>
+<accuracy>3.289</accuracy>
+<speed>1.1092452</speed>
+<bearing>103.4163</bearing>
+<bearingAccuracyDegrees>12.97213</bearingAccuracyDegrees>
+<time>1746105624321</time>
+</trkpt>
+<trkpt lat="55.9419217" lon="-4.3151342">
+<ele>106.22963128579113></ele>
+<accuracy>3.345</accuracy>
+<speed>1.199456</speed>
+<bearing>104.8538</bearing>
+<bearingAccuracyDegrees>12.802198</bearingAccuracyDegrees>
+<time>1746105625464</time>
+</trkpt>
+<trkpt lat="55.9419212" lon="-4.3151106">
+<ele>106.19247558418701></ele>
+<accuracy>3.404</accuracy>
+<speed>1.2157623</speed>
+<bearing>94.648544</bearing>
+<bearingAccuracyDegrees>12.176024</bearingAccuracyDegrees>
+<time>1746105626588</time>
+</trkpt>
+<trkpt lat="55.9419238" lon="-4.3150893">
+<ele>106.11832482077013></ele>
+<accuracy>3.466</accuracy>
+<speed>1.2553524</speed>
+<bearing>89.32181</bearing>
+<bearingAccuracyDegrees>12.053644</bearingAccuracyDegrees>
+<time>1746105627546</time>
+</trkpt>
+<trkpt lat="55.9419266" lon="-4.3150638">
+<ele>106.08016645438693></ele>
+<accuracy>3.576</accuracy>
+<speed>1.3072417</speed>
+<bearing>92.89372</bearing>
+<bearingAccuracyDegrees>11.699295</bearingAccuracyDegrees>
+<time>1746105628448</time>
+</trkpt>
+<trkpt lat="55.9419267" lon="-4.3150377">
+<ele>106.11240376592826></ele>
+<accuracy>3.687</accuracy>
+<speed>1.329381</speed>
+<bearing>96.818924</bearing>
+<bearingAccuracyDegrees>10.436336</bearingAccuracyDegrees>
+<time>1746105629406</time>
+</trkpt>
+<trkpt lat="55.941925" lon="-4.3150106">
+<ele>106.13528193130011></ele>
+<accuracy>3.748</accuracy>
+<speed>1.3272854</speed>
+<bearing>97.933754</bearing>
+<bearingAccuracyDegrees>10.125498</bearingAccuracyDegrees>
+<time>1746105630486</time>
+</trkpt>
+<trkpt lat="55.9419217" lon="-4.3149839">
+<ele>106.18727798803722></ele>
+<accuracy>3.759</accuracy>
+<speed>1.3202877</speed>
+<bearing>99.734924</bearing>
+<bearingAccuracyDegrees>10.327988</bearingAccuracyDegrees>
+<time>1746105631590</time>
+</trkpt>
+<trkpt lat="55.9419189" lon="-4.3149609">
+<ele>106.21716262505595></ele>
+<accuracy>3.765</accuracy>
+<speed>1.3090985</speed>
+<bearing>98.82744</bearing>
+<bearingAccuracyDegrees>10.11435</bearingAccuracyDegrees>
+<time>1746105632557</time>
+</trkpt>
+<trkpt lat="55.941917" lon="-4.3149306">
+<ele>106.22080238258664></ele>
+<accuracy>3.768</accuracy>
+<speed>1.3265377</speed>
+<bearing>96.2892</bearing>
+<bearingAccuracyDegrees>9.738034</bearingAccuracyDegrees>
+<time>1746105633559</time>
+</trkpt>
+<trkpt lat="55.9419144" lon="-4.3148951">
+<ele>106.32506331731616></ele>
+<accuracy>3.722</accuracy>
+<speed>1.3439565</speed>
+<bearing>93.747574</bearing>
+<bearingAccuracyDegrees>9.254297</bearingAccuracyDegrees>
+<time>1746105634562</time>
+</trkpt>
+<trkpt lat="55.9419094" lon="-4.3148598">
+<ele>106.32506331731616></ele>
+<accuracy>3.681</accuracy>
+<speed>1.3597172</speed>
+<bearing>96.201614</bearing>
+<bearingAccuracyDegrees>8.987595</bearingAccuracyDegrees>
+<time>1746105635526</time>
+</trkpt>
+<trkpt lat="55.9419016" lon="-4.3148213">
+<ele>106.7317818499985></ele>
+<accuracy>3.622</accuracy>
+<speed>1.3580813</speed>
+<bearing>107.337776</bearing>
+<bearingAccuracyDegrees>8.86596</bearingAccuracyDegrees>
+<time>1746105636567</time>
+</trkpt>
+<trkpt lat="55.9418929" lon="-4.3147895">
+<ele>106.71670279798903></ele>
+<accuracy>3.486</accuracy>
+<speed>1.3321166</speed>
+<bearing>112.45584</bearing>
+<bearingAccuracyDegrees>7.4217806</bearingAccuracyDegrees>
+<time>1746105637569</time>
+</trkpt>
+<trkpt lat="55.9418871" lon="-4.3147637">
+<ele>106.51276966704884></ele>
+<accuracy>3.354</accuracy>
+<speed>1.3101865</speed>
+<bearing>108.08815</bearing>
+<bearingAccuracyDegrees>9.092581</bearingAccuracyDegrees>
+<time>1746105638571</time>
+</trkpt>
+<trkpt lat="55.9418824" lon="-4.3147383">
+<ele>106.51276966704884></ele>
+<accuracy>3.266</accuracy>
+<speed>1.2930901</speed>
+<bearing>103.69014</bearing>
+<bearingAccuracyDegrees>9.07741</bearingAccuracyDegrees>
+<time>1746105639591</time>
+</trkpt>
+<trkpt lat="55.941879" lon="-4.3147165">
+<ele>106.33514812174285></ele>
+<accuracy>3.215</accuracy>
+<speed>1.2963897</speed>
+<bearing>105.44584</bearing>
+<bearingAccuracyDegrees>9.41339</bearingAccuracyDegrees>
+<time>1746105640576</time>
+</trkpt>
+<trkpt lat="55.9418753" lon="-4.3146942">
+<ele>106.49613071964433></ele>
+<accuracy>3.154</accuracy>
+<speed>1.2759373</speed>
+<bearing>106.08413</bearing>
+<bearingAccuracyDegrees>10.12103</bearingAccuracyDegrees>
+<time>1746105641578</time>
+</trkpt>
+<trkpt lat="55.9418732" lon="-4.3146747">
+<ele>106.33670802141025></ele>
+<accuracy>3.154</accuracy>
+<speed>1.2298427</speed>
+<bearing>103.4127</bearing>
+<bearingAccuracyDegrees>10.158646</bearingAccuracyDegrees>
+<time>1746105642580</time>
+</trkpt>
+<trkpt lat="55.9418747" lon="-4.3146533">
+<ele>106.33670802141025></ele>
+<accuracy>3.176</accuracy>
+<speed>1.2303023</speed>
+<bearing>97.067894</bearing>
+<bearingAccuracyDegrees>10.381428</bearingAccuracyDegrees>
+<time>1746105643624</time>
+</trkpt>
+<trkpt lat="55.9418819" lon="-4.3146352">
+<ele>106.36750527877602></ele>
+<accuracy>3.197</accuracy>
+<speed>1.2348719</speed>
+<bearing>92.94715</bearing>
+<bearingAccuracyDegrees>11.694599</bearingAccuracyDegrees>
+<time>1746105644585</time>
+</trkpt>
+<trkpt lat="55.9418861" lon="-4.3146189">
+<ele>106.3928341386422></ele>
+<accuracy>3.19</accuracy>
+<speed>1.2315596</speed>
+<bearing>94.345085</bearing>
+<bearingAccuracyDegrees>12.032435</bearingAccuracyDegrees>
+<time>1746105645587</time>
+</trkpt>
+<trkpt lat="55.941887" lon="-4.3146023">
+<ele>106.3928341386422></ele>
+<accuracy>3.207</accuracy>
+<speed>1.2521847</speed>
+<bearing>90.08235</bearing>
+<bearingAccuracyDegrees>12.759434</bearingAccuracyDegrees>
+<time>1746105646524</time>
+</trkpt>
+<trkpt lat="55.9418883" lon="-4.3145848">
+<ele>106.50860992717912></ele>
+<accuracy>3.234</accuracy>
+<speed>1.2627724</speed>
+<bearing>92.307556</bearing>
+<bearingAccuracyDegrees>13.056968</bearingAccuracyDegrees>
+<time>1746105647592</time>
+</trkpt>
+<trkpt lat="55.941889" lon="-4.314567">
+<ele>106.5571855708207></ele>
+<accuracy>3.253</accuracy>
+<speed>1.239719</speed>
+<bearing>87.58979</bearing>
+<bearingAccuracyDegrees>12.744319</bearingAccuracyDegrees>
+<time>1746105648786</time>
+</trkpt>
+<trkpt lat="55.9418907" lon="-4.3145447">
+<ele>106.71371139858564></ele>
+<accuracy>3.362</accuracy>
+<speed>1.2394527</speed>
+<bearing>84.37058</bearing>
+<bearingAccuracyDegrees>13.003211</bearingAccuracyDegrees>
+<time>1746105649931</time>
+</trkpt>
+<trkpt lat="55.9418929" lon="-4.3145194">
+<ele>106.71527131409988></ele>
+<accuracy>3.557</accuracy>
+<speed>1.2585582</speed>
+<bearing>84.53815</bearing>
+<bearingAccuracyDegrees>13.33163</bearingAccuracyDegrees>
+<time>1746105651124</time>
+</trkpt>
+<trkpt lat="55.9418949" lon="-4.3144933">
+<ele>106.83005631938283></ele>
+<accuracy>3.79</accuracy>
+<speed>1.282113</speed>
+<bearing>85.8687</bearing>
+<bearingAccuracyDegrees>12.703961</bearingAccuracyDegrees>
+<time>1746105652305</time>
+</trkpt>
+<trkpt lat="55.9418961" lon="-4.3144665">
+<ele>106.74542973630813></ele>
+<accuracy>4.085</accuracy>
+<speed>1.1984851</speed>
+<bearing>84.07411</bearing>
+<bearingAccuracyDegrees>13.448292</bearingAccuracyDegrees>
+<time>1746105653488</time>
+</trkpt>
+<trkpt lat="55.9418985" lon="-4.3144474">
+<ele>106.61364397487256></ele>
+<accuracy>4.476</accuracy>
+<speed>1.204633</speed>
+<bearing>82.36109</bearing>
+<bearingAccuracyDegrees>14.628914</bearingAccuracyDegrees>
+<time>1746105654407</time>
+</trkpt>
+<trkpt lat="55.9419013" lon="-4.3144279">
+<ele>106.45422127663849></ele>
+<accuracy>4.749</accuracy>
+<speed>1.195965</speed>
+<bearing>83.816986</bearing>
+<bearingAccuracyDegrees>14.514673</bearingAccuracyDegrees>
+<time>1746105655402</time>
+</trkpt>
+<trkpt lat="55.9419033" lon="-4.314407">
+<ele>106.36926666232984></ele>
+<accuracy>5.092</accuracy>
+<speed>1.1528829</speed>
+<bearing>82.60468</bearing>
+<bearingAccuracyDegrees>13.310269</bearingAccuracyDegrees>
+<time>1746105656564</time>
+</trkpt>
+<trkpt lat="55.9419059" lon="-4.3143889">
+<ele>106.41970420505766></ele>
+<accuracy>5.392</accuracy>
+<speed>1.1490438</speed>
+<bearing>81.56091</bearing>
+<bearingAccuracyDegrees>13.066923</bearingAccuracyDegrees>
+<time>1746105657614</time>
+</trkpt>
+<trkpt lat="55.941906" lon="-4.3143679">
+<ele>106.38317071286112></ele>
+<accuracy>5.598</accuracy>
+<speed>1.1410432</speed>
+<bearing>82.44287</bearing>
+<bearingAccuracyDegrees>12.886899</bearingAccuracyDegrees>
+<time>1746105658617</time>
+</trkpt>
+<trkpt lat="55.9419052" lon="-4.3143447">
+<ele>106.36029186554218></ele>
+<accuracy>5.747</accuracy>
+<speed>1.1399896</speed>
+<bearing>85.287796</bearing>
+<bearingAccuracyDegrees>12.329435</bearingAccuracyDegrees>
+<time>1746105659561</time>
+</trkpt>
+<trkpt lat="55.9419031" lon="-4.3143227">
+<ele>106.32375616221034></ele>
+<accuracy>5.816</accuracy>
+<speed>1.1823748</speed>
+<bearing>89.6757</bearing>
+<bearingAccuracyDegrees>12.172116</bearingAccuracyDegrees>
+<time>1746105660622</time>
+</trkpt>
+<trkpt lat="55.9418987" lon="-4.3142999">
+<ele>106.34014236111999></ele>
+<accuracy>5.775</accuracy>
+<speed>1.1853541</speed>
+<bearing>88.285995</bearing>
+<bearingAccuracyDegrees>12.33486</bearingAccuracyDegrees>
+<time>1746105661524</time>
+</trkpt>
+<trkpt lat="55.9418823" lon="-4.3142622">
+<ele>106.34014236111999></ele>
+<accuracy>5.414</accuracy>
+<speed>1.1560374</speed>
+<bearing>91.75768</bearing>
+<bearingAccuracyDegrees>9.712771</bearingAccuracyDegrees>
+<time>1746105662509</time>
+</trkpt>
+<trkpt lat="55.941873" lon="-4.3142299">
+<ele>106.23328156295975></ele>
+<accuracy>4.87</accuracy>
+<speed>1.1822002</speed>
+<bearing>91.14712</bearing>
+<bearingAccuracyDegrees>9.961965</bearingAccuracyDegrees>
+<time>1746105663629</time>
+</trkpt>
+<trkpt lat="55.9418667" lon="-4.3142052">
+<ele>106.75518043132575></ele>
+<accuracy>4.266</accuracy>
+<speed>1.1631628</speed>
+<bearing>92.09014</bearing>
+<bearingAccuracyDegrees>9.503414</bearingAccuracyDegrees>
+<time>1746105664531</time>
+</trkpt>
+<trkpt lat="55.9418654" lon="-4.3141879">
+<ele>106.75518043132575></ele>
+<accuracy>3.896</accuracy>
+<speed>1.1603876</speed>
+<bearing>96.72333</bearing>
+<bearingAccuracyDegrees>9.694228</bearingAccuracyDegrees>
+<time>1746105665470</time>
+</trkpt>
+<trkpt lat="55.9418598" lon="-4.3141649">
+<ele>106.71670279798903></ele>
+<accuracy>3.232</accuracy>
+<speed>1.2138261</speed>
+<bearing>102.27163</bearing>
+<bearingAccuracyDegrees>9.568432</bearingAccuracyDegrees>
+<time>1746105666567</time>
+</trkpt>
+<trkpt lat="55.9418527" lon="-4.3141415">
+<ele>106.37445939515536></ele>
+<accuracy>3.147</accuracy>
+<speed>1.2627034</speed>
+<bearing>105.233635</bearing>
+<bearingAccuracyDegrees>9.262789</bearingAccuracyDegrees>
+<time>1746105667536</time>
+</trkpt>
+<trkpt lat="55.9418473" lon="-4.3141172">
+<ele>106.33078292931638></ele>
+<accuracy>3.081</accuracy>
+<speed>1.2988036</speed>
+<bearing>105.97715</bearing>
+<bearingAccuracyDegrees>9.579292</bearingAccuracyDegrees>
+<time>1746105668540</time>
+</trkpt>
+<trkpt lat="55.9418449" lon="-4.3140959">
+<ele>106.33078292931638></ele>
+<accuracy>3.063</accuracy>
+<speed>1.2963246</speed>
+<bearing>109.44011</bearing>
+<bearingAccuracyDegrees>10.302751</bearingAccuracyDegrees>
+<time>1746105669542</time>
+</trkpt>
+<trkpt lat="55.9418442" lon="-4.3140716">
+<ele>106.17240014435697></ele>
+<accuracy>3.065</accuracy>
+<speed>1.2971886</speed>
+<bearing>105.766914</bearing>
+<bearingAccuracyDegrees>11.389199</bearingAccuracyDegrees>
+<time>1746105670460</time>
+</trkpt>
+<trkpt lat="55.9418436" lon="-4.3139711">
+<ele>106.31540369501442></ele>
+<accuracy>3.068</accuracy>
+<speed>1.2529098</speed>
+<bearing>93.06297</bearing>
+<bearingAccuracyDegrees>9.682466</bearingAccuracyDegrees>
+<time>1746105674487</time>
+</trkpt>
+<trkpt lat="55.9418449" lon="-4.3139462">
+<ele>106.27380749847688></ele>
+<accuracy>3.072</accuracy>
+<speed>1.2225069</speed>
+<bearing>80.60265</bearing>
+<bearingAccuracyDegrees>10.405505</bearingAccuracyDegrees>
+<time>1746105675556</time>
+</trkpt>
+<trkpt lat="55.9418489" lon="-4.3139227">
+<ele>106.23325140056154></ele>
+<accuracy>3.182</accuracy>
+<speed>1.2500831</speed>
+<bearing>73.06671</bearing>
+<bearingAccuracyDegrees>12.0093565</bearingAccuracyDegrees>
+<time>1746105676558</time>
+</trkpt>
+<trkpt lat="55.9418547" lon="-4.3138982">
+<ele>106.29200580970519></ele>
+<accuracy>3.332</accuracy>
+<speed>1.2231016</speed>
+<bearing>76.70665</bearing>
+<bearingAccuracyDegrees>12.239544</bearingAccuracyDegrees>
+<time>1746105677560</time>
+</trkpt>
+<trkpt lat="55.9418578" lon="-4.313875">
+<ele>106.46920213653817></ele>
+<accuracy>3.572</accuracy>
+<speed>1.155359</speed>
+<bearing>85.648895</bearing>
+<bearingAccuracyDegrees>11.821982</bearingAccuracyDegrees>
+<time>1746105678563</time>
+</trkpt>
+<trkpt lat="55.9418605" lon="-4.3138549">
+<ele>106.4858406131405></ele>
+<accuracy>3.849</accuracy>
+<speed>1.1321877</speed>
+<bearing>84.91638</bearing>
+<bearingAccuracyDegrees>11.892373</bearingAccuracyDegrees>
+<time>1746105679565</time>
+</trkpt>
+<trkpt lat="55.9418633" lon="-4.3138381">
+<ele>106.25070998471466></ele>
+<accuracy>4.023</accuracy>
+<speed>1.0859371</speed>
+<bearing>83.10078</bearing>
+<bearingAccuracyDegrees>12.452506</bearingAccuracyDegrees>
+<time>1746105680567</time>
+</trkpt>
+<trkpt lat="55.9418691" lon="-4.3138194">
+<ele>106.06892938964401></ele>
+<accuracy>4.432</accuracy>
+<speed>0.9412116</speed>
+<bearing>74.18975</bearing>
+<bearingAccuracyDegrees>12.123303</bearingAccuracyDegrees>
+<time>1746105681983</time>
+</trkpt>
+<trkpt lat="55.9418725" lon="-4.3138023">
+<ele>105.98345524481256></ele>
+<accuracy>4.649</accuracy>
+<speed>0.9443451</speed>
+<bearing>89.624115</bearing>
+<bearingAccuracyDegrees>13.337399</bearingAccuracyDegrees>
+<time>1746105683248</time>
+</trkpt>
+<trkpt lat="55.9418732" lon="-4.3137801">
+<ele>105.92217002128592></ele>
+<accuracy>4.829</accuracy>
+<speed>1.0437067</speed>
+<bearing>87.85429</bearing>
+<bearingAccuracyDegrees>12.753259</bearingAccuracyDegrees>
+<time>1746105684507</time>
+</trkpt>
+<trkpt lat="55.9418737" lon="-4.3137627">
+<ele>105.73374709042346></ele>
+<accuracy>4.916</accuracy>
+<speed>1.0628138</speed>
+<bearing>87.47633</bearing>
+<bearingAccuracyDegrees>13.247609</bearingAccuracyDegrees>
+<time>1746105685579</time>
+</trkpt>
+<trkpt lat="55.9418746" lon="-4.313746">
+<ele>105.72061014525985></ele>
+<accuracy>5.032</accuracy>
+<speed>1.1188492</speed>
+<bearing>85.05902</bearing>
+<bearingAccuracyDegrees>13.322328</bearingAccuracyDegrees>
+<time>1746105686580</time>
+</trkpt>
+<trkpt lat="55.9418792" lon="-4.3137239">
+<ele>105.78483501727919></ele>
+<accuracy>4.52</accuracy>
+<speed>1.1982652</speed>
+<bearing>86.86554</bearing>
+<bearingAccuracyDegrees>12.053353</bearingAccuracyDegrees>
+<time>1746105688549</time>
+</trkpt>
+<trkpt lat="55.9418739" lon="-4.3136988">
+<ele>105.7099648601362></ele>
+<accuracy>4.102</accuracy>
+<speed>1.2436961</speed>
+<bearing>89.02387</bearing>
+<bearingAccuracyDegrees>12.320793</bearingAccuracyDegrees>
+<time>1746105689633</time>
+</trkpt>
+<trkpt lat="55.94187" lon="-4.3136804">
+<ele>105.5602265012428></ele>
+<accuracy>3.798</accuracy>
+<speed>1.2808601</speed>
+<bearing>89.45621</bearing>
+<bearingAccuracyDegrees>12.381325</bearingAccuracyDegrees>
+<time>1746105690590</time>
+</trkpt>
+<trkpt lat="55.9418694" lon="-4.3136586">
+<ele>105.840083360239></ele>
+<accuracy>3.324</accuracy>
+<speed>1.2782747</speed>
+<bearing>91.09335</bearing>
+<bearingAccuracyDegrees>10.028568</bearingAccuracyDegrees>
+<time>1746105691593</time>
+</trkpt>
+<trkpt lat="55.9418685" lon="-4.3136349">
+<ele>105.76937536649733></ele>
+<accuracy>3.076</accuracy>
+<speed>1.2782806</speed>
+<bearing>97.0619</bearing>
+<bearingAccuracyDegrees>11.624955</bearingAccuracyDegrees>
+<time>1746105692595</time>
+</trkpt>
+<trkpt lat="55.9418666" lon="-4.3136114">
+<ele>105.76937536649733></ele>
+<accuracy>3.118</accuracy>
+<speed>1.283754</speed>
+<bearing>98.39843</bearing>
+<bearingAccuracyDegrees>12.112898</bearingAccuracyDegrees>
+<time>1746105693591</time>
+</trkpt>
+<trkpt lat="55.9418643" lon="-4.313589">
+<ele>105.62900092517391></ele>
+<accuracy>3.248</accuracy>
+<speed>1.2917929</speed>
+<bearing>98.84791</bearing>
+<bearingAccuracyDegrees>11.650744</bearingAccuracyDegrees>
+<time>1746105694599</time>
+</trkpt>
+<trkpt lat="55.9418616" lon="-4.3135658">
+<ele>105.3585190367414></ele>
+<accuracy>3.383</accuracy>
+<speed>1.3252228</speed>
+<bearing>98.98532</bearing>
+<bearingAccuracyDegrees>10.064514</bearingAccuracyDegrees>
+<time>1746105695602</time>
+</trkpt>
+<trkpt lat="55.9418594" lon="-4.3135417">
+<ele>105.32420584864857></ele>
+<accuracy>3.687</accuracy>
+<speed>1.3171151</speed>
+<bearing>96.01897</bearing>
+<bearingAccuracyDegrees>10.304369</bearingAccuracyDegrees>
+<time>1746105696603</time>
+</trkpt>
+<trkpt lat="55.9418587" lon="-4.3135204">
+<ele>105.25142075135864></ele>
+<accuracy>3.876</accuracy>
+<speed>1.3047092</speed>
+<bearing>94.34213</bearing>
+<bearingAccuracyDegrees>11.791924</bearingAccuracyDegrees>
+<time>1746105697606</time>
+</trkpt>
+<trkpt lat="55.941857" lon="-4.3134965">
+<ele>105.25142075135864></ele>
+<accuracy>3.969</accuracy>
+<speed>1.3002867</speed>
+<bearing>94.350174</bearing>
+<bearingAccuracyDegrees>11.858609</bearingAccuracyDegrees>
+<time>1746105698560</time>
+</trkpt>
+<trkpt lat="55.9418543" lon="-4.3134738">
+<ele>105.22334666417089></ele>
+<accuracy>4.071</accuracy>
+<speed>1.2788678</speed>
+<bearing>117.615654</bearing>
+<bearingAccuracyDegrees>12.168564</bearingAccuracyDegrees>
+<time>1746105699611</time>
+</trkpt>
+<trkpt lat="55.9418453" lon="-4.3134563">
+<ele>105.30341004370732></ele>
+<accuracy>4.134</accuracy>
+<speed>1.303567</speed>
+<bearing>120.10249</bearing>
+<bearingAccuracyDegrees>11.990687</bearingAccuracyDegrees>
+<time>1746105700613</time>
+</trkpt>
+<trkpt lat="55.9418424" lon="-4.3134362">
+<ele>106.5999984741211></ele>
+<accuracy>4.17</accuracy>
+<speed>1.3577496</speed>
+<bearing>96.379616</bearing>
+<bearingAccuracyDegrees>12.264035</bearingAccuracyDegrees>
+<time>1746105701515</time>
+</trkpt>
+<trkpt lat="55.9418543" lon="-4.3132655">
+<ele>106.5999984741211></ele>
+<accuracy>3.378</accuracy>
+<speed>1.4871902</speed>
+<bearing>85.443634</bearing>
+<bearingAccuracyDegrees>9.835949</bearingAccuracyDegrees>
+<time>1746105707524</time>
+</trkpt>
+<trkpt lat="55.9418625" lon="-4.3131292">
+<ele>106.5999984741211></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4471682</speed>
+<bearing>85.109314</bearing>
+<bearingAccuracyDegrees>9.672317</bearingAccuracyDegrees>
+<time>1746105712540</time>
+</trkpt>
+<trkpt lat="55.9418743" lon="-4.3130052">
+<ele>106.5999984741211></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4666687</speed>
+<bearing>76.93038</bearing>
+<bearingAccuracyDegrees>9.157769</bearingAccuracyDegrees>
+<time>1746105717481</time>
+</trkpt>
+<trkpt lat="55.9418778" lon="-4.312978">
+<ele>106.5999984741211></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4703897</speed>
+<bearing>80.1579</bearing>
+<bearingAccuracyDegrees>9.205834</bearingAccuracyDegrees>
+<time>1746105718507</time>
+</trkpt>
+<trkpt lat="55.9418801" lon="-4.3129458">
+<ele>106.5999984741211></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4898416</speed>
+<bearing>81.75883</bearing>
+<bearingAccuracyDegrees>9.660543</bearingAccuracyDegrees>
+<time>1746105719548</time>
+</trkpt>
+<trkpt lat="55.9418806" lon="-4.3129138">
+<ele>106.5999984741211></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4985627</speed>
+<bearing>84.40797</bearing>
+<bearingAccuracyDegrees>9.673092</bearingAccuracyDegrees>
+<time>1746105720603</time>
+</trkpt>
+<trkpt lat="55.9418796" lon="-4.3128895">
+<ele>106.5999984741211></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4785695</speed>
+<bearing>83.92169</bearing>
+<bearingAccuracyDegrees>9.538998</bearingAccuracyDegrees>
+<time>1746105721561</time>
+</trkpt>
+<trkpt lat="55.9418769" lon="-4.3128659">
+<ele>106.5999984741211></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4789752</speed>
+<bearing>85.76907</bearing>
+<bearingAccuracyDegrees>9.1019945</bearingAccuracyDegrees>
+<time>1746105722563</time>
+</trkpt>
+<trkpt lat="55.941874" lon="-4.312847">
+<ele>106.5999984741211></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4577813</speed>
+<bearing>86.97125</bearing>
+<bearingAccuracyDegrees>9.708581</bearingAccuracyDegrees>
+<time>1746105723565</time>
+</trkpt>
+<trkpt lat="55.9418609" lon="-4.3127033">
+<ele>107.0999984741211></ele>
+<accuracy>3.244</accuracy>
+<speed>1.4955294</speed>
+<bearing>97.01493</bearing>
+<bearingAccuracyDegrees>10.378314</bearingAccuracyDegrees>
+<time>1746105729563</time>
+</trkpt>
+<trkpt lat="55.9418571" lon="-4.312673">
+<ele>107.0999984741211></ele>
+<accuracy>3.485</accuracy>
+<speed>1.5061384</speed>
+<bearing>99.75901</bearing>
+<bearingAccuracyDegrees>9.844127</bearingAccuracyDegrees>
+<time>1746105730606</time>
+</trkpt>
+<trkpt lat="55.9418544" lon="-4.3126458">
+<ele>107.0999984741211></ele>
+<accuracy>3.753</accuracy>
+<speed>1.5088209</speed>
+<bearing>98.054825</bearing>
+<bearingAccuracyDegrees>9.952646</bearingAccuracyDegrees>
+<time>1746105731584</time>
+</trkpt>
+<trkpt lat="55.9418533" lon="-4.3126156">
+<ele>107.0999984741211></ele>
+<accuracy>3.962</accuracy>
+<speed>1.4937063</speed>
+<bearing>97.78611</bearing>
+<bearingAccuracyDegrees>10.472623</bearingAccuracyDegrees>
+<time>1746105732586</time>
+</trkpt>
+<trkpt lat="55.9418522" lon="-4.3125877">
+<ele>107.0999984741211></ele>
+<accuracy>4.299</accuracy>
+<speed>1.4778966</speed>
+<bearing>100.05908</bearing>
+<bearingAccuracyDegrees>10.1619215</bearingAccuracyDegrees>
+<time>1746105733589</time>
+</trkpt>
+<trkpt lat="55.9418518" lon="-4.3125633">
+<ele>107.0999984741211></ele>
+<accuracy>4.516</accuracy>
+<speed>1.4551185</speed>
+<bearing>96.437744</bearing>
+<bearingAccuracyDegrees>10.351248</bearingAccuracyDegrees>
+<time>1746105734591</time>
+</trkpt>
+<trkpt lat="55.9418544" lon="-4.3125415">
+<ele>107.0999984741211></ele>
+<accuracy>4.671</accuracy>
+<speed>1.4374943</speed>
+<bearing>90.170074</bearing>
+<bearingAccuracyDegrees>12.021837</bearingAccuracyDegrees>
+<time>1746105735593</time>
+</trkpt>
+<trkpt lat="55.9418594" lon="-4.3125224">
+<ele>107.0999984741211></ele>
+<accuracy>4.764</accuracy>
+<speed>1.4341625</speed>
+<bearing>85.39579</bearing>
+<bearingAccuracyDegrees>11.7932825</bearingAccuracyDegrees>
+<time>1746105736594</time>
+</trkpt>
+<trkpt lat="55.9418649" lon="-4.3125053">
+<ele>107.0999984741211></ele>
+<accuracy>4.79</accuracy>
+<speed>1.4225156</speed>
+<bearing>80.1697</bearing>
+<bearingAccuracyDegrees>12.389525</bearingAccuracyDegrees>
+<time>1746105737598</time>
+</trkpt>
+<trkpt lat="55.9418713" lon="-4.3124922">
+<ele>108.5999984741211></ele>
+<accuracy>4.785</accuracy>
+<speed>1.3969026</speed>
+<bearing>79.444725</bearing>
+<bearingAccuracyDegrees>12.095098</bearingAccuracyDegrees>
+<time>1746105738500</time>
+</trkpt>
+<trkpt lat="55.941872" lon="-4.3124663">
+<ele>108.5999984741211></ele>
+<accuracy>4.738</accuracy>
+<speed>1.3793081</speed>
+<bearing>89.318436</bearing>
+<bearingAccuracyDegrees>12.016091</bearingAccuracyDegrees>
+<time>1746105739506</time>
+</trkpt>
+<trkpt lat="55.9418728" lon="-4.3124484">
+<ele>108.5999984741211></ele>
+<accuracy>4.626</accuracy>
+<speed>1.3803318</speed>
+<bearing>90.532036</bearing>
+<bearingAccuracyDegrees>10.142719</bearingAccuracyDegrees>
+<time>1746105740568</time>
+</trkpt>
+<trkpt lat="55.9418732" lon="-4.3124297">
+<ele>108.5999984741211></ele>
+<accuracy>4.521</accuracy>
+<speed>1.3729922</speed>
+<bearing>90.86347</bearing>
+<bearingAccuracyDegrees>12.705609</bearingAccuracyDegrees>
+<time>1746105741607</time>
+</trkpt>
+<trkpt lat="55.9418735" lon="-4.3124105">
+<ele>108.5999984741211></ele>
+<accuracy>4.442</accuracy>
+<speed>1.3782821</speed>
+<bearing>89.53086</bearing>
+<bearingAccuracyDegrees>12.59154</bearingAccuracyDegrees>
+<time>1746105742609</time>
+</trkpt>
+<trkpt lat="55.9418737" lon="-4.3123923">
+<ele>108.5></ele>
+<accuracy>4.446</accuracy>
+<speed>1.3626767</speed>
+<bearing>89.862564</bearing>
+<bearingAccuracyDegrees>12.78385</bearingAccuracyDegrees>
+<time>1746105743511</time>
+</trkpt>
+<trkpt lat="55.9418654" lon="-4.3123589">
+<ele>108.5></ele>
+<accuracy>4.441</accuracy>
+<speed>1.3866682</speed>
+<bearing>96.8306</bearing>
+<bearingAccuracyDegrees>13.905445</bearingAccuracyDegrees>
+<time>1746105744514</time>
+</trkpt>
+<trkpt lat="55.941862" lon="-4.3123356">
+<ele>108.5></ele>
+<accuracy>4.56</accuracy>
+<speed>1.3763858</speed>
+<bearing>96.07811</bearing>
+<bearingAccuracyDegrees>14.406209</bearingAccuracyDegrees>
+<time>1746105745615</time>
+</trkpt>
+<trkpt lat="55.9418591" lon="-4.3123138">
+<ele>108.5></ele>
+<accuracy>4.691</accuracy>
+<speed>1.355538</speed>
+<bearing>93.681305</bearing>
+<bearingAccuracyDegrees>14.799234</bearingAccuracyDegrees>
+<time>1746105746540</time>
+</trkpt>
+<trkpt lat="55.9418568" lon="-4.3122917">
+<ele>108.5></ele>
+<accuracy>4.916</accuracy>
+<speed>1.2996117</speed>
+<bearing>95.99558</bearing>
+<bearingAccuracyDegrees>15.661364</bearingAccuracyDegrees>
+<time>1746105747621</time>
+</trkpt>
+<trkpt lat="55.941853" lon="-4.3122694">
+<ele>108.5999984741211></ele>
+<accuracy>5.253</accuracy>
+<speed>1.2978474</speed>
+<bearing>97.94356</bearing>
+<bearingAccuracyDegrees>13.06219</bearingAccuracyDegrees>
+<time>1746105748623</time>
+</trkpt>
+<trkpt lat="55.9418489" lon="-4.3122468">
+<ele>108.5999984741211></ele>
+<accuracy>5.507</accuracy>
+<speed>1.3058928</speed>
+<bearing>98.53835</bearing>
+<bearingAccuracyDegrees>14.691899</bearingAccuracyDegrees>
+<time>1746105749625</time>
+</trkpt>
+<trkpt lat="55.9418459" lon="-4.3122248">
+<ele>108.5999984741211></ele>
+<accuracy>5.677</accuracy>
+<speed>1.3073355</speed>
+<bearing>97.4404</bearing>
+<bearingAccuracyDegrees>13.129704</bearingAccuracyDegrees>
+<time>1746105750549</time>
+</trkpt>
+<trkpt lat="55.9418433" lon="-4.3122016">
+<ele>108.5999984741211></ele>
+<accuracy>5.787</accuracy>
+<speed>1.3204746</speed>
+<bearing>94.812004</bearing>
+<bearingAccuracyDegrees>15.365087</bearingAccuracyDegrees>
+<time>1746105751630</time>
+</trkpt>
+<trkpt lat="55.941842" lon="-4.3121776">
+<ele>108.5999984741211></ele>
+<accuracy>5.893</accuracy>
+<speed>1.3407327</speed>
+<bearing>92.597664</bearing>
+<bearingAccuracyDegrees>14.736792</bearingAccuracyDegrees>
+<time>1746105752532</time>
+</trkpt>
+<trkpt lat="55.9418421" lon="-4.3121542">
+<ele>109.80000305175781></ele>
+<accuracy>5.928</accuracy>
+<speed>1.346491</speed>
+<bearing>95.70629</bearing>
+<bearingAccuracyDegrees>13.334176</bearingAccuracyDegrees>
+<time>1746105753533</time>
+</trkpt>
+<trkpt lat="55.9418432" lon="-4.3121274">
+<ele>109.80000305175781></ele>
+<accuracy>5.915</accuracy>
+<speed>1.3512203</speed>
+<bearing>97.79989</bearing>
+<bearingAccuracyDegrees>12.393577</bearingAccuracyDegrees>
+<time>1746105754509</time>
+</trkpt>
+<trkpt lat="55.941843" lon="-4.3120998">
+<ele>109.80000305175781></ele>
+<accuracy>5.84</accuracy>
+<speed>1.3555385</speed>
+<bearing>98.48923</bearing>
+<bearingAccuracyDegrees>11.905968</bearingAccuracyDegrees>
+<time>1746105755602</time>
+</trkpt>
+<trkpt lat="55.9418427" lon="-4.3120734">
+<ele>109.80000305175781></ele>
+<accuracy>5.726</accuracy>
+<speed>1.3774402</speed>
+<bearing>97.1269</bearing>
+<bearingAccuracyDegrees>11.89461</bearingAccuracyDegrees>
+<time>1746105756540</time>
+</trkpt>
+<trkpt lat="55.9418425" lon="-4.3120496">
+<ele>109.80000305175781></ele>
+<accuracy>5.55</accuracy>
+<speed>1.3619955</speed>
+<bearing>95.693756</bearing>
+<bearingAccuracyDegrees>11.794673</bearingAccuracyDegrees>
+<time>1746105757543</time>
+</trkpt>
+<trkpt lat="55.9418414" lon="-4.3120273">
+<ele>109.9000015258789></ele>
+<accuracy>5.403</accuracy>
+<speed>1.3612027</speed>
+<bearing>95.692116</bearing>
+<bearingAccuracyDegrees>11.831406</bearingAccuracyDegrees>
+<time>1746105758546</time>
+</trkpt>
+<trkpt lat="55.9418399" lon="-4.3120014">
+<ele>109.9000015258789></ele>
+<accuracy>5.326</accuracy>
+<speed>1.3508576</speed>
+<bearing>95.509796</bearing>
+<bearingAccuracyDegrees>10.439443</bearingAccuracyDegrees>
+<time>1746105759547</time>
+</trkpt>
+<trkpt lat="55.9418392" lon="-4.3119805">
+<ele>109.9000015258789></ele>
+<accuracy>5.259</accuracy>
+<speed>1.3363235</speed>
+<bearing>94.669876</bearing>
+<bearingAccuracyDegrees>12.88081</bearingAccuracyDegrees>
+<time>1746105760544</time>
+</trkpt>
+<trkpt lat="55.9418391" lon="-4.3119568">
+<ele>109.9000015258789></ele>
+<accuracy>5.252</accuracy>
+<speed>1.3437357</speed>
+<bearing>95.02336</bearing>
+<bearingAccuracyDegrees>13.149867</bearingAccuracyDegrees>
+<time>1746105761626</time>
+</trkpt>
+<trkpt lat="55.9418397" lon="-4.3119387">
+<ele>109.9000015258789></ele>
+<accuracy>5.327</accuracy>
+<speed>1.345727</speed>
+<bearing>93.56912</bearing>
+<bearingAccuracyDegrees>13.21363</bearingAccuracyDegrees>
+<time>1746105762555</time>
+</trkpt>
+<trkpt lat="55.9418413" lon="-4.3119212">
+<ele>109.9000015258789></ele>
+<accuracy>5.462</accuracy>
+<speed>1.3522389</speed>
+<bearing>90.68568</bearing>
+<bearingAccuracyDegrees>15.008961</bearingAccuracyDegrees>
+<time>1746105763557</time>
+</trkpt>
+<trkpt lat="55.9418403" lon="-4.3118963">
+<ele>109.9000015258789></ele>
+<accuracy>5.679</accuracy>
+<speed>1.3468208</speed>
+<bearing>96.23178</bearing>
+<bearingAccuracyDegrees>13.15877</bearingAccuracyDegrees>
+<time>1746105764559</time>
+</trkpt>
+<trkpt lat="55.9418381" lon="-4.3118775">
+<ele>109.9000015258789></ele>
+<accuracy>5.815</accuracy>
+<speed>1.3627133</speed>
+<bearing>99.32699</bearing>
+<bearingAccuracyDegrees>13.382412</bearingAccuracyDegrees>
+<time>1746105765500</time>
+</trkpt>
+<trkpt lat="55.9418343" lon="-4.3118564">
+<ele>109.9000015258789></ele>
+<accuracy>5.971</accuracy>
+<speed>1.367013</speed>
+<bearing>103.56728</bearing>
+<bearingAccuracyDegrees>12.847204</bearingAccuracyDegrees>
+<time>1746105766546</time>
+</trkpt>
+<trkpt lat="55.94183" lon="-4.3118346">
+<ele>109.9000015258789></ele>
+<accuracy>6.086</accuracy>
+<speed>1.3676659</speed>
+<bearing>99.88047</bearing>
+<bearingAccuracyDegrees>12.821302</bearingAccuracyDegrees>
+<time>1746105767649</time>
+</trkpt>
+<trkpt lat="55.9418289" lon="-4.3118141">
+<ele>109.9000015258789></ele>
+<accuracy>6.099</accuracy>
+<speed>1.3329843</speed>
+<bearing>95.007034</bearing>
+<bearingAccuracyDegrees>12.43368</bearingAccuracyDegrees>
+<time>1746105768721</time>
+</trkpt>
+<trkpt lat="55.9418442" lon="-4.3116352">
+<ele>110.5999984741211></ele>
+<accuracy>6.635</accuracy>
+<speed>1.366447</speed>
+<bearing>82.721954</bearing>
+<bearingAccuracyDegrees>14.476008</bearingAccuracyDegrees>
+<time>1746105777403</time>
+</trkpt>
+<trkpt lat="55.9418552" lon="-4.3115672">
+<ele>110.4000015258789></ele>
+<accuracy>6.745</accuracy>
+<speed>1.4156464</speed>
+<bearing>63.307087</bearing>
+<bearingAccuracyDegrees>11.576269</bearingAccuracyDegrees>
+<time>1746105779549</time>
+</trkpt>
+<trkpt lat="55.9418629" lon="-4.3115408">
+<ele>110.4000015258789></ele>
+<accuracy>6.644</accuracy>
+<speed>1.3521279</speed>
+<bearing>57.481613</bearing>
+<bearingAccuracyDegrees>12.004463</bearingAccuracyDegrees>
+<time>1746105780618</time>
+</trkpt>
+<trkpt lat="55.9418724" lon="-4.3115201">
+<ele>110.4000015258789></ele>
+<accuracy>6.483</accuracy>
+<speed>1.3416289</speed>
+<bearing>51.67998</bearing>
+<bearingAccuracyDegrees>11.790679</bearingAccuracyDegrees>
+<time>1746105781598</time>
+</trkpt>
+<trkpt lat="55.9418838" lon="-4.3114999">
+<ele>110.4000015258789></ele>
+<accuracy>6.163</accuracy>
+<speed>1.3501005</speed>
+<bearing>40.203766</bearing>
+<bearingAccuracyDegrees>11.824572</bearingAccuracyDegrees>
+<time>1746105782601</time>
+</trkpt>
+<trkpt lat="55.9418964" lon="-4.3114829">
+<ele>110.4000015258789></ele>
+<accuracy>5.778</accuracy>
+<speed>1.3516991</speed>
+<bearing>33.33728</bearing>
+<bearingAccuracyDegrees>11.701955</bearingAccuracyDegrees>
+<time>1746105783603</time>
+</trkpt>
+<trkpt lat="55.9419048" lon="-4.3114483">
+<ele>110.80000305175781></ele>
+<accuracy>5.47</accuracy>
+<speed>1.3830818</speed>
+<bearing>28.894463</bearing>
+<bearingAccuracyDegrees>10.209738</bearingAccuracyDegrees>
+<time>1746105784605</time>
+</trkpt>
+<trkpt lat="55.9419174" lon="-4.3114371">
+<ele>110.80000305175781></ele>
+<accuracy>5.227</accuracy>
+<speed>1.385218</speed>
+<bearing>22.945179</bearing>
+<bearingAccuracyDegrees>10.099674</bearingAccuracyDegrees>
+<time>1746105785507</time>
+</trkpt>
+<trkpt lat="55.9419316" lon="-4.3114289">
+<ele>110.80000305175781></ele>
+<accuracy>5.057</accuracy>
+<speed>1.399999</speed>
+<bearing>18.60178</bearing>
+<bearingAccuracyDegrees>12.081276</bearingAccuracyDegrees>
+<time>1746105786440</time>
+</trkpt>
+<trkpt lat="55.9419486" lon="-4.3114214">
+<ele>110.80000305175781></ele>
+<accuracy>4.836</accuracy>
+<speed>1.4310249</speed>
+<bearing>14.738294</bearing>
+<bearingAccuracyDegrees>11.994566</bearingAccuracyDegrees>
+<time>1746105787504</time>
+</trkpt>
+<trkpt lat="55.9419641" lon="-4.3114166">
+<ele>110.80000305175781></ele>
+<accuracy>4.707</accuracy>
+<speed>1.434819</speed>
+<bearing>9.456179</bearing>
+<bearingAccuracyDegrees>12.129155</bearingAccuracyDegrees>
+<time>1746105788567</time>
+</trkpt>
+<trkpt lat="55.9419675" lon="-4.3113859">
+<ele>110.80000305175781></ele>
+<accuracy>4.711</accuracy>
+<speed>1.3913792</speed>
+<bearing>43.906475</bearing>
+<bearingAccuracyDegrees>12.225619</bearingAccuracyDegrees>
+<time>1746105789616</time>
+</trkpt>
+<trkpt lat="55.9419755" lon="-4.3113668">
+<ele>110.80000305175781></ele>
+<accuracy>4.787</accuracy>
+<speed>1.3751239</speed>
+<bearing>27.669918</bearing>
+<bearingAccuracyDegrees>12.219158</bearingAccuracyDegrees>
+<time>1746105790619</time>
+</trkpt>
+<trkpt lat="55.9419897" lon="-4.3113631">
+<ele>110.80000305175781></ele>
+<accuracy>4.895</accuracy>
+<speed>1.383752</speed>
+<bearing>7.038862</bearing>
+<bearingAccuracyDegrees>12.59773</bearingAccuracyDegrees>
+<time>1746105791520</time>
+</trkpt>
+<trkpt lat="55.9420055" lon="-4.3113639">
+<ele>110.80000305175781></ele>
+<accuracy>5.054</accuracy>
+<speed>1.4182267</speed>
+<bearing>4.510765</bearing>
+<bearingAccuracyDegrees>12.703831</bearingAccuracyDegrees>
+<time>1746105792623</time>
+</trkpt>
+<trkpt lat="55.9420204" lon="-4.3113636">
+<ele>110.80000305175781></ele>
+<accuracy>5.237</accuracy>
+<speed>1.4168354</speed>
+<bearing>4.190395</bearing>
+<bearingAccuracyDegrees>12.671085</bearingAccuracyDegrees>
+<time>1746105793626</time>
+</trkpt>
+<trkpt lat="55.9420333" lon="-4.3113548">
+<ele>110.80000305175781></ele>
+<accuracy>5.402</accuracy>
+<speed>1.3823452</speed>
+<bearing>3.9069915</bearing>
+<bearingAccuracyDegrees>12.263536</bearingAccuracyDegrees>
+<time>1746105794628</time>
+</trkpt>
+<trkpt lat="55.942049" lon="-4.3113602">
+<ele>110.80000305175781></ele>
+<accuracy>5.572</accuracy>
+<speed>1.3841232</speed>
+<bearing>3.4239273</bearing>
+<bearingAccuracyDegrees>12.321853</bearingAccuracyDegrees>
+<time>1746105795630</time>
+</trkpt>
+<trkpt lat="55.9420651" lon="-4.3113661">
+<ele>110.80000305175781></ele>
+<accuracy>5.727</accuracy>
+<speed>1.3987076</speed>
+<bearing>4.138768</bearing>
+<bearingAccuracyDegrees>12.235238</bearingAccuracyDegrees>
+<time>1746105796532</time>
+</trkpt>
+<trkpt lat="55.9420807" lon="-4.3113719">
+<ele>110.80000305175781></ele>
+<accuracy>5.818</accuracy>
+<speed>1.3875417</speed>
+<bearing>2.3220012</bearing>
+<bearingAccuracyDegrees>11.8013935</bearingAccuracyDegrees>
+<time>1746105797547</time>
+</trkpt>
+<trkpt lat="55.9420959" lon="-4.3113808">
+<ele>110.80000305175781></ele>
+<accuracy>5.919</accuracy>
+<speed>1.3714372</speed>
+<bearing>357.6988</bearing>
+<bearingAccuracyDegrees>11.817726</bearingAccuracyDegrees>
+<time>1746105798590</time>
+</trkpt>
+<trkpt lat="55.9421172" lon="-4.3113613">
+<ele>111.30000305175781></ele>
+<accuracy>6.003</accuracy>
+<speed>1.3606849</speed>
+<bearing>0.7027811</bearing>
+<bearingAccuracyDegrees>10.21783</bearingAccuracyDegrees>
+<time>1746105799621</time>
+</trkpt>
+<trkpt lat="55.9421316" lon="-4.3113645">
+<ele>111.30000305175781></ele>
+<accuracy>6.032</accuracy>
+<speed>1.3570538</speed>
+<bearing>359.7418</bearing>
+<bearingAccuracyDegrees>11.919083</bearingAccuracyDegrees>
+<time>1746105800642</time>
+</trkpt>
+<trkpt lat="55.9421459" lon="-4.3113763">
+<ele>111.30000305175781></ele>
+<accuracy>6.019</accuracy>
+<speed>1.3841887</speed>
+<bearing>357.84058</bearing>
+<bearingAccuracyDegrees>12.061726</bearingAccuracyDegrees>
+<time>1746105801544</time>
+</trkpt>
+<trkpt lat="55.9421604" lon="-4.3113871">
+<ele>111.30000305175781></ele>
+<accuracy>5.985</accuracy>
+<speed>1.4117846</speed>
+<bearing>357.0951</bearing>
+<bearingAccuracyDegrees>12.072343</bearingAccuracyDegrees>
+<time>1746105802546</time>
+</trkpt>
+<trkpt lat="55.9421757" lon="-4.311397">
+<ele>111.30000305175781></ele>
+<accuracy>5.981</accuracy>
+<speed>1.4329962</speed>
+<bearing>354.25418</bearing>
+<bearingAccuracyDegrees>12.049478</bearingAccuracyDegrees>
+<time>1746105803549</time>
+</trkpt>
+<trkpt lat="55.9421903" lon="-4.3114071">
+<ele>111.30000305175781></ele>
+<accuracy>6.03</accuracy>
+<speed>1.4340097</speed>
+<bearing>353.4962</bearing>
+<bearingAccuracyDegrees>12.606474</bearingAccuracyDegrees>
+<time>1746105804551</time>
+</trkpt>
+<trkpt lat="55.942205" lon="-4.311413">
+<ele>111.30000305175781></ele>
+<accuracy>6.092</accuracy>
+<speed>1.4355451</speed>
+<bearing>21.335375</bearing>
+<bearingAccuracyDegrees>12.012292</bearingAccuracyDegrees>
+<time>1746105805552</time>
+</trkpt>
+<trkpt lat="55.9422705" lon="-4.3113542">
+<ele>111.30000305175781></ele>
+<accuracy>6.092</accuracy>
+<speed>1.5053647</speed>
+<bearing>27.627747</bearing>
+<bearingAccuracyDegrees>11.937371</bearingAccuracyDegrees>
+<time>1746105810528</time>
+</trkpt>
+<trkpt lat="55.9422838" lon="-4.3113435">
+<ele>111.30000305175781></ele>
+<accuracy>6.034</accuracy>
+<speed>1.5122917</speed>
+<bearing>22.989395</bearing>
+<bearingAccuracyDegrees>11.798952</bearingAccuracyDegrees>
+<time>1746105811529</time>
+</trkpt>
+<trkpt lat="55.9422968" lon="-4.3113379">
+<ele>111.30000305175781></ele>
+<accuracy>5.798</accuracy>
+<speed>1.5361023</speed>
+<bearing>21.272566</bearing>
+<bearingAccuracyDegrees>11.645912</bearingAccuracyDegrees>
+<time>1746105812541</time>
+</trkpt>
+<trkpt lat="55.9423088" lon="-4.3113331">
+<ele>111.30000305175781></ele>
+<accuracy>5.389</accuracy>
+<speed>1.5230486</speed>
+<bearing>13.312893</bearing>
+<bearingAccuracyDegrees>10.183979</bearingAccuracyDegrees>
+<time>1746105813526</time>
+</trkpt>
+<trkpt lat="55.9423212" lon="-4.3113339">
+<ele>111.30000305175781></ele>
+<accuracy>4.895</accuracy>
+<speed>1.5183461</speed>
+<bearing>357.6305</bearing>
+<bearingAccuracyDegrees>10.273506</bearingAccuracyDegrees>
+<time>1746105814526</time>
+</trkpt>
+<trkpt lat="55.9423338" lon="-4.3113377">
+<ele>111.30000305175781></ele>
+<accuracy>4.356</accuracy>
+<speed>1.5076182</speed>
+<bearing>349.78992</bearing>
+<bearingAccuracyDegrees>11.878713</bearingAccuracyDegrees>
+<time>1746105815569</time>
+</trkpt>
+<trkpt lat="55.9423478" lon="-4.3113402">
+<ele>111.30000305175781></ele>
+<accuracy>3.806</accuracy>
+<speed>1.4954839</speed>
+<bearing>347.0836</bearing>
+<bearingAccuracyDegrees>11.808652</bearingAccuracyDegrees>
+<time>1746105816602</time>
+</trkpt>
+<trkpt lat="55.9423609" lon="-4.3113419">
+<ele>111.30000305175781></ele>
+<accuracy>3.79</accuracy>
+<speed>1.474615</speed>
+<bearing>348.87903</bearing>
+<bearingAccuracyDegrees>13.13234</bearingAccuracyDegrees>
+<time>1746105817581</time>
+</trkpt>
+<trkpt lat="55.9423751" lon="-4.3113437">
+<ele>111.30000305175781></ele>
+<accuracy>3.789</accuracy>
+<speed>1.4735979</speed>
+<bearing>349.84274</bearing>
+<bearingAccuracyDegrees>13.296791</bearingAccuracyDegrees>
+<time>1746105818583</time>
+</trkpt>
+<trkpt lat="55.9423897" lon="-4.3113448">
+<ele>111.30000305175781></ele>
+<accuracy>4.004</accuracy>
+<speed>1.452906</speed>
+<bearing>350.19913</bearing>
+<bearingAccuracyDegrees>14.9063425</bearingAccuracyDegrees>
+<time>1746105819585</time>
+</trkpt>
+<trkpt lat="55.9424029" lon="-4.3113399">
+<ele>111.30000305175781></ele>
+<accuracy>4.347</accuracy>
+<speed>1.4182024</speed>
+<bearing>356.91074</bearing>
+<bearingAccuracyDegrees>15.308757</bearingAccuracyDegrees>
+<time>1746105820588</time>
+</trkpt>
+<trkpt lat="55.9424161" lon="-4.3113176">
+<ele>111.30000305175781></ele>
+<accuracy>4.826</accuracy>
+<speed>1.4489434</speed>
+<bearing>7.3007374</bearing>
+<bearingAccuracyDegrees>12.5459585</bearingAccuracyDegrees>
+<time>1746105821590</time>
+</trkpt>
+<trkpt lat="55.942429" lon="-4.3112833">
+<ele>111.30000305175781></ele>
+<accuracy>5.101</accuracy>
+<speed>1.4432447</speed>
+<bearing>13.282561</bearing>
+<bearingAccuracyDegrees>9.872436</bearingAccuracyDegrees>
+<time>1746105822592</time>
+</trkpt>
+<trkpt lat="55.9424432" lon="-4.3112438">
+<ele>111.30000305175781></ele>
+<accuracy>5.323</accuracy>
+<speed>1.4407225</speed>
+<bearing>13.35839</bearing>
+<bearingAccuracyDegrees>9.105843</bearingAccuracyDegrees>
+<time>1746105823548</time>
+</trkpt>
+<trkpt lat="55.9424577" lon="-4.3112303">
+<ele>111.30000305175781></ele>
+<accuracy>5.361</accuracy>
+<speed>1.4577923</speed>
+<bearing>10.815116</bearing>
+<bearingAccuracyDegrees>9.343323</bearingAccuracyDegrees>
+<time>1746105824597</time>
+</trkpt>
+<trkpt lat="55.942472" lon="-4.311211">
+<ele>111.30000305175781></ele>
+<accuracy>5.296</accuracy>
+<speed>1.4834995</speed>
+<bearing>15.105052</bearing>
+<bearingAccuracyDegrees>9.700627</bearingAccuracyDegrees>
+<time>1746105825599</time>
+</trkpt>
+<trkpt lat="55.9424864" lon="-4.3111932">
+<ele>111.30000305175781></ele>
+<accuracy>5.161</accuracy>
+<speed>1.5041069</speed>
+<bearing>16.700869</bearing>
+<bearingAccuracyDegrees>9.446887</bearingAccuracyDegrees>
+<time>1746105826535</time>
+</trkpt>
+<trkpt lat="55.9425013" lon="-4.311177">
+<ele>111.30000305175781></ele>
+<accuracy>5.002</accuracy>
+<speed>1.525991</speed>
+<bearing>15.318511</bearing>
+<bearingAccuracyDegrees>10.237988</bearingAccuracyDegrees>
+<time>1746105827526</time>
+</trkpt>
+<trkpt lat="55.942567" lon="-4.3111268">
+<ele>111.30000305175781></ele>
+<accuracy>5.028</accuracy>
+<speed>1.5245893</speed>
+<bearing>18.90894</bearing>
+<bearingAccuracyDegrees>12.280614</bearingAccuracyDegrees>
+<time>1746105831613</time>
+</trkpt>
+<trkpt lat="55.9426137" lon="-4.3110885">
+<ele>111.30000305175781></ele>
+<accuracy>5.394</accuracy>
+<speed>1.5182484</speed>
+<bearing>19.672186</bearing>
+<bearingAccuracyDegrees>12.6975765</bearingAccuracyDegrees>
+<time>1746105834620</time>
+</trkpt>
+<trkpt lat="55.9426288" lon="-4.3110756">
+<ele>111.30000305175781></ele>
+<accuracy>5.476</accuracy>
+<speed>1.5130538</speed>
+<bearing>21.159195</bearing>
+<bearingAccuracyDegrees>12.876997</bearingAccuracyDegrees>
+<time>1746105835622</time>
+</trkpt>
+<trkpt lat="55.9426446" lon="-4.3110594">
+<ele>111.30000305175781></ele>
+<accuracy>5.278</accuracy>
+<speed>1.4964132</speed>
+<bearing>21.018068</bearing>
+<bearingAccuracyDegrees>11.855574</bearingAccuracyDegrees>
+<time>1746105836624</time>
+</trkpt>
+<trkpt lat="55.9426579" lon="-4.3110479">
+<ele>111.30000305175781></ele>
+<accuracy>4.961</accuracy>
+<speed>1.4675826</speed>
+<bearing>20.803234</bearing>
+<bearingAccuracyDegrees>9.972442</bearingAccuracyDegrees>
+<time>1746105837627</time>
+</trkpt>
+<trkpt lat="55.9426716" lon="-4.311038">
+<ele>111.30000305175781></ele>
+<accuracy>4.65</accuracy>
+<speed>1.4777385</speed>
+<bearing>21.271185</bearing>
+<bearingAccuracyDegrees>10.037838</bearingAccuracyDegrees>
+<time>1746105838542</time>
+</trkpt>
+<trkpt lat="55.942687" lon="-4.3110284">
+<ele>111.30000305175781></ele>
+<accuracy>4.257</accuracy>
+<speed>1.4770621</speed>
+<bearing>20.143396</bearing>
+<bearingAccuracyDegrees>10.228696</bearingAccuracyDegrees>
+<time>1746105839655</time>
+</trkpt>
+<trkpt lat="55.9427007" lon="-4.3110218">
+<ele>111.30000305175781></ele>
+<accuracy>3.853</accuracy>
+<speed>1.4843853</speed>
+<bearing>19.369764</bearing>
+<bearingAccuracyDegrees>9.862402</bearingAccuracyDegrees>
+<time>1746105840714</time>
+</trkpt>
+<trkpt lat="55.9427117" lon="-4.311018">
+<ele>111.30000305175781></ele>
+<accuracy>3.727</accuracy>
+<speed>1.4600618</speed>
+<bearing>19.694063</bearing>
+<bearingAccuracyDegrees>10.089998</bearingAccuracyDegrees>
+<time>1746105841636</time>
+</trkpt>
+<trkpt lat="55.942725" lon="-4.3110154">
+<ele>111.30000305175781></ele>
+<accuracy>3.547</accuracy>
+<speed>1.4586066</speed>
+<bearing>15.537194</bearing>
+<bearingAccuracyDegrees>9.808751</bearingAccuracyDegrees>
+<time>1746105842638</time>
+</trkpt>
+<trkpt lat="55.9427396" lon="-4.3110126">
+<ele>111.30000305175781></ele>
+<accuracy>3.436</accuracy>
+<speed>1.4586649</speed>
+<bearing>14.401544</bearing>
+<bearingAccuracyDegrees>9.632407</bearingAccuracyDegrees>
+<time>1746105843640</time>
+</trkpt>
+<trkpt lat="55.9427544" lon="-4.3110108">
+<ele>111.30000305175781></ele>
+<accuracy>3.379</accuracy>
+<speed>1.4706284</speed>
+<bearing>13.612295</bearing>
+<bearingAccuracyDegrees>10.150097</bearingAccuracyDegrees>
+<time>1746105844643</time>
+</trkpt>
+<trkpt lat="55.9427687" lon="-4.3110076">
+<ele>111.30000305175781></ele>
+<accuracy>3.337</accuracy>
+<speed>1.4661436</speed>
+<bearing>16.134064</bearing>
+<bearingAccuracyDegrees>10.064698</bearingAccuracyDegrees>
+<time>1746105845645</time>
+</trkpt>
+<trkpt lat="55.9427831" lon="-4.3110029">
+<ele>111.30000305175781></ele>
+<accuracy>3.304</accuracy>
+<speed>1.4706445</speed>
+<bearing>17.055195</bearing>
+<bearingAccuracyDegrees>11.735935</bearingAccuracyDegrees>
+<time>1746105846646</time>
+</trkpt>
+<trkpt lat="55.9427981" lon="-4.3109969">
+<ele>111.30000305175781></ele>
+<accuracy>3.29</accuracy>
+<speed>1.475734</speed>
+<bearing>16.051376</bearing>
+<bearingAccuracyDegrees>9.939658</bearingAccuracyDegrees>
+<time>1746105847564</time>
+</trkpt>
+<trkpt lat="55.9428152" lon="-4.3109915">
+<ele>111.30000305175781></ele>
+<accuracy>3.323</accuracy>
+<speed>1.449286</speed>
+<bearing>5.6047444</bearing>
+<bearingAccuracyDegrees>9.93228</bearingAccuracyDegrees>
+<time>1746105848687</time>
+</trkpt>
+<trkpt lat="55.9428271" lon="-4.3109925">
+<ele>111.30000305175781></ele>
+<accuracy>3.343</accuracy>
+<speed>1.4357554</speed>
+<bearing>1.6136602</bearing>
+<bearingAccuracyDegrees>9.844332</bearingAccuracyDegrees>
+<time>1746105849654</time>
+</trkpt>
+<trkpt lat="55.9428399" lon="-4.3109912">
+<ele>111.30000305175781></ele>
+<accuracy>3.329</accuracy>
+<speed>1.4114478</speed>
+<bearing>12.908401</bearing>
+<bearingAccuracyDegrees>9.908333</bearingAccuracyDegrees>
+<time>1746105850656</time>
+</trkpt>
+<trkpt lat="55.9428536" lon="-4.3109835">
+<ele>111.30000305175781></ele>
+<accuracy>3.303</accuracy>
+<speed>1.4262476</speed>
+<bearing>15.729553</bearing>
+<bearingAccuracyDegrees>9.7695055</bearingAccuracyDegrees>
+<time>1746105851659</time>
+</trkpt>
+<trkpt lat="55.9428694" lon="-4.3109768">
+<ele>111.30000305175781></ele>
+<accuracy>3.276</accuracy>
+<speed>1.4415969</speed>
+<bearing>13.398819</bearing>
+<bearingAccuracyDegrees>9.440804</bearingAccuracyDegrees>
+<time>1746105852661</time>
+</trkpt>
+<trkpt lat="55.9428861" lon="-4.3109717">
+<ele>111.30000305175781></ele>
+<accuracy>3.257</accuracy>
+<speed>1.443206</speed>
+<bearing>14.743187</bearing>
+<bearingAccuracyDegrees>9.877288</bearingAccuracyDegrees>
+<time>1746105853662</time>
+</trkpt>
+<trkpt lat="55.9429024" lon="-4.3109673">
+<ele>111.30000305175781></ele>
+<accuracy>3.203</accuracy>
+<speed>1.4284904</speed>
+<bearing>8.263961</bearing>
+<bearingAccuracyDegrees>9.84048</bearingAccuracyDegrees>
+<time>1746105854609</time>
+</trkpt>
+<trkpt lat="55.94292" lon="-4.310968">
+<ele>111.30000305175781></ele>
+<accuracy>3.201</accuracy>
+<speed>1.4167721</speed>
+<bearing>1.6024942</bearing>
+<bearingAccuracyDegrees>9.858805</bearingAccuracyDegrees>
+<time>1746105855691</time>
+</trkpt>
+<trkpt lat="55.9429342" lon="-4.3109707">
+<ele>111.30000305175781></ele>
+<accuracy>3.191</accuracy>
+<speed>1.417382</speed>
+<bearing>3.2180188</bearing>
+<bearingAccuracyDegrees>9.691275</bearingAccuracyDegrees>
+<time>1746105856670</time>
+</trkpt>
+<trkpt lat="55.9429501" lon="-4.3109731">
+<ele>111.30000305175781></ele>
+<accuracy>3.162</accuracy>
+<speed>1.4066086</speed>
+<bearing>6.5214705</bearing>
+<bearingAccuracyDegrees>9.428578</bearingAccuracyDegrees>
+<time>1746105857672</time>
+</trkpt>
+<trkpt lat="55.9429653" lon="-4.3109722">
+<ele>111.30000305175781></ele>
+<accuracy>3.163</accuracy>
+<speed>1.4181361</speed>
+<bearing>12.334486</bearing>
+<bearingAccuracyDegrees>8.919014</bearingAccuracyDegrees>
+<time>1746105858675</time>
+</trkpt>
+<trkpt lat="55.9429796" lon="-4.3109683">
+<ele>111.30000305175781></ele>
+<accuracy>3.179</accuracy>
+<speed>1.4173579</speed>
+<bearing>13.591962</bearing>
+<bearingAccuracyDegrees>8.778811</bearingAccuracyDegrees>
+<time>1746105859677</time>
+</trkpt>
+<trkpt lat="55.9429947" lon="-4.3109634">
+<ele>111.30000305175781></ele>
+<accuracy>3.184</accuracy>
+<speed>1.3958474</speed>
+<bearing>13.600034</bearing>
+<bearingAccuracyDegrees>9.461266</bearingAccuracyDegrees>
+<time>1746105860602</time>
+</trkpt>
+<trkpt lat="55.9430115" lon="-4.3109576">
+<ele>111.30000305175781></ele>
+<accuracy>3.17</accuracy>
+<speed>1.3981123</speed>
+<bearing>8.933549</bearing>
+<bearingAccuracyDegrees>8.980677</bearingAccuracyDegrees>
+<time>1746105861705</time>
+</trkpt>
+<trkpt lat="55.9430243" lon="-4.3109542">
+<ele>111.30000305175781></ele>
+<accuracy>3.182</accuracy>
+<speed>1.4044603</speed>
+<bearing>6.374059</bearing>
+<bearingAccuracyDegrees>8.844841</bearingAccuracyDegrees>
+<time>1746105862683</time>
+</trkpt>
+<trkpt lat="55.9430368" lon="-4.3109506">
+<ele>111.30000305175781></ele>
+<accuracy>3.187</accuracy>
+<speed>1.4017615</speed>
+<bearing>8.751881</bearing>
+<bearingAccuracyDegrees>9.067718</bearingAccuracyDegrees>
+<time>1746105863586</time>
+</trkpt>
+<trkpt lat="55.9430499" lon="-4.3109434">
+<ele>111.30000305175781></ele>
+<accuracy>3.189</accuracy>
+<speed>1.3943795</speed>
+<bearing>8.279024</bearing>
+<bearingAccuracyDegrees>9.100078</bearingAccuracyDegrees>
+<time>1746105864588</time>
+</trkpt>
+<trkpt lat="55.9430636" lon="-4.3109376">
+<ele>111.30000305175781></ele>
+<accuracy>3.19</accuracy>
+<speed>1.393467</speed>
+<bearing>5.220679</bearing>
+<bearingAccuracyDegrees>8.91198</bearingAccuracyDegrees>
+<time>1746105865563</time>
+</trkpt>
+<trkpt lat="55.9430781" lon="-4.3109326">
+<ele>111.30000305175781></ele>
+<accuracy>3.22</accuracy>
+<speed>1.3785408</speed>
+<bearing>4.9879723</bearing>
+<bearingAccuracyDegrees>9.072025</bearingAccuracyDegrees>
+<time>1746105866666</time>
+</trkpt>
+<trkpt lat="55.9430894" lon="-4.3109276">
+<ele>111.30000305175781></ele>
+<accuracy>3.243</accuracy>
+<speed>1.3815638</speed>
+<bearing>8.721117</bearing>
+<bearingAccuracyDegrees>9.006778</bearingAccuracyDegrees>
+<time>1746105867595</time>
+</trkpt>
+<trkpt lat="55.9431015" lon="-4.3109219">
+<ele>111.30000305175781></ele>
+<accuracy>3.239</accuracy>
+<speed>1.3806084</speed>
+<bearing>10.388478</bearing>
+<bearingAccuracyDegrees>9.156661</bearingAccuracyDegrees>
+<time>1746105868597</time>
+</trkpt>
+<trkpt lat="55.9431143" lon="-4.3109153">
+<ele>111.30000305175781></ele>
+<accuracy>3.242</accuracy>
+<speed>1.3828778</speed>
+<bearing>12.2749</bearing>
+<bearingAccuracyDegrees>9.345663</bearingAccuracyDegrees>
+<time>1746105869600</time>
+</trkpt>
+<trkpt lat="55.9431292" lon="-4.310912">
+<ele>111.30000305175781></ele>
+<accuracy>3.213</accuracy>
+<speed>1.3737454</speed>
+<bearing>11.550543</bearing>
+<bearingAccuracyDegrees>8.991114</bearingAccuracyDegrees>
+<time>1746105870546</time>
+</trkpt>
+<trkpt lat="55.9431429" lon="-4.3109074">
+<ele>111.30000305175781></ele>
+<accuracy>3.158</accuracy>
+<speed>1.3783218</speed>
+<bearing>12.082954</bearing>
+<bearingAccuracyDegrees>8.997627</bearingAccuracyDegrees>
+<time>1746105871647</time>
+</trkpt>
+<trkpt lat="55.9431528" lon="-4.3109032">
+<ele>111.30000305175781></ele>
+<accuracy>3.103</accuracy>
+<speed>1.3781235</speed>
+<bearing>10.753616</bearing>
+<bearingAccuracyDegrees>9.146116</bearingAccuracyDegrees>
+<time>1746105872606</time>
+</trkpt>
+<trkpt lat="55.9432023" lon="-4.3108966">
+<ele>111.30000305175781></ele>
+<accuracy>3.131</accuracy>
+<speed>1.4026011</speed>
+<bearing>11.711701</bearing>
+<bearingAccuracyDegrees>12.425742</bearingAccuracyDegrees>
+<time>1746105876616</time>
+</trkpt>
+<trkpt lat="55.9432161" lon="-4.3108913">
+<ele>111.30000305175781></ele>
+<accuracy>3.258</accuracy>
+<speed>1.4134768</speed>
+<bearing>10.775497</bearing>
+<bearingAccuracyDegrees>10.207127</bearingAccuracyDegrees>
+<time>1746105877552</time>
+</trkpt>
+<trkpt lat="55.9432318" lon="-4.3108868">
+<ele>111.30000305175781></ele>
+<accuracy>3.489</accuracy>
+<speed>1.4269992</speed>
+<bearing>7.7688055</bearing>
+<bearingAccuracyDegrees>11.964419</bearingAccuracyDegrees>
+<time>1746105878624</time>
+</trkpt>
+<trkpt lat="55.9432491" lon="-4.3108836">
+<ele>111.30000305175781></ele>
+<accuracy>3.814</accuracy>
+<speed>1.4242549</speed>
+<bearing>5.333166</bearing>
+<bearingAccuracyDegrees>10.1820965</bearingAccuracyDegrees>
+<time>1746105879725</time>
+</trkpt>
+<trkpt lat="55.9432615" lon="-4.3108818">
+<ele>111.30000305175781></ele>
+<accuracy>4.08</accuracy>
+<speed>1.4251971</speed>
+<bearing>7.4510713</bearing>
+<bearingAccuracyDegrees>11.748254</bearingAccuracyDegrees>
+<time>1746105880625</time>
+</trkpt>
+<trkpt lat="55.9432754" lon="-4.3108742">
+<ele>111.30000305175781></ele>
+<accuracy>4.293</accuracy>
+<speed>1.4253387</speed>
+<bearing>7.7087336</bearing>
+<bearingAccuracyDegrees>10.174301</bearingAccuracyDegrees>
+<time>1746105881527</time>
+</trkpt>
+<trkpt lat="55.9432901" lon="-4.3108668">
+<ele>111.30000305175781></ele>
+<accuracy>4.409</accuracy>
+<speed>1.4229926</speed>
+<bearing>7.1423254</bearing>
+<bearingAccuracyDegrees>9.840297</bearingAccuracyDegrees>
+<time>1746105882560</time>
+</trkpt>
+<trkpt lat="55.9433039" lon="-4.3108618">
+<ele>111.30000305175781></ele>
+<accuracy>4.479</accuracy>
+<speed>1.4049354</speed>
+<bearing>6.5420527</bearing>
+<bearingAccuracyDegrees>9.8773365</bearingAccuracyDegrees>
+<time>1746105883604</time>
+</trkpt>
+<trkpt lat="55.9433156" lon="-4.3108589">
+<ele>111.30000305175781></ele>
+<accuracy>4.566</accuracy>
+<speed>1.380737</speed>
+<bearing>9.971505</bearing>
+<bearingAccuracyDegrees>10.140582</bearingAccuracyDegrees>
+<time>1746105884634</time>
+</trkpt>
+<trkpt lat="55.943325" lon="-4.3108561">
+<ele>111.30000305175781></ele>
+<accuracy>4.636</accuracy>
+<speed>1.3745503</speed>
+<bearing>11.967138</bearing>
+<bearingAccuracyDegrees>11.888606</bearingAccuracyDegrees>
+<time>1746105885535</time>
+</trkpt>
+<trkpt lat="55.9433365" lon="-4.3108513">
+<ele>111.30000305175781></ele>
+<accuracy>4.691</accuracy>
+<speed>1.3750161</speed>
+<bearing>10.845226</bearing>
+<bearingAccuracyDegrees>12.360015</bearingAccuracyDegrees>
+<time>1746105886537</time>
+</trkpt>
+<trkpt lat="55.9433473" lon="-4.3108468">
+<ele>111.30000305175781></ele>
+<accuracy>4.711</accuracy>
+<speed>1.3672782</speed>
+<bearing>8.383902</bearing>
+<bearingAccuracyDegrees>10.431609</bearingAccuracyDegrees>
+<time>1746105887443</time>
+</trkpt>
+<trkpt lat="55.9433614" lon="-4.3108411">
+<ele>111.30000305175781></ele>
+<accuracy>4.765</accuracy>
+<speed>1.3758787</speed>
+<bearing>8.546552</bearing>
+<bearingAccuracyDegrees>12.097045</bearingAccuracyDegrees>
+<time>1746105888550</time>
+</trkpt>
+<trkpt lat="55.9433754" lon="-4.3108368">
+<ele>111.30000305175781></ele>
+<accuracy>4.797</accuracy>
+<speed>1.3886071</speed>
+<bearing>11.955588</bearing>
+<bearingAccuracyDegrees>11.701106</bearingAccuracyDegrees>
+<time>1746105889545</time>
+</trkpt>
+<trkpt lat="55.9433878" lon="-4.3108271">
+<ele>111.30000305175781></ele>
+<accuracy>4.838</accuracy>
+<speed>1.3392038</speed>
+<bearing>49.106457</bearing>
+<bearingAccuracyDegrees>12.320645</bearingAccuracyDegrees>
+<time>1746105890547</time>
+</trkpt>
+<trkpt lat="55.943393" lon="-4.3108094">
+<ele>111.30000305175781></ele>
+<accuracy>4.88</accuracy>
+<speed>1.3377991</speed>
+<bearing>50.36817</bearing>
+<bearingAccuracyDegrees>12.305066</bearingAccuracyDegrees>
+<time>1746105891469</time>
+</trkpt>
+<trkpt lat="55.9434035" lon="-4.3108052">
+<ele>111.30000305175781></ele>
+<accuracy>4.872</accuracy>
+<speed>1.3497139</speed>
+<bearing>5.649795</bearing>
+<bearingAccuracyDegrees>12.525077</bearingAccuracyDegrees>
+<time>1746105892552</time>
+</trkpt>
+<trkpt lat="55.943418" lon="-4.3108054">
+<ele>111.30000305175781></ele>
+<accuracy>4.871</accuracy>
+<speed>1.3853945</speed>
+<bearing>8.607687</bearing>
+<bearingAccuracyDegrees>12.435381</bearingAccuracyDegrees>
+<time>1746105893554</time>
+</trkpt>
+<trkpt lat="55.9434342" lon="-4.3108009">
+<ele>111.30000305175781></ele>
+<accuracy>4.812</accuracy>
+<speed>1.4162521</speed>
+<bearing>4.905237</bearing>
+<bearingAccuracyDegrees>12.390186</bearingAccuracyDegrees>
+<time>1746105894549</time>
+</trkpt>
+<trkpt lat="55.9434502" lon="-4.3107995">
+<ele>111.30000305175781></ele>
+<accuracy>4.77</accuracy>
+<speed>1.4296465</speed>
+<bearing>5.6453457</bearing>
+<bearingAccuracyDegrees>11.876918</bearingAccuracyDegrees>
+<time>1746105895583</time>
+</trkpt>
+<trkpt lat="55.9434641" lon="-4.3107984">
+<ele>111.30000305175781></ele>
+<accuracy>4.742</accuracy>
+<speed>1.4366616</speed>
+<bearing>6.2822714</bearing>
+<bearingAccuracyDegrees>11.694158</bearingAccuracyDegrees>
+<time>1746105896560</time>
+</trkpt>
+<trkpt lat="55.9434793" lon="-4.3107983">
+<ele>111.30000305175781></ele>
+<accuracy>4.732</accuracy>
+<speed>1.4472064</speed>
+<bearing>7.567607</bearing>
+<bearingAccuracyDegrees>12.0026865</bearingAccuracyDegrees>
+<time>1746105897563</time>
+</trkpt>
+<trkpt lat="55.9434942" lon="-4.3107977">
+<ele>111.30000305175781></ele>
+<accuracy>4.736</accuracy>
+<speed>1.4546884</speed>
+<bearing>5.7082067</bearing>
+<bearingAccuracyDegrees>12.234814</bearingAccuracyDegrees>
+<time>1746105898566</time>
+</trkpt>
+<trkpt lat="55.9435086" lon="-4.3107978">
+<ele>111.30000305175781></ele>
+<accuracy>4.795</accuracy>
+<speed>1.4398953</speed>
+<bearing>3.0621169</bearing>
+<bearingAccuracyDegrees>12.036659</bearingAccuracyDegrees>
+<time>1746105899568</time>
+</trkpt>
+<trkpt lat="55.9435212" lon="-4.3107994">
+<ele>111.30000305175781></ele>
+<accuracy>4.831</accuracy>
+<speed>1.4145769</speed>
+<bearing>4.130697</bearing>
+<bearingAccuracyDegrees>11.764183</bearingAccuracyDegrees>
+<time>1746105900570</time>
+</trkpt>
+<trkpt lat="55.943534" lon="-4.3107992">
+<ele>111.30000305175781></ele>
+<accuracy>4.856</accuracy>
+<speed>1.4061334</speed>
+<bearing>0.46814388</bearing>
+<bearingAccuracyDegrees>10.379154</bearingAccuracyDegrees>
+<time>1746105901522</time>
+</trkpt>
+<trkpt lat="55.9435496" lon="-4.3108001">
+<ele>111.30000305175781></ele>
+<accuracy>4.916</accuracy>
+<speed>1.3866554</speed>
+<bearing>354.69077</bearing>
+<bearingAccuracyDegrees>12.370736</bearingAccuracyDegrees>
+<time>1746105902630</time>
+</trkpt>
+<trkpt lat="55.9435639" lon="-4.3107995">
+<ele>111.30000305175781></ele>
+<accuracy>4.902</accuracy>
+<speed>1.3668196</speed>
+<bearing>353.09042</bearing>
+<bearingAccuracyDegrees>12.069165</bearingAccuracyDegrees>
+<time>1746105903577</time>
+</trkpt>
+<trkpt lat="55.9435794" lon="-4.3107992">
+<ele>111.30000305175781></ele>
+<accuracy>4.779</accuracy>
+<speed>1.3853487</speed>
+<bearing>355.92758</bearing>
+<bearingAccuracyDegrees>11.547685</bearingAccuracyDegrees>
+<time>1746105904580</time>
+</trkpt>
+<trkpt lat="55.9435936" lon="-4.3107974">
+<ele>111.30000305175781></ele>
+<accuracy>4.669</accuracy>
+<speed>1.3983018</speed>
+<bearing>359.67307</bearing>
+<bearingAccuracyDegrees>11.7240305</bearingAccuracyDegrees>
+<time>1746105905582</time>
+</trkpt>
+<trkpt lat="55.9436075" lon="-4.3107923">
+<ele>111.30000305175781></ele>
+<accuracy>4.59</accuracy>
+<speed>1.4174479</speed>
+<bearing>3.848943</bearing>
+<bearingAccuracyDegrees>11.617268</bearingAccuracyDegrees>
+<time>1746105906584</time>
+</trkpt>
+<trkpt lat="55.9436217" lon="-4.3107847">
+<ele>111.30000305175781></ele>
+<accuracy>4.483</accuracy>
+<speed>1.4252511</speed>
+<bearing>7.4052114</bearing>
+<bearingAccuracyDegrees>9.974201</bearingAccuracyDegrees>
+<time>1746105907585</time>
+</trkpt>
+<trkpt lat="55.943636" lon="-4.3107799">
+<ele>111.30000305175781></ele>
+<accuracy>4.37</accuracy>
+<speed>1.4258105</speed>
+<bearing>7.0053954</bearing>
+<bearingAccuracyDegrees>10.235061</bearingAccuracyDegrees>
+<time>1746105908553</time>
+</trkpt>
+<trkpt lat="55.9436507" lon="-4.3107749">
+<ele>111.30000305175781></ele>
+<accuracy>4.306</accuracy>
+<speed>1.418523</speed>
+<bearing>10.648719</bearing>
+<bearingAccuracyDegrees>9.883504</bearingAccuracyDegrees>
+<time>1746105909603</time>
+</trkpt>
+<trkpt lat="55.9436672" lon="-4.3107701">
+<ele>111.30000305175781></ele>
+<accuracy>4.257</accuracy>
+<speed>1.4274569</speed>
+<bearing>9.537593</bearing>
+<bearingAccuracyDegrees>10.1992445</bearingAccuracyDegrees>
+<time>1746105910592</time>
+</trkpt>
+<trkpt lat="55.9436828" lon="-4.3107676">
+<ele>111.30000305175781></ele>
+<accuracy>4.214</accuracy>
+<speed>1.4109243</speed>
+<bearing>6.0808682</bearing>
+<bearingAccuracyDegrees>10.19447</bearingAccuracyDegrees>
+<time>1746105911596</time>
+</trkpt>
+<trkpt lat="55.9436964" lon="-4.3107658">
+<ele>111.30000305175781></ele>
+<accuracy>4.245</accuracy>
+<speed>1.42605</speed>
+<bearing>4.1520123</bearing>
+<bearingAccuracyDegrees>11.849693</bearingAccuracyDegrees>
+<time>1746105912598</time>
+</trkpt>
+<trkpt lat="55.9437097" lon="-4.3107647">
+<ele>111.30000305175781></ele>
+<accuracy>4.316</accuracy>
+<speed>1.4425688</speed>
+<bearing>5.0623326</bearing>
+<bearingAccuracyDegrees>12.284955</bearingAccuracyDegrees>
+<time>1746105913600</time>
+</trkpt>
+<trkpt lat="55.9437234" lon="-4.310762">
+<ele>111.30000305175781></ele>
+<accuracy>4.425</accuracy>
+<speed>1.4815751</speed>
+<bearing>4.587288</bearing>
+<bearingAccuracyDegrees>12.719608</bearingAccuracyDegrees>
+<time>1746105914601</time>
+</trkpt>
+<trkpt lat="55.9437356" lon="-4.3107608">
+<ele>111.30000305175781></ele>
+<accuracy>4.554</accuracy>
+<speed>1.4692916</speed>
+<bearing>357.89447</bearing>
+<bearingAccuracyDegrees>12.738315</bearingAccuracyDegrees>
+<time>1746105915505</time>
+</trkpt>
+<trkpt lat="55.9437533" lon="-4.3107699">
+<ele>111.30000305175781></ele>
+<accuracy>4.649</accuracy>
+<speed>1.4750758</speed>
+<bearing>354.61987</bearing>
+<bearingAccuracyDegrees>12.726864</bearingAccuracyDegrees>
+<time>1746105916409</time>
+</trkpt>
+<trkpt lat="55.9437696" lon="-4.3107721">
+<ele>111.30000305175781></ele>
+<accuracy>4.72</accuracy>
+<speed>1.4984107</speed>
+<bearing>358.7307</bearing>
+<bearingAccuracyDegrees>12.75632</bearingAccuracyDegrees>
+<time>1746105917460</time>
+</trkpt>
+<trkpt lat="55.9437865" lon="-4.3107697">
+<ele>111.30000305175781></ele>
+<accuracy>4.773</accuracy>
+<speed>1.4579203</speed>
+<bearing>359.40338</bearing>
+<bearingAccuracyDegrees>12.364872</bearingAccuracyDegrees>
+<time>1746105918553</time>
+</trkpt>
+<trkpt lat="55.9438029" lon="-4.310766">
+<ele>111.30000305175781></ele>
+<accuracy>4.787</accuracy>
+<speed>1.4212189</speed>
+<bearing>357.19547</bearing>
+<bearingAccuracyDegrees>12.415531</bearingAccuracyDegrees>
+<time>1746105919607</time>
+</trkpt>
+<trkpt lat="55.9438174" lon="-4.3107648">
+<ele>111.30000305175781></ele>
+<accuracy>4.782</accuracy>
+<speed>1.4143151</speed>
+<bearing>359.4137</bearing>
+<bearingAccuracyDegrees>11.974503</bearingAccuracyDegrees>
+<time>1746105920616</time>
+</trkpt>
+<trkpt lat="55.943832" lon="-4.3107617">
+<ele>111.30000305175781></ele>
+<accuracy>4.769</accuracy>
+<speed>1.4299896</speed>
+<bearing>4.35195</bearing>
+<bearingAccuracyDegrees>11.991526</bearingAccuracyDegrees>
+<time>1746105921617</time>
+</trkpt>
+<trkpt lat="55.9438451" lon="-4.3107572">
+<ele>111.30000305175781></ele>
+<accuracy>4.785</accuracy>
+<speed>1.4232748</speed>
+<bearing>7.892537</bearing>
+<bearingAccuracyDegrees>12.764912</bearingAccuracyDegrees>
+<time>1746105922620</time>
+</trkpt>
+<trkpt lat="55.9438586" lon="-4.3107523">
+<ele>111.30000305175781></ele>
+<accuracy>4.819</accuracy>
+<speed>1.4120723</speed>
+<bearing>5.3047495</bearing>
+<bearingAccuracyDegrees>12.729396</bearingAccuracyDegrees>
+<time>1746105923623</time>
+</trkpt>
+<trkpt lat="55.9439054" lon="-4.3107422">
+<ele>111.30000305175781></ele>
+<accuracy>5.081</accuracy>
+<speed>1.0973214</speed>
+<bearing>354.30542</bearing>
+<bearingAccuracyDegrees>12.766656</bearingAccuracyDegrees>
+<time>1746105928635</time>
+</trkpt>
+<trkpt lat="55.9439177" lon="-4.3107421">
+<ele>111.30000305175781></ele>
+<accuracy>5.054</accuracy>
+<speed>1.1798296</speed>
+<bearing>354.21063</bearing>
+<bearingAccuracyDegrees>12.699134</bearingAccuracyDegrees>
+<time>1746105929549</time>
+</trkpt>
+<trkpt lat="55.9439341" lon="-4.3107409">
+<ele>111.30000305175781></ele>
+<accuracy>5.074</accuracy>
+<speed>1.3116544</speed>
+<bearing>1.9050267</bearing>
+<bearingAccuracyDegrees>12.845579</bearingAccuracyDegrees>
+<time>1746105930639</time>
+</trkpt>
+<trkpt lat="55.9439517" lon="-4.3107365">
+<ele>111.97271954643458></ele>
+<accuracy>5.061</accuracy>
+<speed>1.4224988</speed>
+<bearing>4.167272</bearing>
+<bearingAccuracyDegrees>12.797556</bearingAccuracyDegrees>
+<time>1746105931548</time>
+</trkpt>
+<trkpt lat="55.9439683" lon="-4.3107324">
+<ele>111.97271954643458></ele>
+<accuracy>5.112</accuracy>
+<speed>1.4902937</speed>
+<bearing>6.065417</bearing>
+<bearingAccuracyDegrees>12.748784</bearingAccuracyDegrees>
+<time>1746105932485</time>
+</trkpt>
+<trkpt lat="55.9439879" lon="-4.3107299">
+<ele>111.96753643634995></ele>
+<accuracy>5.204</accuracy>
+<speed>1.5288723</speed>
+<bearing>6.3954062</bearing>
+<bearingAccuracyDegrees>12.482517</bearingAccuracyDegrees>
+<time>1746105933570</time>
+</trkpt>
+<trkpt lat="55.9440066" lon="-4.3107285">
+<ele>111.91051475548733></ele>
+<accuracy>5.323</accuracy>
+<speed>1.5164394</speed>
+<bearing>6.0602283</bearing>
+<bearingAccuracyDegrees>12.641372</bearingAccuracyDegrees>
+<time>1746105934629</time>
+</trkpt>
+<trkpt lat="55.9440229" lon="-4.3107274">
+<ele>111.87128227368603></ele>
+<accuracy>5.4</accuracy>
+<speed>1.5405847</speed>
+<bearing>4.4393477</bearing>
+<bearingAccuracyDegrees>12.197512</bearingAccuracyDegrees>
+<time>1746105935550</time>
+</trkpt>
+<trkpt lat="55.9440388" lon="-4.3107259">
+<ele>111.86510008853458></ele>
+<accuracy>5.451</accuracy>
+<speed>1.4833704</speed>
+<bearing>350.11884</bearing>
+<bearingAccuracyDegrees>12.168835</bearingAccuracyDegrees>
+<time>1746105936553</time>
+</trkpt>
+<trkpt lat="55.944054" lon="-4.3107294">
+<ele>111.87342472225629></ele>
+<accuracy>5.484</accuracy>
+<speed>1.4666947</speed>
+<bearing>353.2162</bearing>
+<bearingAccuracyDegrees>12.677231</bearingAccuracyDegrees>
+<time>1746105937555</time>
+</trkpt>
+<trkpt lat="55.9440693" lon="-4.3107276">
+<ele>111.90360158705323></ele>
+<accuracy>5.459</accuracy>
+<speed>1.4358938</speed>
+<bearing>6.7509174</bearing>
+<bearingAccuracyDegrees>12.146484</bearingAccuracyDegrees>
+<time>1746105938557</time>
+</trkpt>
+<trkpt lat="55.9440868" lon="-4.3107103">
+<ele>112.00453876631981></ele>
+<accuracy>5.054</accuracy>
+<speed>1.4545968</speed>
+<bearing>14.194883</bearing>
+<bearingAccuracyDegrees>10.042124</bearingAccuracyDegrees>
+<time>1746105939559</time>
+</trkpt>
+<trkpt lat="55.9441026" lon="-4.310697">
+<ele>111.79642216778252></ele>
+<accuracy>4.558</accuracy>
+<speed>1.4856973</speed>
+<bearing>24.595766</bearing>
+<bearingAccuracyDegrees>9.992351</bearingAccuracyDegrees>
+<time>1746105940561</time>
+</trkpt>
+<trkpt lat="55.9441149" lon="-4.3106823">
+<ele>111.69704826853874></ele>
+<accuracy>4.08</accuracy>
+<speed>1.4780213</speed>
+<bearing>42.50513</bearing>
+<bearingAccuracyDegrees>11.622745</bearingAccuracyDegrees>
+<time>1746105941564</time>
+</trkpt>
+<trkpt lat="55.9441248" lon="-4.310665">
+<ele>111.68300074190797></ele>
+<accuracy>3.597</accuracy>
+<speed>1.4962314</speed>
+<bearing>49.576035</bearing>
+<bearingAccuracyDegrees>10.158487</bearingAccuracyDegrees>
+<time>1746105942566</time>
+</trkpt>
+<trkpt lat="55.9441337" lon="-4.3106451">
+<ele>111.55429506564332></ele>
+<accuracy>3.135</accuracy>
+<speed>1.5093837</speed>
+<bearing>54.999146</bearing>
+<bearingAccuracyDegrees>11.639076</bearingAccuracyDegrees>
+<time>1746105943569</time>
+</trkpt>
+<trkpt lat="55.9441422" lon="-4.3106268">
+<ele>111.62245170332106></ele>
+<accuracy>3.038</accuracy>
+<speed>1.4879621</speed>
+<bearing>61.122673</bearing>
+<bearingAccuracyDegrees>11.636628</bearingAccuracyDegrees>
+<time>1746105944523</time>
+</trkpt>
+<trkpt lat="55.9441493" lon="-4.310604">
+<ele>111.54991305652004></ele>
+<accuracy>3.062</accuracy>
+<speed>1.46219</speed>
+<bearing>70.96951</bearing>
+<bearingAccuracyDegrees>12.058596</bearingAccuracyDegrees>
+<time>1746105945609</time>
+</trkpt>
+<trkpt lat="55.9441468" lon="-4.3104967">
+<ele>112.27209464975004></ele>
+<accuracy>4.316</accuracy>
+<speed>1.355301</speed>
+<bearing>93.0618</bearing>
+<bearingAccuracyDegrees>14.999418</bearingAccuracyDegrees>
+<time>1746105950584</time>
+</trkpt>
+<trkpt lat="55.9441444" lon="-4.3104733">
+<ele>112.45577154387138></ele>
+<accuracy>4.565</accuracy>
+<speed>1.4006191</speed>
+<bearing>94.71635</bearing>
+<bearingAccuracyDegrees>13.216224</bearingAccuracyDegrees>
+<time>1746105951587</time>
+</trkpt>
+<trkpt lat="55.9441419" lon="-4.3104486">
+<ele>112.55905670052454></ele>
+<accuracy>4.882</accuracy>
+<speed>1.4185073</speed>
+<bearing>95.37166</bearing>
+<bearingAccuracyDegrees>14.693551</bearingAccuracyDegrees>
+<time>1746105952588</time>
+</trkpt>
+<trkpt lat="55.9441368" lon="-4.3104228">
+<ele>112.55905670052454></ele>
+<accuracy>5.097</accuracy>
+<speed>1.4281863</speed>
+<bearing>91.23327</bearing>
+<bearingAccuracyDegrees>13.345618</bearingAccuracyDegrees>
+<time>1746105953608</time>
+</trkpt>
+<trkpt lat="55.9441322" lon="-4.310398">
+<ele>112.35098671012176></ele>
+<accuracy>5.353</accuracy>
+<speed>1.4430041</speed>
+<bearing>96.59971</bearing>
+<bearingAccuracyDegrees>12.951704</bearingAccuracyDegrees>
+<time>1746105954594</time>
+</trkpt>
+<trkpt lat="55.9441263" lon="-4.3103686">
+<ele>112.35098671012176></ele>
+<accuracy>5.509</accuracy>
+<speed>1.461779</speed>
+<bearing>102.86368</bearing>
+<bearingAccuracyDegrees>12.589317</bearingAccuracyDegrees>
+<time>1746105955630</time>
+</trkpt>
+<trkpt lat="55.9441223" lon="-4.3103464">
+<ele>112.58721114691267></ele>
+<accuracy>5.599</accuracy>
+<speed>1.4694886</speed>
+<bearing>103.657074</bearing>
+<bearingAccuracyDegrees>12.232439</bearingAccuracyDegrees>
+<time>1746105956598</time>
+</trkpt>
+<trkpt lat="55.9441177" lon="-4.3103232">
+<ele>112.5029175754054></ele>
+<accuracy>5.511</accuracy>
+<speed>1.428287</speed>
+<bearing>103.343666</bearing>
+<bearingAccuracyDegrees>12.12773</bearingAccuracyDegrees>
+<time>1746105957601</time>
+</trkpt>
+<trkpt lat="55.9441143" lon="-4.3102955">
+<ele>112.39260871753584></ele>
+<accuracy>5.432</accuracy>
+<speed>1.4676974</speed>
+<bearing>101.79431</bearing>
+<bearingAccuracyDegrees>10.088279</bearingAccuracyDegrees>
+<time>1746105958603</time>
+</trkpt>
+<trkpt lat="55.9441125" lon="-4.3102673">
+<ele>112.29478883857396></ele>
+<accuracy>5.248</accuracy>
+<speed>1.4893922</speed>
+<bearing>101.373344</bearing>
+<bearingAccuracyDegrees>9.702298</bearingAccuracyDegrees>
+<time>1746105959605</time>
+</trkpt>
+<trkpt lat="55.9441101" lon="-4.3102402">
+<ele>112.29478883857396></ele>
+<accuracy>5.157</accuracy>
+<speed>1.4629434</speed>
+<bearing>100.96854</bearing>
+<bearingAccuracyDegrees>9.421669</bearingAccuracyDegrees>
+<time>1746105960607</time>
+</trkpt>
+<trkpt lat="55.9441083" lon="-4.3102156">
+<ele>112.34630023189243></ele>
+<accuracy>5.026</accuracy>
+<speed>1.4496338</speed>
+<bearing>105.08253</bearing>
+<bearingAccuracyDegrees>9.713874</bearingAccuracyDegrees>
+<time>1746105961610</time>
+</trkpt>
+<trkpt lat="55.9441061" lon="-4.31019">
+<ele>112.34630023189243></ele>
+<accuracy>4.938</accuracy>
+<speed>1.4176998</speed>
+<bearing>103.98802</bearing>
+<bearingAccuracyDegrees>9.422845</bearingAccuracyDegrees>
+<time>1746105962617</time>
+</trkpt>
+<trkpt lat="55.9441044" lon="-4.3101689">
+<ele>112.59056361544606></ele>
+<accuracy>4.861</accuracy>
+<speed>1.3953724</speed>
+<bearing>101.17447</bearing>
+<bearingAccuracyDegrees>9.434722</bearingAccuracyDegrees>
+<time>1746105963614</time>
+</trkpt>
+<trkpt lat="55.944103" lon="-4.3101471">
+<ele>112.74957640391986></ele>
+<accuracy>4.718</accuracy>
+<speed>1.324036</speed>
+<bearing>98.82218</bearing>
+<bearingAccuracyDegrees>10.278704</bearingAccuracyDegrees>
+<time>1746105964617</time>
+</trkpt>
+<trkpt lat="55.9441029" lon="-4.3101263">
+<ele>112.89215156721383></ele>
+<accuracy>4.612</accuracy>
+<speed>1.2844793</speed>
+<bearing>97.5635</bearing>
+<bearingAccuracyDegrees>11.453084</bearingAccuracyDegrees>
+<time>1746105965618</time>
+</trkpt>
+<trkpt lat="55.9441032" lon="-4.3101073">
+<ele>113.27415909102248></ele>
+<accuracy>4.561</accuracy>
+<speed>1.2445374</speed>
+<bearing>98.788155</bearing>
+<bearingAccuracyDegrees>11.897674</bearingAccuracyDegrees>
+<time>1746105966621</time>
+</trkpt>
+<trkpt lat="55.9441035" lon="-4.3100903">
+<ele>113.58326716396274></ele>
+<accuracy>4.453</accuracy>
+<speed>1.2193239</speed>
+<bearing>98.698784</bearing>
+<bearingAccuracyDegrees>11.895226</bearingAccuracyDegrees>
+<time>1746105967624</time>
+</trkpt>
+<trkpt lat="55.9441024" lon="-4.310073">
+<ele>113.95275435357206></ele>
+<accuracy>4.402</accuracy>
+<speed>1.2042519</speed>
+<bearing>98.97222</bearing>
+<bearingAccuracyDegrees>12.1330805</bearingAccuracyDegrees>
+<time>1746105968626</time>
+</trkpt>
+<trkpt lat="55.9441043" lon="-4.3100555">
+<ele>114.27229551241953></ele>
+<accuracy>4.412</accuracy>
+<speed>0.9425778</speed>
+<bearing>96.141304</bearing>
+<bearingAccuracyDegrees>12.7309065</bearingAccuracyDegrees>
+<time>1746105970251</time>
+</trkpt>
+<trkpt lat="55.9441089" lon="-4.3100357">
+<ele>115.17566934616687></ele>
+<accuracy>4.258</accuracy>
+<speed>0.8567031</speed>
+<bearing>90.17822</bearing>
+<bearingAccuracyDegrees>14.826022</bearingAccuracyDegrees>
+<time>1746105974525</time>
+</trkpt>
+<trkpt lat="55.9441114" lon="-4.3100149">
+<ele>115.28322558844042></ele>
+<accuracy>4.228</accuracy>
+<speed>1.0186498</speed>
+<bearing>90.308426</bearing>
+<bearingAccuracyDegrees>15.842315</bearingAccuracyDegrees>
+<time>1746105975549</time>
+</trkpt>
+<trkpt lat="55.9441137" lon="-4.3099958">
+<ele>117.0></ele>
+<accuracy>4.224</accuracy>
+<speed>1.0325725</speed>
+<bearing>90.30509</bearing>
+<bearingAccuracyDegrees>15.399514</bearingAccuracyDegrees>
+<time>1746105976549</time>
+</trkpt>
+<trkpt lat="55.9441163" lon="-4.3099783">
+<ele>117.0></ele>
+<accuracy>4.264</accuracy>
+<speed>1.0323167</speed>
+<bearing>88.12451</bearing>
+<bearingAccuracyDegrees>14.996441</bearingAccuracyDegrees>
+<time>1746105977631</time>
+</trkpt>
+<trkpt lat="55.9441194" lon="-4.3099595">
+<ele>117.5999984741211></ele>
+<accuracy>4.402</accuracy>
+<speed>1.0027648</speed>
+<bearing>96.480736</bearing>
+<bearingAccuracyDegrees>14.895623</bearingAccuracyDegrees>
+<time>1746105978903</time>
+</trkpt>
+<trkpt lat="55.9441149" lon="-4.3099455">
+<ele>117.5999984741211></ele>
+<accuracy>4.478</accuracy>
+<speed>0.94850856</speed>
+<bearing>142.86082</bearing>
+<bearingAccuracyDegrees>15.576735</bearingAccuracyDegrees>
+<time>1746105980907</time>
+</trkpt>
+<trkpt lat="55.944105" lon="-4.3099431">
+<ele>117.5999984741211></ele>
+<accuracy>4.536</accuracy>
+<speed>0.92425823</speed>
+<bearing>157.06477</bearing>
+<bearingAccuracyDegrees>15.9840555</bearingAccuracyDegrees>
+<time>1746105982110</time>
+</trkpt>
+<trkpt lat="55.9440947" lon="-4.3099459">
+<ele>117.0></ele>
+<accuracy>4.55</accuracy>
+<speed>0.924052</speed>
+<bearing>160.38579</bearing>
+<bearingAccuracyDegrees>16.17098</bearingAccuracyDegrees>
+<time>1746105983220</time>
+</trkpt>
+<trkpt lat="55.9440815" lon="-4.3099512">
+<ele>117.0></ele>
+<accuracy>4.603</accuracy>
+<speed>0.90564656</speed>
+<bearing>164.16158</bearing>
+<bearingAccuracyDegrees>18.097881</bearingAccuracyDegrees>
+<time>1746105984383</time>
+</trkpt>
+<trkpt lat="55.9440656" lon="-4.3099548">
+<ele>117.0></ele>
+<accuracy>4.672</accuracy>
+<speed>1.0971271</speed>
+<bearing>169.78789</bearing>
+<bearingAccuracyDegrees>17.832314</bearingAccuracyDegrees>
+<time>1746105985627</time>
+</trkpt>
+<trkpt lat="55.9440541" lon="-4.3099602">
+<ele>117.0></ele>
+<accuracy>4.714</accuracy>
+<speed>1.1432827</speed>
+<bearing>161.35733</bearing>
+<bearingAccuracyDegrees>17.59602</bearingAccuracyDegrees>
+<time>1746105986567</time>
+</trkpt>
+<trkpt lat="55.9440428" lon="-4.3099572">
+<ele>117.0></ele>
+<accuracy>4.721</accuracy>
+<speed>1.0712419</speed>
+<bearing>133.56917</bearing>
+<bearingAccuracyDegrees>15.663417</bearingAccuracyDegrees>
+<time>1746105987624</time>
+</trkpt>
+<trkpt lat="55.9440356" lon="-4.3099448">
+<ele>117.0></ele>
+<accuracy>4.73</accuracy>
+<speed>0.9591236</speed>
+<bearing>107.29143</bearing>
+<bearingAccuracyDegrees>15.730604</bearingAccuracyDegrees>
+<time>1746105989045</time>
+</trkpt>
+<trkpt lat="55.9440335" lon="-4.3099282">
+<ele>117.0></ele>
+<accuracy>4.702</accuracy>
+<speed>0.9276891</speed>
+<bearing>98.02727</bearing>
+<bearingAccuracyDegrees>16.160639</bearingAccuracyDegrees>
+<time>1746105990576</time>
+</trkpt>
+<trkpt lat="55.9440285" lon="-4.3099108">
+<ele>117.0></ele>
+<accuracy>4.657</accuracy>
+<speed>0.92199373</speed>
+<bearing>103.04112</bearing>
+<bearingAccuracyDegrees>16.107515</bearingAccuracyDegrees>
+<time>1746105992579</time>
+</trkpt>
+<trkpt lat="55.9440266" lon="-4.3098929">
+<ele>117.0></ele>
+<accuracy>4.658</accuracy>
+<speed>0.7171077</speed>
+<bearing>101.710625</bearing>
+<bearingAccuracyDegrees>15.093712</bearingAccuracyDegrees>
+<time>1746105994247</time>
+</trkpt>
+<trkpt lat="55.9440265" lon="-4.3098756">
+<ele>117.0></ele>
+<accuracy>4.671</accuracy>
+<speed>0.8418314</speed>
+<bearing>94.24281</bearing>
+<bearingAccuracyDegrees>15.68212</bearingAccuracyDegrees>
+<time>1746105995587</time>
+</trkpt>
+<trkpt lat="55.9440246" lon="-4.3098577">
+<ele>118.97362887415775></ele>
+<accuracy>4.069</accuracy>
+<speed>0.8156802</speed>
+<bearing>97.77549</bearing>
+<bearingAccuracyDegrees>14.83323</bearingAccuracyDegrees>
+<time>1746105997592</time>
+</trkpt>
+<trkpt lat="55.9440313" lon="-4.3098452">
+<ele>118.30000305175781></ele>
+<accuracy>3.297</accuracy>
+<speed>0.6847096</speed>
+<bearing>92.79412</bearing>
+<bearingAccuracyDegrees>12.433315</bearingAccuracyDegrees>
+<time>1746105999952</time>
+</trkpt>
+<trkpt lat="55.9440325" lon="-4.309827">
+<ele>118.30000305175781></ele>
+<accuracy>3.0</accuracy>
+<speed>0.6058931</speed>
+<bearing>88.96404</bearing>
+<bearingAccuracyDegrees>12.597244</bearingAccuracyDegrees>
+<time>1746106002406</time>
+</trkpt>
+<trkpt lat="55.9440322" lon="-4.3098075">
+<ele>119.81331056837823></ele>
+<accuracy>3.0</accuracy>
+<speed>0.58599615</speed>
+<bearing>93.13543</bearing>
+<bearingAccuracyDegrees>13.133856</bearingAccuracyDegrees>
+<time>1746106004964</time>
+</trkpt>
+<trkpt lat="55.944019" lon="-4.3096914">
+<ele>121.0></ele>
+<accuracy>3.0</accuracy>
+<speed>0.9575403</speed>
+<bearing>98.77293</bearing>
+<bearingAccuracyDegrees>10.350388</bearingAccuracyDegrees>
+<time>1746106012026</time>
+</trkpt>
+<trkpt lat="55.9440156" lon="-4.3096713">
+<ele>121.0></ele>
+<accuracy>3.0</accuracy>
+<speed>0.9808961</speed>
+<bearing>98.2885</bearing>
+<bearingAccuracyDegrees>11.783442</bearingAccuracyDegrees>
+<time>1746106013291</time>
+</trkpt>
+<trkpt lat="55.9440179" lon="-4.309654">
+<ele>121.0></ele>
+<accuracy>3.0</accuracy>
+<speed>0.8067211</speed>
+<bearing>89.69483</bearing>
+<bearingAccuracyDegrees>11.947562</bearingAccuracyDegrees>
+<time>1746106015245</time>
+</trkpt>
+<trkpt lat="55.9440192" lon="-4.3096336">
+<ele>121.69999694824219></ele>
+<accuracy>3.0</accuracy>
+<speed>0.3917375</speed>
+<bearing>89.019585</bearing>
+<bearingAccuracyDegrees>9.852392</bearingAccuracyDegrees>
+<time>1746106021551</time>
+</trkpt>
+<trkpt lat="55.9440178" lon="-4.3096177">
+<ele>121.69999694824219></ele>
+<accuracy>3.0</accuracy>
+<speed>0.5266124</speed>
+<bearing>92.789444</bearing>
+<bearingAccuracyDegrees>10.225734</bearingAccuracyDegrees>
+<time>1746106022549</time>
+</trkpt>
+<trkpt lat="55.9440159" lon="-4.3095951">
+<ele>123.69999694824219></ele>
+<accuracy>3.0</accuracy>
+<speed>0.6191077</speed>
+<bearing>89.77443</bearing>
+<bearingAccuracyDegrees>11.690121</bearingAccuracyDegrees>
+<time>1746106024325</time>
+</trkpt>
+<trkpt lat="55.9440159" lon="-4.3095715">
+<ele>123.69999694824219></ele>
+<accuracy>3.0</accuracy>
+<speed>0.8086038</speed>
+<bearing>92.597275</bearing>
+<bearingAccuracyDegrees>11.882392</bearingAccuracyDegrees>
+<time>1746106025629</time>
+</trkpt>
+<trkpt lat="55.9440146" lon="-4.3095453">
+<ele>123.69999694824219></ele>
+<accuracy>3.0</accuracy>
+<speed>0.9466635</speed>
+<bearing>92.29866</bearing>
+<bearingAccuracyDegrees>10.226529</bearingAccuracyDegrees>
+<time>1746106026558</time>
+</trkpt>
+<trkpt lat="55.9440167" lon="-4.3095287">
+<ele>123.69999694824219></ele>
+<accuracy>3.0</accuracy>
+<speed>0.68955326</speed>
+<bearing>89.28005</bearing>
+<bearingAccuracyDegrees>12.570109</bearingAccuracyDegrees>
+<time>1746106028561</time>
+</trkpt>
+<trkpt lat="55.9440208" lon="-4.3095122">
+<ele>123.69999694824219></ele>
+<accuracy>3.0</accuracy>
+<speed>0.53036255</speed>
+<bearing>88.41662</bearing>
+<bearingAccuracyDegrees>11.850945</bearingAccuracyDegrees>
+<time>1746106031441</time>
+</trkpt>
+<trkpt lat="55.9440224" lon="-4.3094959">
+<ele>123.69999694824219></ele>
+<accuracy>3.0</accuracy>
+<speed>0.65869105</speed>
+<bearing>86.6683</bearing>
+<bearingAccuracyDegrees>9.465454</bearingAccuracyDegrees>
+<time>1746106032628</time>
+</trkpt>
+<trkpt lat="55.9440228" lon="-4.3094769">
+<ele>123.69999694824219></ele>
+<accuracy>3.0</accuracy>
+<speed>0.70058435</speed>
+<bearing>86.95338</bearing>
+<bearingAccuracyDegrees>10.457649</bearingAccuracyDegrees>
+<time>1746106033674</time>
+</trkpt>
+<trkpt lat="55.9440218" lon="-4.3094579">
+<ele>123.69999694824219></ele>
+<accuracy>3.0</accuracy>
+<speed>0.847056</speed>
+<bearing>85.098656</bearing>
+<bearingAccuracyDegrees>11.6242485</bearingAccuracyDegrees>
+<time>1746106034676</time>
+</trkpt>
+<trkpt lat="55.944022" lon="-4.3094393">
+<ele>123.69999694824219></ele>
+<accuracy>3.0</accuracy>
+<speed>0.9161033</speed>
+<bearing>80.037544</bearing>
+<bearingAccuracyDegrees>12.474117</bearingAccuracyDegrees>
+<time>1746106035578</time>
+</trkpt>
+<trkpt lat="55.9440239" lon="-4.3094155">
+<ele>123.69999694824219></ele>
+<accuracy>3.015</accuracy>
+<speed>1.0959381</speed>
+<bearing>71.60585</bearing>
+<bearingAccuracyDegrees>13.2773485</bearingAccuracyDegrees>
+<time>1746106036584</time>
+</trkpt>
+<trkpt lat="55.9440713" lon="-4.3094218">
+<ele>125.52201119084417></ele>
+<accuracy>4.015</accuracy>
+<speed>1.1554873</speed>
+<bearing>317.9573</bearing>
+<bearingAccuracyDegrees>14.581974</bearingAccuracyDegrees>
+<time>1746106042594</time>
+</trkpt>
+<trkpt lat="55.9440897" lon="-4.3094612">
+<ele>125.44592852814432></ele>
+<accuracy>4.249</accuracy>
+<speed>1.2603319</speed>
+<bearing>316.3431</bearing>
+<bearingAccuracyDegrees>15.062214</bearingAccuracyDegrees>
+<time>1746106044527</time>
+</trkpt>
+<trkpt lat="55.9441007" lon="-4.3094791">
+<ele>125.34796006343822></ele>
+<accuracy>4.385</accuracy>
+<speed>1.2944757</speed>
+<bearing>319.12027</bearing>
+<bearingAccuracyDegrees>15.299672</bearingAccuracyDegrees>
+<time>1746106045604</time>
+</trkpt>
+<trkpt lat="55.9441119" lon="-4.3094919">
+<ele>123.69999694824219></ele>
+<accuracy>4.52</accuracy>
+<speed>1.3426375</speed>
+<bearing>319.22086</bearing>
+<bearingAccuracyDegrees>15.768856</bearingAccuracyDegrees>
+<time>1746106046603</time>
+</trkpt>
+<trkpt lat="55.944125" lon="-4.3095041">
+<ele>123.69999694824219></ele>
+<accuracy>4.686</accuracy>
+<speed>1.3914587</speed>
+<bearing>318.95554</bearing>
+<bearingAccuracyDegrees>15.625649</bearingAccuracyDegrees>
+<time>1746106047605</time>
+</trkpt>
+<trkpt lat="55.9441374" lon="-4.3095177">
+<ele>124.3202539464665></ele>
+<accuracy>4.873</accuracy>
+<speed>1.4130235</speed>
+<bearing>317.84824</bearing>
+<bearingAccuracyDegrees>16.135923</bearingAccuracyDegrees>
+<time>1746106048607</time>
+</trkpt>
+<trkpt lat="55.9441503" lon="-4.3095323">
+<ele>124.42991948591438></ele>
+<accuracy>5.076</accuracy>
+<speed>1.4133236</speed>
+<bearing>321.6003</bearing>
+<bearingAccuracyDegrees>14.291357</bearingAccuracyDegrees>
+<time>1746106049610</time>
+</trkpt>
+<trkpt lat="55.9441642" lon="-4.309543">
+<ele>124.44468946168766></ele>
+<accuracy>5.207</accuracy>
+<speed>1.4091649</speed>
+<bearing>327.8316</bearing>
+<bearingAccuracyDegrees>12.924594</bearingAccuracyDegrees>
+<time>1746106050613</time>
+</trkpt>
+<trkpt lat="55.9441784" lon="-4.3095549">
+<ele>124.77536022414492></ele>
+<accuracy>5.319</accuracy>
+<speed>1.400031</speed>
+<bearing>326.78387</bearing>
+<bearingAccuracyDegrees>11.92811</bearingAccuracyDegrees>
+<time>1746106051614</time>
+</trkpt>
+<trkpt lat="55.9441914" lon="-4.3095597">
+<ele>125.08383978731493></ele>
+<accuracy>5.178</accuracy>
+<speed>1.3532082</speed>
+<bearing>26.458029</bearing>
+<bearingAccuracyDegrees>11.657322</bearingAccuracyDegrees>
+<time>1746106052617</time>
+</trkpt>
+<trkpt lat="55.9441966" lon="-4.3095408">
+<ele>125.05986969503505></ele>
+<accuracy>4.825</accuracy>
+<speed>1.3479831</speed>
+<bearing>76.41772</bearing>
+<bearingAccuracyDegrees>12.311306</bearingAccuracyDegrees>
+<time>1746106053620</time>
+</trkpt>
+<trkpt lat="55.9442021" lon="-4.309528">
+<ele>124.82830324558509></ele>
+<accuracy>4.114</accuracy>
+<speed>1.3080484</speed>
+<bearing>20.512045</bearing>
+<bearingAccuracyDegrees>11.863814</bearingAccuracyDegrees>
+<time>1746106054744</time>
+</trkpt>
+<trkpt lat="55.9442162" lon="-4.3095418">
+<ele>124.64979528155624></ele>
+<accuracy>3.637</accuracy>
+<speed>1.3383652</speed>
+<bearing>300.99817</bearing>
+<bearingAccuracyDegrees>12.383984</bearingAccuracyDegrees>
+<time>1746106055847</time>
+</trkpt>
+<trkpt lat="55.9442253" lon="-4.309578">
+<ele>124.64979528155624></ele>
+<accuracy>3.104</accuracy>
+<speed>1.381018</speed>
+<bearing>306.55188</bearing>
+<bearingAccuracyDegrees>12.622175</bearingAccuracyDegrees>
+<time>1746106057090</time>
+</trkpt>
+<trkpt lat="55.9442395" lon="-4.3095913">
+<ele>124.72170374150272></ele>
+<accuracy>3.125</accuracy>
+<speed>1.3391409</speed>
+<bearing>27.224972</bearing>
+<bearingAccuracyDegrees>12.488811</bearingAccuracyDegrees>
+<time>1746106058047</time>
+</trkpt>
+<trkpt lat="55.9442497" lon="-4.3095763">
+<ele>124.86713256551366></ele>
+<accuracy>3.221</accuracy>
+<speed>1.366094</speed>
+<bearing>80.53349</bearing>
+<bearingAccuracyDegrees>11.980874</bearingAccuracyDegrees>
+<time>1746106059044</time>
+</trkpt>
+<trkpt lat="55.9442531" lon="-4.3095604">
+<ele>124.84400597964711></ele>
+<accuracy>3.271</accuracy>
+<speed>1.3461487</speed>
+<bearing>93.34374</bearing>
+<bearingAccuracyDegrees>15.366456</bearingAccuracyDegrees>
+<time>1746106060088</time>
+</trkpt>
+<trkpt lat="55.9442585" lon="-4.3095471">
+<ele>124.76271630834995></ele>
+<accuracy>3.297</accuracy>
+<speed>1.3332965</speed>
+<bearing>84.81339</bearing>
+<bearingAccuracyDegrees>15.757815</bearingAccuracyDegrees>
+<time>1746106061171</time>
+</trkpt>
+<trkpt lat="55.9442661" lon="-4.3095339">
+<ele>125.28386427823173></ele>
+<accuracy>3.33</accuracy>
+<speed>1.2831659</speed>
+<bearing>83.95142</bearing>
+<bearingAccuracyDegrees>16.310701</bearingAccuracyDegrees>
+<time>1746106062844</time>
+</trkpt>
+<trkpt lat="55.9442765" lon="-4.3095252">
+<ele>125.34379121735552></ele>
+<accuracy>3.293</accuracy>
+<speed>1.3057865</speed>
+<bearing>74.359436</bearing>
+<bearingAccuracyDegrees>12.562615</bearingAccuracyDegrees>
+<time>1746106063943</time>
+</trkpt>
+<trkpt lat="55.9442901" lon="-4.3095189">
+<ele>125.21277624890442></ele>
+<accuracy>3.25</accuracy>
+<speed>1.2212007</speed>
+<bearing>42.72478</bearing>
+<bearingAccuracyDegrees>11.807463</bearingAccuracyDegrees>
+<time>1746106065087</time>
+</trkpt>
+<trkpt lat="55.9443022" lon="-4.3095166">
+<ele>125.31074544971925></ele>
+<accuracy>3.288</accuracy>
+<speed>1.3183533</speed>
+<bearing>53.44987</bearing>
+<bearingAccuracyDegrees>12.213901</bearingAccuracyDegrees>
+<time>1746106066165</time>
+</trkpt>
+<trkpt lat="55.9443139" lon="-4.3095094">
+<ele>125.53730289794068></ele>
+<accuracy>3.323</accuracy>
+<speed>1.3592082</speed>
+<bearing>49.428272</bearing>
+<bearingAccuracyDegrees>11.505076</bearingAccuracyDegrees>
+<time>1746106067183</time>
+</trkpt>
+<trkpt lat="55.9443296" lon="-4.3095036">
+<ele>125.56161613096182></ele>
+<accuracy>3.291</accuracy>
+<speed>1.3825437</speed>
+<bearing>50.384136</bearing>
+<bearingAccuracyDegrees>10.223588</bearingAccuracyDegrees>
+<time>1746106068307</time>
+</trkpt>
+<trkpt lat="55.9443427" lon="-4.3094894">
+<ele>125.7078448102231></ele>
+<accuracy>3.313</accuracy>
+<speed>1.3949404</speed>
+<bearing>49.164646</bearing>
+<bearingAccuracyDegrees>11.788109</bearingAccuracyDegrees>
+<time>1746106069449</time>
+</trkpt>
+<trkpt lat="55.9443556" lon="-4.3094702">
+<ele>125.89305409540398></ele>
+<accuracy>3.512</accuracy>
+<speed>1.3767604</speed>
+<bearing>45.165535</bearing>
+<bearingAccuracyDegrees>12.021024</bearingAccuracyDegrees>
+<time>1746106070583</time>
+</trkpt>
+<trkpt lat="55.9443643" lon="-4.3094538">
+<ele>125.96184470757495></ele>
+<accuracy>3.717</accuracy>
+<speed>1.3443228</speed>
+<bearing>49.755558</bearing>
+<bearingAccuracyDegrees>12.949408</bearingAccuracyDegrees>
+<time>1746106071560</time>
+</trkpt>
+<trkpt lat="55.9443728" lon="-4.3094374">
+<ele>126.06503165756027></ele>
+<accuracy>4.171</accuracy>
+<speed>1.297159</speed>
+<bearing>56.39907</bearing>
+<bearingAccuracyDegrees>14.628991</bearingAccuracyDegrees>
+<time>1746106072563</time>
+</trkpt>
+<trkpt lat="55.9443824" lon="-4.3094298">
+<ele>126.23701265889142></ele>
+<accuracy>4.927</accuracy>
+<speed>1.2531561</speed>
+<bearing>49.995068</bearing>
+<bearingAccuracyDegrees>15.578504</bearingAccuracyDegrees>
+<time>1746106073565</time>
+</trkpt>
+<trkpt lat="55.9443974" lon="-4.309439">
+<ele>126.38764725124378></ele>
+<accuracy>5.695</accuracy>
+<speed>1.2560315</speed>
+<bearing>42.654232</bearing>
+<bearingAccuracyDegrees>12.514394</bearingAccuracyDegrees>
+<time>1746106074567</time>
+</trkpt>
+<trkpt lat="55.944415" lon="-4.3094589">
+<ele>126.61279513070616></ele>
+<accuracy>5.812</accuracy>
+<speed>1.2377694</speed>
+<bearing>36.3658</bearing>
+<bearingAccuracyDegrees>9.02722</bearingAccuracyDegrees>
+<time>1746106075570</time>
+</trkpt>
+<trkpt lat="55.9444305" lon="-4.3094636">
+<ele>126.61279513070616></ele>
+<accuracy>5.849</accuracy>
+<speed>1.2592187</speed>
+<bearing>40.53909</bearing>
+<bearingAccuracyDegrees>7.151775</bearingAccuracyDegrees>
+<time>1746106076565</time>
+</trkpt>
+<trkpt lat="55.9444421" lon="-4.309456">
+<ele>126.74373336187621></ele>
+<accuracy>5.662</accuracy>
+<speed>1.2381856</speed>
+<bearing>39.615856</bearing>
+<bearingAccuracyDegrees>9.637507</bearingAccuracyDegrees>
+<time>1746106077574</time>
+</trkpt>
+<trkpt lat="55.9444516" lon="-4.3094427">
+<ele>126.91462272056145></ele>
+<accuracy>5.383</accuracy>
+<speed>1.2171271</speed>
+<bearing>39.233517</bearing>
+<bearingAccuracyDegrees>9.569807</bearingAccuracyDegrees>
+<time>1746106078576</time>
+</trkpt>
+<trkpt lat="55.9444577" lon="-4.3094267">
+<ele>128.0></ele>
+<accuracy>5.393</accuracy>
+<speed>1.2280298</speed>
+<bearing>41.398617</bearing>
+<bearingAccuracyDegrees>11.329165</bearingAccuracyDegrees>
+<time>1746106079482</time>
+</trkpt>
+<trkpt lat="55.9444652" lon="-4.3094095">
+<ele>128.0></ele>
+<accuracy>5.652</accuracy>
+<speed>1.2459388</speed>
+<bearing>41.59996</bearing>
+<bearingAccuracyDegrees>12.601364</bearingAccuracyDegrees>
+<time>1746106080581</time>
+</trkpt>
+<trkpt lat="55.9444728" lon="-4.3093908">
+<ele>128.0></ele>
+<accuracy>6.415</accuracy>
+<speed>1.2493457</speed>
+<bearing>45.48109</bearing>
+<bearingAccuracyDegrees>13.086017</bearingAccuracyDegrees>
+<time>1746106081583</time>
+</trkpt>
+<trkpt lat="55.9444802" lon="-4.3093726">
+<ele>128.0></ele>
+<accuracy>7.41</accuracy>
+<speed>1.2546195</speed>
+<bearing>47.240654</bearing>
+<bearingAccuracyDegrees>14.928145</bearingAccuracyDegrees>
+<time>1746106082586</time>
+</trkpt>
+<trkpt lat="55.9444897" lon="-4.3093516">
+<ele>128.0></ele>
+<accuracy>8.294</accuracy>
+<speed>1.2810788</speed>
+<bearing>53.894493</bearing>
+<bearingAccuracyDegrees>15.150852</bearingAccuracyDegrees>
+<time>1746106083653</time>
+</trkpt>
+<trkpt lat="55.944496" lon="-4.3093358">
+<ele>127.84456989447466></ele>
+<accuracy>9.327</accuracy>
+<speed>1.2837975</speed>
+<bearing>54.59798</bearing>
+<bearingAccuracyDegrees>15.250565</bearingAccuracyDegrees>
+<time>1746106084590</time>
+</trkpt>
+<trkpt lat="55.9445027" lon="-4.309317">
+<ele>128.0900902623698></ele>
+<accuracy>9.887</accuracy>
+<speed>1.2622778</speed>
+<bearing>46.404594</bearing>
+<bearingAccuracyDegrees>15.469452</bearingAccuracyDegrees>
+<time>1746106085592</time>
+</trkpt>
+<trkpt lat="55.9445093" lon="-4.3092985">
+<ele>128.0900902623698></ele>
+<accuracy>10.567</accuracy>
+<speed>1.2604343</speed>
+<bearing>49.79816</bearing>
+<bearingAccuracyDegrees>16.387526</bearingAccuracyDegrees>
+<time>1746106086527</time>
+</trkpt>
+<trkpt lat="55.9445151" lon="-4.3092781">
+<ele>128.253289484031></ele>
+<accuracy>11.417</accuracy>
+<speed>1.2702451</speed>
+<bearing>51.42534</bearing>
+<bearingAccuracyDegrees>17.759909</bearingAccuracyDegrees>
+<time>1746106087597</time>
+</trkpt>
+<trkpt lat="55.9445214" lon="-4.3092581">
+<ele>128.26460047120764></ele>
+<accuracy>12.076</accuracy>
+<speed>1.2655487</speed>
+<bearing>56.445057</bearing>
+<bearingAccuracyDegrees>18.128395</bearingAccuracyDegrees>
+<time>1746106088599</time>
+</trkpt>
+<trkpt lat="55.9445283" lon="-4.3092398">
+<ele>128.4492969028094></ele>
+<accuracy>13.356</accuracy>
+<speed>1.2642612</speed>
+<bearing>52.368805</bearing>
+<bearingAccuracyDegrees>18.364922</bearingAccuracyDegrees>
+<time>1746106089602</time>
+</trkpt>
+<trkpt lat="55.9445357" lon="-4.3092195">
+<ele>128.4492969028094></ele>
+<accuracy>14.379</accuracy>
+<speed>1.2844149</speed>
+<bearing>52.003975</bearing>
+<bearingAccuracyDegrees>18.045124</bearingAccuracyDegrees>
+<time>1746106090588</time>
+</trkpt>
+<trkpt lat="55.9445416" lon="-4.3091997">
+<ele>128.58370220314262></ele>
+<accuracy>15.306</accuracy>
+<speed>1.27255</speed>
+<bearing>56.001</bearing>
+<bearingAccuracyDegrees>18.701603</bearingAccuracyDegrees>
+<time>1746106091606</time>
+</trkpt>
+<trkpt lat="55.9445482" lon="-4.3091838">
+<ele>128.7577106386939></ele>
+<accuracy>16.469</accuracy>
+<speed>1.2931703</speed>
+<bearing>53.629047</bearing>
+<bearingAccuracyDegrees>18.480215</bearingAccuracyDegrees>
+<time>1746106092608</time>
+</trkpt>
+<trkpt lat="55.9445621" lon="-4.309192">
+<ele>128.6063916540764></ele>
+<accuracy>18.533</accuracy>
+<speed>1.260335</speed>
+<bearing>44.38213</bearing>
+<bearingAccuracyDegrees>36.347233</bearingAccuracyDegrees>
+<time>1746106093610</time>
+</trkpt>
+<trkpt lat="55.9446146" lon="-4.309335">
+<ele>128.69240913780925></ele>
+<accuracy>19.31</accuracy>
+<speed>1.2598333</speed>
+<bearing>358.9776</bearing>
+<bearingAccuracyDegrees>10.226261</bearingAccuracyDegrees>
+<time>1746106094613</time>
+</trkpt>
+<trkpt lat="55.9446797" lon="-4.3095207">
+<ele>128.76122374425358></ele>
+<accuracy>17.229</accuracy>
+<speed>1.267139</speed>
+<bearing>350.559</bearing>
+<bearingAccuracyDegrees>7.117583</bearingAccuracyDegrees>
+<time>1746106095615</time>
+</trkpt>
+<trkpt lat="55.9447039" lon="-4.3095595">
+<ele>128.8573665933971></ele>
+<accuracy>14.309</accuracy>
+<speed>1.2798777</speed>
+<bearing>350.4098</bearing>
+<bearingAccuracyDegrees>6.779381</bearingAccuracyDegrees>
+<time>1746106096617</time>
+</trkpt>
+<trkpt lat="55.9447218" lon="-4.3095737">
+<ele>128.8573665933971></ele>
+<accuracy>11.696</accuracy>
+<speed>1.3215947</speed>
+<bearing>346.43997</bearing>
+<bearingAccuracyDegrees>8.634637</bearingAccuracyDegrees>
+<time>1746106097563</time>
+</trkpt>
+<trkpt lat="55.9447383" lon="-4.3095915">
+<ele>129.08910803842997></ele>
+<accuracy>8.624</accuracy>
+<speed>1.3219821</speed>
+<bearing>345.89377</bearing>
+<bearingAccuracyDegrees>9.386058</bearingAccuracyDegrees>
+<time>1746106098622</time>
+</trkpt>
+<trkpt lat="55.9447563" lon="-4.309614">
+<ele>130.90000915527344></ele>
+<accuracy>3.919</accuracy>
+<speed>1.3142637</speed>
+<bearing>348.86853</bearing>
+<bearingAccuracyDegrees>12.614644</bearingAccuracyDegrees>
+<time>1746106099624</time>
+</trkpt>
+<trkpt lat="55.9447708" lon="-4.3096441">
+<ele>130.90000915527344></ele>
+<accuracy>3.052</accuracy>
+<speed>1.2906374</speed>
+<bearing>330.1003</bearing>
+<bearingAccuracyDegrees>8.941766</bearingAccuracyDegrees>
+<time>1746106100627</time>
+</trkpt>
+<trkpt lat="55.9447843" lon="-4.3096729">
+<ele>130.90000915527344></ele>
+<accuracy>3.062</accuracy>
+<speed>1.33765</speed>
+<bearing>320.1447</bearing>
+<bearingAccuracyDegrees>6.9257855</bearingAccuracyDegrees>
+<time>1746106101631</time>
+</trkpt>
+<trkpt lat="55.9447959" lon="-4.3096956">
+<ele>130.50001525878906></ele>
+<accuracy>3.058</accuracy>
+<speed>1.3538475</speed>
+<bearing>328.72867</bearing>
+<bearingAccuracyDegrees>6.804981</bearingAccuracyDegrees>
+<time>1746106102630</time>
+</trkpt>
+<trkpt lat="55.9448097" lon="-4.3097139">
+<ele>130.50001525878906></ele>
+<accuracy>3.074</accuracy>
+<speed>1.3290266</speed>
+<bearing>334.5483</bearing>
+<bearingAccuracyDegrees>7.132993</bearingAccuracyDegrees>
+<time>1746106103634</time>
+</trkpt>
+<trkpt lat="55.9448245" lon="-4.3097273">
+<ele>130.50001525878906></ele>
+<accuracy>3.074</accuracy>
+<speed>1.2925671</speed>
+<bearing>318.08676</bearing>
+<bearingAccuracyDegrees>8.950986</bearingAccuracyDegrees>
+<time>1746106104636</time>
+</trkpt>
+<trkpt lat="55.9448345" lon="-4.3097417">
+<ele>130.50001525878906></ele>
+<accuracy>3.102</accuracy>
+<speed>1.2815983</speed>
+<bearing>315.17865</bearing>
+<bearingAccuracyDegrees>9.5791235</bearingAccuracyDegrees>
+<time>1746106105537</time>
+</trkpt>
+<trkpt lat="55.9448441" lon="-4.3097499">
+<ele>130.50001525878906></ele>
+<accuracy>3.193</accuracy>
+<speed>1.2743926</speed>
+<bearing>328.92938</bearing>
+<bearingAccuracyDegrees>9.747543</bearingAccuracyDegrees>
+<time>1746106106540</time>
+</trkpt>
+<trkpt lat="55.9448535" lon="-4.3097522">
+<ele>130.50001525878906></ele>
+<accuracy>3.298</accuracy>
+<speed>1.2617564</speed>
+<bearing>335.57822</bearing>
+<bearingAccuracyDegrees>9.716541</bearingAccuracyDegrees>
+<time>1746106107487</time>
+</trkpt>
+<trkpt lat="55.9448654" lon="-4.3097527">
+<ele>130.50001525878906></ele>
+<accuracy>3.498</accuracy>
+<speed>1.2723976</speed>
+<bearing>342.43222</bearing>
+<bearingAccuracyDegrees>9.863827</bearingAccuracyDegrees>
+<time>1746106108645</time>
+</trkpt>
+<trkpt lat="55.9448808" lon="-4.3097455">
+<ele>130.50001525878906></ele>
+<accuracy>3.725</accuracy>
+<speed>1.3092932</speed>
+<bearing>347.06097</bearing>
+<bearingAccuracyDegrees>10.208452</bearingAccuracyDegrees>
+<time>1746106109547</time>
+</trkpt>
+<trkpt lat="55.9448937" lon="-4.3097393">
+<ele>130.50001525878906></ele>
+<accuracy>3.847</accuracy>
+<speed>1.3008447</speed>
+<bearing>343.17352</bearing>
+<bearingAccuracyDegrees>11.552781</bearingAccuracyDegrees>
+<time>1746106110481</time>
+</trkpt>
+<trkpt lat="55.9449088" lon="-4.3097335">
+<ele>130.50001525878906></ele>
+<accuracy>3.998</accuracy>
+<speed>1.3052268</speed>
+<bearing>343.4671</bearing>
+<bearingAccuracyDegrees>9.930986</bearingAccuracyDegrees>
+<time>1746106111657</time>
+</trkpt>
+<trkpt lat="55.9449221" lon="-4.3097228">
+<ele>130.90000915527344></ele>
+<accuracy>4.002</accuracy>
+<speed>1.3008062</speed>
+<bearing>353.23007</bearing>
+<bearingAccuracyDegrees>9.692444</bearingAccuracyDegrees>
+<time>1746106112787</time>
+</trkpt>
+<trkpt lat="55.9449379" lon="-4.3097194">
+<ele>130.90000915527344></ele>
+<accuracy>4.017</accuracy>
+<speed>1.2711029</speed>
+<bearing>351.824</bearing>
+<bearingAccuracyDegrees>10.107823</bearingAccuracyDegrees>
+<time>1746106114157</time>
+</trkpt>
+<trkpt lat="55.9449549" lon="-4.3097097">
+<ele>130.90000915527344></ele>
+<accuracy>3.959</accuracy>
+<speed>1.2711829</speed>
+<bearing>357.491</bearing>
+<bearingAccuracyDegrees>9.731871</bearingAccuracyDegrees>
+<time>1746106115265</time>
+</trkpt>
+<trkpt lat="55.9449668" lon="-4.3097019">
+<ele>130.90000915527344></ele>
+<accuracy>3.892</accuracy>
+<speed>1.2799925</speed>
+<bearing>2.9682033</bearing>
+<bearingAccuracyDegrees>9.712862</bearingAccuracyDegrees>
+<time>1746106116325</time>
+</trkpt>
+<trkpt lat="55.9449803" lon="-4.3096893">
+<ele>130.50001525878906></ele>
+<accuracy>3.848</accuracy>
+<speed>1.2973772</speed>
+<bearing>12.233717</bearing>
+<bearingAccuracyDegrees>9.639499</bearingAccuracyDegrees>
+<time>1746106117468</time>
+</trkpt>
+<trkpt lat="55.9449931" lon="-4.3096765">
+<ele>130.50001525878906></ele>
+<accuracy>3.808</accuracy>
+<speed>1.3060236</speed>
+<bearing>12.54431</bearing>
+<bearingAccuracyDegrees>9.566894</bearingAccuracyDegrees>
+<time>1746106118567</time>
+</trkpt>
+<trkpt lat="55.9450041" lon="-4.3096643">
+<ele>130.50001525878906></ele>
+<accuracy>3.764</accuracy>
+<speed>1.3140413</speed>
+<bearing>13.577458</bearing>
+<bearingAccuracyDegrees>9.589054</bearingAccuracyDegrees>
+<time>1746106119570</time>
+</trkpt>
+<trkpt lat="55.9450157" lon="-4.3096524">
+<ele>130.50001525878906></ele>
+<accuracy>3.72</accuracy>
+<speed>1.340444</speed>
+<bearing>10.333316</bearing>
+<bearingAccuracyDegrees>9.89644</bearingAccuracyDegrees>
+<time>1746106120572</time>
+</trkpt>
+<trkpt lat="55.9450269" lon="-4.3096424">
+<ele>130.50001525878906></ele>
+<accuracy>3.703</accuracy>
+<speed>1.3351606</speed>
+<bearing>10.270883</bearing>
+<bearingAccuracyDegrees>11.590069</bearingAccuracyDegrees>
+<time>1746106121508</time>
+</trkpt>
+<trkpt lat="55.9450393" lon="-4.3096317">
+<ele>130.90000915527344></ele>
+<accuracy>3.77</accuracy>
+<speed>1.3639436</speed>
+<bearing>11.388529</bearing>
+<bearingAccuracyDegrees>11.944746</bearingAccuracyDegrees>
+<time>1746106122576</time>
+</trkpt>
+<trkpt lat="55.9450504" lon="-4.3096237">
+<ele>130.90000915527344></ele>
+<accuracy>3.794</accuracy>
+<speed>1.3293883</speed>
+<bearing>9.668311</bearing>
+<bearingAccuracyDegrees>11.655846</bearingAccuracyDegrees>
+<time>1746106123579</time>
+</trkpt>
+<trkpt lat="55.9450633" lon="-4.30961">
+<ele>130.90000915527344></ele>
+<accuracy>3.89</accuracy>
+<speed>1.3539628</speed>
+<bearing>18.684809</bearing>
+<bearingAccuracyDegrees>12.602116</bearingAccuracyDegrees>
+<time>1746106124581</time>
+</trkpt>
+<trkpt lat="55.9450736" lon="-4.3095964">
+<ele>130.90000915527344></ele>
+<accuracy>4.055</accuracy>
+<speed>1.3350936</speed>
+<bearing>25.17559</bearing>
+<bearingAccuracyDegrees>12.704021</bearingAccuracyDegrees>
+<time>1746106125583</time>
+</trkpt>
+<trkpt lat="55.9450828" lon="-4.3095754">
+<ele>130.90000915527344></ele>
+<accuracy>4.151</accuracy>
+<speed>1.3326079</speed>
+<bearing>31.878962</bearing>
+<bearingAccuracyDegrees>12.4749565</bearingAccuracyDegrees>
+<time>1746106126609</time>
+</trkpt>
+<trkpt lat="55.945091" lon="-4.3095578">
+<ele>130.90000915527344></ele>
+<accuracy>4.21</accuracy>
+<speed>1.3447278</speed>
+<bearing>25.554441</bearing>
+<bearingAccuracyDegrees>12.518089</bearingAccuracyDegrees>
+<time>1746106127588</time>
+</trkpt>
+<trkpt lat="55.9451" lon="-4.3095474">
+<ele>130.90000915527344></ele>
+<accuracy>4.297</accuracy>
+<speed>1.3224648</speed>
+<bearing>29.24807</bearing>
+<bearingAccuracyDegrees>12.274066</bearingAccuracyDegrees>
+<time>1746106128590</time>
+</trkpt>
+<trkpt lat="55.945111" lon="-4.309533">
+<ele>132.2115783512596></ele>
+<accuracy>4.373</accuracy>
+<speed>1.2993754</speed>
+<bearing>35.881798</bearing>
+<bearingAccuracyDegrees>10.423688</bearingAccuracyDegrees>
+<time>1746106129593</time>
+</trkpt>
+<trkpt lat="55.9451212" lon="-4.3095237">
+<ele>132.2115783512596></ele>
+<accuracy>4.362</accuracy>
+<speed>1.2902948</speed>
+<bearing>37.177025</bearing>
+<bearingAccuracyDegrees>11.895978</bearingAccuracyDegrees>
+<time>1746106130628</time>
+</trkpt>
+<trkpt lat="55.9451309" lon="-4.3095146">
+<ele>132.14849183162528></ele>
+<accuracy>4.324</accuracy>
+<speed>1.3240336</speed>
+<bearing>33.13286</bearing>
+<bearingAccuracyDegrees>9.979252</bearingAccuracyDegrees>
+<time>1746106131812</time>
+</trkpt>
+<trkpt lat="55.9451427" lon="-4.3095059">
+<ele>130.50001525878906></ele>
+<accuracy>4.295</accuracy>
+<speed>1.3460938</speed>
+<bearing>26.746054</bearing>
+<bearingAccuracyDegrees>9.94365</bearingAccuracyDegrees>
+<time>1746106132944</time>
+</trkpt>
+<trkpt lat="55.9451539" lon="-4.309496">
+<ele>130.50001525878906></ele>
+<accuracy>4.252</accuracy>
+<speed>1.354607</speed>
+<bearing>30.935863</bearing>
+<bearingAccuracyDegrees>11.456303</bearingAccuracyDegrees>
+<time>1746106134084</time>
+</trkpt>
+<trkpt lat="55.9451655" lon="-4.3094772">
+<ele>132.1009659207659></ele>
+<accuracy>4.12</accuracy>
+<speed>1.3424152</speed>
+<bearing>35.193985</bearing>
+<bearingAccuracyDegrees>10.277461</bearingAccuracyDegrees>
+<time>1746106135249</time>
+</trkpt>
+<trkpt lat="55.9451739" lon="-4.3094672">
+<ele>132.34989225511075></ele>
+<accuracy>4.051</accuracy>
+<speed>1.3043274</speed>
+<bearing>34.37278</bearing>
+<bearingAccuracyDegrees>9.980243</bearingAccuracyDegrees>
+<time>1746106136392</time>
+</trkpt>
+<trkpt lat="55.945183" lon="-4.3094553">
+<ele>132.45685390397165></ele>
+<accuracy>3.955</accuracy>
+<speed>1.2981622</speed>
+<bearing>40.62614</bearing>
+<bearingAccuracyDegrees>9.847691</bearingAccuracyDegrees>
+<time>1746106137583</time>
+</trkpt>
+<trkpt lat="55.9451904" lon="-4.3094454">
+<ele>132.62061994818447></ele>
+<accuracy>3.897</accuracy>
+<speed>1.2765951</speed>
+<bearing>38.016964</bearing>
+<bearingAccuracyDegrees>9.84768</bearingAccuracyDegrees>
+<time>1746106138612</time>
+</trkpt>
+<trkpt lat="55.9452009" lon="-4.3094377">
+<ele>132.64565452273547></ele>
+<accuracy>3.845</accuracy>
+<speed>1.3209084</speed>
+<bearing>37.282394</bearing>
+<bearingAccuracyDegrees>10.065431</bearingAccuracyDegrees>
+<time>1746106139614</time>
+</trkpt>
+<trkpt lat="55.9452127" lon="-4.3094303">
+<ele>132.64565452273547></ele>
+<accuracy>3.844</accuracy>
+<speed>1.3226509</speed>
+<bearing>36.581722</bearing>
+<bearingAccuracyDegrees>12.136331</bearingAccuracyDegrees>
+<time>1746106140543</time>
+</trkpt>
+<trkpt lat="55.9452246" lon="-4.309419">
+<ele>132.79490541921524></ele>
+<accuracy>3.86</accuracy>
+<speed>1.3280315</speed>
+<bearing>33.587467</bearing>
+<bearingAccuracyDegrees>11.694774</bearingAccuracyDegrees>
+<time>1746106141620</time>
+</trkpt>
+<trkpt lat="55.9452347" lon="-4.3094052">
+<ele>132.93520818466632></ele>
+<accuracy>3.893</accuracy>
+<speed>1.3326284</speed>
+<bearing>32.73762</bearing>
+<bearingAccuracyDegrees>11.870943</bearingAccuracyDegrees>
+<time>1746106142622</time>
+</trkpt>
+<trkpt lat="55.9452449" lon="-4.3093957">
+<ele>133.2215581063036></ele>
+<accuracy>3.952</accuracy>
+<speed>1.3056096</speed>
+<bearing>36.007034</bearing>
+<bearingAccuracyDegrees>12.260449</bearingAccuracyDegrees>
+<time>1746106143624</time>
+</trkpt>
+<trkpt lat="55.9452554" lon="-4.3093903">
+<ele>133.2215581063036></ele>
+<accuracy>4.022</accuracy>
+<speed>1.2878395</speed>
+<bearing>34.918037</bearing>
+<bearingAccuracyDegrees>12.12999</bearingAccuracyDegrees>
+<time>1746106144557</time>
+</trkpt>
+<trkpt lat="55.9452653" lon="-4.309376">
+<ele>133.43386952954137></ele>
+<accuracy>4.069</accuracy>
+<speed>1.2836919</speed>
+<bearing>33.118237</bearing>
+<bearingAccuracyDegrees>11.683116</bearingAccuracyDegrees>
+<time>1746106145647</time>
+</trkpt>
+<trkpt lat="55.9452773" lon="-4.3093664">
+<ele>133.76665964099485></ele>
+<accuracy>4.082</accuracy>
+<speed>1.3479184</speed>
+<bearing>30.024567</bearing>
+<bearingAccuracyDegrees>10.095715</bearingAccuracyDegrees>
+<time>1746106146797</time>
+</trkpt>
+<trkpt lat="55.9452914" lon="-4.309354">
+<ele>134.2061095396146></ele>
+<accuracy>4.093</accuracy>
+<speed>1.3753887</speed>
+<bearing>32.494762</bearing>
+<bearingAccuracyDegrees>9.890698</bearingAccuracyDegrees>
+<time>1746106147966</time>
+</trkpt>
+<trkpt lat="55.9453055" lon="-4.3093386">
+<ele>134.19648912457626></ele>
+<accuracy>4.07</accuracy>
+<speed>1.3862818</speed>
+<bearing>38.928917</bearing>
+<bearingAccuracyDegrees>10.1420145</bearingAccuracyDegrees>
+<time>1746106149070</time>
+</trkpt>
+<trkpt lat="55.9453192" lon="-4.3093234">
+<ele>134.42728897837526></ele>
+<accuracy>4.009</accuracy>
+<speed>1.3749795</speed>
+<bearing>44.6578</bearing>
+<bearingAccuracyDegrees>10.323743</bearingAccuracyDegrees>
+<time>1746106150203</time>
+</trkpt>
+<trkpt lat="55.9453306" lon="-4.3093105">
+<ele>134.59656125470312></ele>
+<accuracy>3.936</accuracy>
+<speed>1.3783265</speed>
+<bearing>39.161728</bearing>
+<bearingAccuracyDegrees>10.243517</bearingAccuracyDegrees>
+<time>1746106151325</time>
+</trkpt>
+<trkpt lat="55.9453427" lon="-4.3092975">
+<ele>134.61717397798284></ele>
+<accuracy>3.857</accuracy>
+<speed>1.3662966</speed>
+<bearing>36.18065</bearing>
+<bearingAccuracyDegrees>9.165264</bearingAccuracyDegrees>
+<time>1746106152487</time>
+</trkpt>
+<trkpt lat="55.9453533" lon="-4.3092857">
+<ele>134.45284627742973></ele>
+<accuracy>3.78</accuracy>
+<speed>1.365399</speed>
+<bearing>33.52739</bearing>
+<bearingAccuracyDegrees>9.748546</bearingAccuracyDegrees>
+<time>1746106153547</time>
+</trkpt>
+<trkpt lat="55.9453634" lon="-4.3092749">
+<ele>134.55248582420572></ele>
+<accuracy>3.729</accuracy>
+<speed>1.3662211</speed>
+<bearing>32.27947</bearing>
+<bearingAccuracyDegrees>9.741587</bearingAccuracyDegrees>
+<time>1746106154449</time>
+</trkpt>
+<trkpt lat="55.9453726" lon="-4.3092577">
+<ele>134.5759612781301></ele>
+<accuracy>3.695</accuracy>
+<speed>1.3488101</speed>
+<bearing>34.769096</bearing>
+<bearingAccuracyDegrees>9.735833</bearingAccuracyDegrees>
+<time>1746106155425</time>
+</trkpt>
+<trkpt lat="55.9453822" lon="-4.30924">
+<ele>134.8717516547779></ele>
+<accuracy>3.703</accuracy>
+<speed>1.3487762</speed>
+<bearing>51.06431</bearing>
+<bearingAccuracyDegrees>9.888605</bearingAccuracyDegrees>
+<time>1746106156546</time>
+</trkpt>
+<trkpt lat="55.9453883" lon="-4.3092204">
+<ele>134.90248041957653></ele>
+<accuracy>3.772</accuracy>
+<speed>1.3247643</speed>
+<bearing>56.3764</bearing>
+<bearingAccuracyDegrees>10.305586</bearingAccuracyDegrees>
+<time>1746106157555</time>
+</trkpt>
+<trkpt lat="55.945395" lon="-4.3092027">
+<ele>135.2124175894453></ele>
+<accuracy>3.812</accuracy>
+<speed>1.3452889</speed>
+<bearing>47.979134</bearing>
+<bearingAccuracyDegrees>10.321515</bearingAccuracyDegrees>
+<time>1746106158558</time>
+</trkpt>
+<trkpt lat="55.9454041" lon="-4.3091875">
+<ele>135.2776308309654></ele>
+<accuracy>3.846</accuracy>
+<speed>1.3524252</speed>
+<bearing>44.975914</bearing>
+<bearingAccuracyDegrees>11.93987</bearingAccuracyDegrees>
+<time>1746106159561</time>
+</trkpt>
+<trkpt lat="55.945408" lon="-4.3091699">
+<ele>135.2776308309654></ele>
+<accuracy>3.831</accuracy>
+<speed>1.3563926</speed>
+<bearing>47.47297</bearing>
+<bearingAccuracyDegrees>12.039614</bearingAccuracyDegrees>
+<time>1746106160508</time>
+</trkpt>
+<trkpt lat="55.9454157" lon="-4.3091489">
+<ele>135.3110202020339></ele>
+<accuracy>3.845</accuracy>
+<speed>1.361443</speed>
+<bearing>47.90782</bearing>
+<bearingAccuracyDegrees>12.397435</bearingAccuracyDegrees>
+<time>1746106161632</time>
+</trkpt>
+<trkpt lat="55.9454223" lon="-4.3091278">
+<ele>135.25364932811016></ele>
+<accuracy>3.873</accuracy>
+<speed>1.3975204</speed>
+<bearing>51.79213</bearing>
+<bearingAccuracyDegrees>12.256014</bearingAccuracyDegrees>
+<time>1746106162567</time>
+</trkpt>
+<trkpt lat="55.9454306" lon="-4.3091039">
+<ele>135.25364932811016></ele>
+<accuracy>3.923</accuracy>
+<speed>1.4061693</speed>
+<bearing>53.08474</bearing>
+<bearingAccuracyDegrees>12.390814</bearingAccuracyDegrees>
+<time>1746106163570</time>
+</trkpt>
+<trkpt lat="55.9454388" lon="-4.3090837">
+<ele>135.25364932811016></ele>
+<accuracy>3.986</accuracy>
+<speed>1.4077154</speed>
+<bearing>54.317158</bearing>
+<bearingAccuracyDegrees>11.63642</bearingAccuracyDegrees>
+<time>1746106164507</time>
+</trkpt>
+<trkpt lat="55.9454498" lon="-4.3090616">
+<ele>135.43309193382697></ele>
+<accuracy>4.112</accuracy>
+<speed>1.4220498</speed>
+<bearing>52.56554</bearing>
+<bearingAccuracyDegrees>12.211138</bearingAccuracyDegrees>
+<time>1746106165630</time>
+</trkpt>
+<trkpt lat="55.945456" lon="-4.3090434">
+<ele>136.50001525878906></ele>
+<accuracy>4.18</accuracy>
+<speed>1.4353755</speed>
+<bearing>58.791782</bearing>
+<bearingAccuracyDegrees>11.806506</bearingAccuracyDegrees>
+<time>1746106166577</time>
+</trkpt>
+<trkpt lat="55.94546" lon="-4.3090229">
+<ele>136.50001525878906></ele>
+<accuracy>4.243</accuracy>
+<speed>1.3947061</speed>
+<bearing>60.53643</bearing>
+<bearingAccuracyDegrees>11.8377285</bearingAccuracyDegrees>
+<time>1746106167579</time>
+</trkpt>
+<trkpt lat="55.9454661" lon="-4.3090042">
+<ele>136.50001525878906></ele>
+<accuracy>4.277</accuracy>
+<speed>1.3916948</speed>
+<bearing>57.714035</bearing>
+<bearingAccuracyDegrees>11.46546</bearingAccuracyDegrees>
+<time>1746106168581</time>
+</trkpt>
+<trkpt lat="55.9454779" lon="-4.3089887">
+<ele>136.50001525878906></ele>
+<accuracy>4.264</accuracy>
+<speed>1.3638557</speed>
+<bearing>46.976048</bearing>
+<bearingAccuracyDegrees>12.166651</bearingAccuracyDegrees>
+<time>1746106169626</time>
+</trkpt>
+<trkpt lat="55.9454867" lon="-4.3089769">
+<ele>136.37857722054346></ele>
+<accuracy>4.278</accuracy>
+<speed>1.3437883</speed>
+<bearing>51.827328</bearing>
+<bearingAccuracyDegrees>12.189402</bearingAccuracyDegrees>
+<time>1746106170586</time>
+</trkpt>
+<trkpt lat="55.9454954" lon="-4.3089597">
+<ele>136.4631051061923></ele>
+<accuracy>4.216</accuracy>
+<speed>1.3442539</speed>
+<bearing>58.056625</bearing>
+<bearingAccuracyDegrees>11.71882</bearingAccuracyDegrees>
+<time>1746106171588</time>
+</trkpt>
+<trkpt lat="55.9455034" lon="-4.3089406">
+<ele>136.4631051061923></ele>
+<accuracy>4.182</accuracy>
+<speed>1.3573186</speed>
+<bearing>58.24582</bearing>
+<bearingAccuracyDegrees>12.051877</bearingAccuracyDegrees>
+<time>1746106172564</time>
+</trkpt>
+<trkpt lat="55.9455112" lon="-4.308921">
+<ele>136.46021868701905></ele>
+<accuracy>4.183</accuracy>
+<speed>1.36302</speed>
+<bearing>52.68673</bearing>
+<bearingAccuracyDegrees>12.259967</bearingAccuracyDegrees>
+<time>1746106173592</time>
+</trkpt>
+<trkpt lat="55.9455179" lon="-4.3089027">
+<ele>136.50717988854439></ele>
+<accuracy>4.18</accuracy>
+<speed>1.3802296</speed>
+<bearing>49.30874</bearing>
+<bearingAccuracyDegrees>12.186406</bearingAccuracyDegrees>
+<time>1746106174594</time>
+</trkpt>
+<trkpt lat="55.9455253" lon="-4.3088855">
+<ele>136.81524149041527></ele>
+<accuracy>4.179</accuracy>
+<speed>1.3635969</speed>
+<bearing>52.07486</bearing>
+<bearingAccuracyDegrees>11.981634</bearingAccuracyDegrees>
+<time>1746106175597</time>
+</trkpt>
+<trkpt lat="55.9455322" lon="-4.3088693">
+<ele>136.81524149041527></ele>
+<accuracy>4.171</accuracy>
+<speed>1.3499453</speed>
+<bearing>59.645317</bearing>
+<bearingAccuracyDegrees>11.845172</bearingAccuracyDegrees>
+<time>1746106176501</time>
+</trkpt>
+<trkpt lat="55.9455384" lon="-4.3088558">
+<ele>136.8719303347825></ele>
+<accuracy>4.03</accuracy>
+<speed>1.366092</speed>
+<bearing>61.47888</bearing>
+<bearingAccuracyDegrees>8.86904</bearingAccuracyDegrees>
+<time>1746106177501</time>
+</trkpt>
+<trkpt lat="55.9455461" lon="-4.3088305">
+<ele>137.07976956349052></ele>
+<accuracy>3.821</accuracy>
+<speed>1.4056481</speed>
+<bearing>63.11247</bearing>
+<bearingAccuracyDegrees>9.623675</bearingAccuracyDegrees>
+<time>1746106178603</time>
+</trkpt>
+<trkpt lat="55.9455525" lon="-4.3088029">
+<ele>137.16870895481858></ele>
+<accuracy>3.649</accuracy>
+<speed>1.4466504</speed>
+<bearing>64.04223</bearing>
+<bearingAccuracyDegrees>9.017184</bearingAccuracyDegrees>
+<time>1746106179606</time>
+</trkpt>
+<trkpt lat="55.9455589" lon="-4.3087759">
+<ele>137.21547232050128></ele>
+<accuracy>3.44</accuracy>
+<speed>1.4764508</speed>
+<bearing>54.91857</bearing>
+<bearingAccuracyDegrees>9.641939</bearingAccuracyDegrees>
+<time>1746106180608</time>
+</trkpt>
+<trkpt lat="55.9455658" lon="-4.3087502">
+<ele>137.21547232050128></ele>
+<accuracy>3.242</accuracy>
+<speed>1.4754195</speed>
+<bearing>59.62713</bearing>
+<bearingAccuracyDegrees>9.720103</bearingAccuracyDegrees>
+<time>1746106181584</time>
+</trkpt>
+<trkpt lat="55.945571" lon="-4.3087248">
+<ele>137.22016875110424></ele>
+<accuracy>3.396</accuracy>
+<speed>1.4691931</speed>
+<bearing>65.29821</bearing>
+<bearingAccuracyDegrees>9.939912</bearingAccuracyDegrees>
+<time>1746106182613</time>
+</trkpt>
+<trkpt lat="55.9455743" lon="-4.3086983">
+<ele>137.26556771250236></ele>
+<accuracy>3.503</accuracy>
+<speed>1.446978</speed>
+<bearing>66.47051</bearing>
+<bearingAccuracyDegrees>10.043931</bearingAccuracyDegrees>
+<time>1746106183615</time>
+</trkpt>
+<trkpt lat="55.9455775" lon="-4.3086787">
+<ele>137.0177584354384></ele>
+<accuracy>3.615</accuracy>
+<speed>1.409621</speed>
+<bearing>70.41359</bearing>
+<bearingAccuracyDegrees>12.262682</bearingAccuracyDegrees>
+<time>1746106184617</time>
+</trkpt>
+<trkpt lat="55.9455821" lon="-4.3086593">
+<ele>137.01671478428744></ele>
+<accuracy>3.734</accuracy>
+<speed>1.3910476</speed>
+<bearing>65.42738</bearing>
+<bearingAccuracyDegrees>12.450396</bearingAccuracyDegrees>
+<time>1746106185620</time>
+</trkpt>
+<trkpt lat="55.9455887" lon="-4.308644">
+<ele>137.01671478428744></ele>
+<accuracy>3.798</accuracy>
+<speed>1.3810496</speed>
+<bearing>64.37394</bearing>
+<bearingAccuracyDegrees>12.647819</bearingAccuracyDegrees>
+<time>1746106186549</time>
+</trkpt>
+<trkpt lat="55.9455958" lon="-4.3086288">
+<ele>137.37932708222357></ele>
+<accuracy>3.887</accuracy>
+<speed>1.3856289</speed>
+<bearing>67.890854</bearing>
+<bearingAccuracyDegrees>12.146493</bearingAccuracyDegrees>
+<time>1746106187524</time>
+</trkpt>
+<trkpt lat="55.945602" lon="-4.3086098">
+<ele>137.5024811237418></ele>
+<accuracy>3.97</accuracy>
+<speed>1.3655324</speed>
+<bearing>66.26527</bearing>
+<bearingAccuracyDegrees>12.086761</bearingAccuracyDegrees>
+<time>1746106188626</time>
+</trkpt>
+<trkpt lat="55.94561" lon="-4.3085882">
+<ele>137.55153449581098></ele>
+<accuracy>4.061</accuracy>
+<speed>1.3774219</speed>
+<bearing>58.44262</bearing>
+<bearingAccuracyDegrees>11.81549</bearingAccuracyDegrees>
+<time>1746106189629</time>
+</trkpt>
+<trkpt lat="55.945623" lon="-4.3085684">
+<ele>137.61363437878336></ele>
+<accuracy>3.864</accuracy>
+<speed>1.3754226</speed>
+<bearing>58.784164</bearing>
+<bearingAccuracyDegrees>9.004321</bearingAccuracyDegrees>
+<time>1746106190631</time>
+</trkpt>
+<trkpt lat="55.9456307" lon="-4.3085473">
+<ele>137.67103803078473></ele>
+<accuracy>3.753</accuracy>
+<speed>1.3582072</speed>
+<bearing>63.100346</bearing>
+<bearingAccuracyDegrees>9.129734</bearingAccuracyDegrees>
+<time>1746106191532</time>
+</trkpt>
+<trkpt lat="55.9456383" lon="-4.3085254">
+<ele>137.7248057981467></ele>
+<accuracy>3.494</accuracy>
+<speed>1.3677869</speed>
+<bearing>62.828915</bearing>
+<bearingAccuracyDegrees>9.794342</bearingAccuracyDegrees>
+<time>1746106192636</time>
+</trkpt>
+<trkpt lat="55.9456448" lon="-4.308507">
+<ele>137.8103906607786></ele>
+<accuracy>3.268</accuracy>
+<speed>1.3656585</speed>
+<bearing>61.802494</bearing>
+<bearingAccuracyDegrees>9.323206</bearingAccuracyDegrees>
+<time>1746106193637</time>
+</trkpt>
+<trkpt lat="55.9456492" lon="-4.3084923">
+<ele>137.89441077515406></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3462996</speed>
+<bearing>63.904095</bearing>
+<bearingAccuracyDegrees>9.470467</bearingAccuracyDegrees>
+<time>1746106194540</time>
+</trkpt>
+<trkpt lat="55.9456542" lon="-4.3084768">
+<ele>137.89441077515406></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3213706</speed>
+<bearing>61.540707</bearing>
+<bearingAccuracyDegrees>9.429652</bearingAccuracyDegrees>
+<time>1746106195545</time>
+</trkpt>
+<trkpt lat="55.9456595" lon="-4.3084629">
+<ele>137.85840610210047></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3128961</speed>
+<bearing>59.513313</bearing>
+<bearingAccuracyDegrees>9.536715</bearingAccuracyDegrees>
+<time>1746106196545</time>
+</trkpt>
+<trkpt lat="55.945665" lon="-4.3084427">
+<ele>137.96559715999243></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3027867</speed>
+<bearing>64.598656</bearing>
+<bearingAccuracyDegrees>9.408063</bearingAccuracyDegrees>
+<time>1746106197552</time>
+</trkpt>
+<trkpt lat="55.9456696" lon="-4.3084201">
+<ele>137.87306925817128></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3061564</speed>
+<bearing>69.44329</bearing>
+<bearingAccuracyDegrees>9.692081</bearingAccuracyDegrees>
+<time>1746106198583</time>
+</trkpt>
+<trkpt lat="55.945673" lon="-4.3083956">
+<ele>137.993099089183></ele>
+<accuracy>3.01</accuracy>
+<speed>1.3403103</speed>
+<bearing>71.03329</bearing>
+<bearingAccuracyDegrees>9.786748</bearingAccuracyDegrees>
+<time>1746106199550</time>
+</trkpt>
+<trkpt lat="55.9456755" lon="-4.3083678">
+<ele>138.0426771169609></ele>
+<accuracy>3.042</accuracy>
+<speed>1.3496734</speed>
+<bearing>70.28635</bearing>
+<bearingAccuracyDegrees>10.194457</bearingAccuracyDegrees>
+<time>1746106200554</time>
+</trkpt>
+<trkpt lat="55.9456782" lon="-4.3083402">
+<ele>138.0426771169609></ele>
+<accuracy>3.088</accuracy>
+<speed>1.4050382</speed>
+<bearing>74.42033</bearing>
+<bearingAccuracyDegrees>11.5534115</bearingAccuracyDegrees>
+<time>1746106201471</time>
+</trkpt>
+<trkpt lat="55.9456806" lon="-4.3083088">
+<ele>138.13818086025182></ele>
+<accuracy>3.19</accuracy>
+<speed>1.4525492</speed>
+<bearing>82.25478</bearing>
+<bearingAccuracyDegrees>11.822586</bearingAccuracyDegrees>
+<time>1746106202488</time>
+</trkpt>
+<trkpt lat="55.9456832" lon="-4.3082786">
+<ele>137.9693669160972></ele>
+<accuracy>3.346</accuracy>
+<speed>1.4833039</speed>
+<bearing>82.92408</bearing>
+<bearingAccuracyDegrees>10.398383</bearingAccuracyDegrees>
+<time>1746106203546</time>
+</trkpt>
+<trkpt lat="55.9456885" lon="-4.3082485">
+<ele>137.9631043430611></ele>
+<accuracy>3.549</accuracy>
+<speed>1.50077</speed>
+<bearing>70.76756</bearing>
+<bearingAccuracyDegrees>10.506609</bearingAccuracyDegrees>
+<time>1746106204605</time>
+</trkpt>
+<trkpt lat="55.9456964" lon="-4.3082245">
+<ele>138.04521486022188></ele>
+<accuracy>3.724</accuracy>
+<speed>1.5032394</speed>
+<bearing>66.872505</bearing>
+<bearingAccuracyDegrees>10.390132</bearingAccuracyDegrees>
+<time>1746106205565</time>
+</trkpt>
+<trkpt lat="55.9457058" lon="-4.3081987">
+<ele>137.9585839088981></ele>
+<accuracy>3.907</accuracy>
+<speed>1.484665</speed>
+<bearing>71.65719</bearing>
+<bearingAccuracyDegrees>9.932185</bearingAccuracyDegrees>
+<time>1746106206567</time>
+</trkpt>
+<trkpt lat="55.945714" lon="-4.3081751">
+<ele>137.7926306681296></ele>
+<accuracy>4.05</accuracy>
+<speed>1.4781183</speed>
+<bearing>67.76687</bearing>
+<bearingAccuracyDegrees>9.479338</bearingAccuracyDegrees>
+<time>1746106207570</time>
+</trkpt>
+<trkpt lat="55.9457218" lon="-4.3081544">
+<ele>137.6647757955824></ele>
+<accuracy>4.11</accuracy>
+<speed>1.4310353</speed>
+<bearing>67.756325</bearing>
+<bearingAccuracyDegrees>10.198575</bearingAccuracyDegrees>
+<time>1746106208572</time>
+</trkpt>
+<trkpt lat="55.9457279" lon="-4.3081373">
+<ele>137.5197019565337></ele>
+<accuracy>4.163</accuracy>
+<speed>1.3955436</speed>
+<bearing>73.23026</bearing>
+<bearingAccuracyDegrees>10.424034</bearingAccuracyDegrees>
+<time>1746106209574</time>
+</trkpt>
+<trkpt lat="55.9457717" lon="-4.3080286">
+<ele>136.67122556623696></ele>
+<accuracy>3.155</accuracy>
+<speed>1.3205601</speed>
+<bearing>71.78655</bearing>
+<bearingAccuracyDegrees>11.729167</bearingAccuracyDegrees>
+<time>1746106216590</time>
+</trkpt>
+<trkpt lat="55.9457767" lon="-4.3080036">
+<ele>136.6315694308797></ele>
+<accuracy>3.312</accuracy>
+<speed>1.3419783</speed>
+<bearing>67.74521</bearing>
+<bearingAccuracyDegrees>12.059831</bearingAccuracyDegrees>
+<time>1746106217592</time>
+</trkpt>
+<trkpt lat="55.9457814" lon="-4.3079782">
+<ele>136.65973722573872></ele>
+<accuracy>3.585</accuracy>
+<speed>1.361128</speed>
+<bearing>67.57198</bearing>
+<bearingAccuracyDegrees>11.69993</bearingAccuracyDegrees>
+<time>1746106218595</time>
+</trkpt>
+<trkpt lat="55.9457854" lon="-4.3079507">
+<ele>136.71662162987457></ele>
+<accuracy>3.814</accuracy>
+<speed>1.4116274</speed>
+<bearing>67.97018</bearing>
+<bearingAccuracyDegrees>11.919755</bearingAccuracyDegrees>
+<time>1746106219596</time>
+</trkpt>
+<trkpt lat="55.9457896" lon="-4.3079183">
+<ele>136.8392443789167></ele>
+<accuracy>4.048</accuracy>
+<speed>1.4446713</speed>
+<bearing>68.64883</bearing>
+<bearingAccuracyDegrees>11.719836</bearingAccuracyDegrees>
+<time>1746106220599</time>
+</trkpt>
+<trkpt lat="55.9457943" lon="-4.3078855">
+<ele>136.93631704323664></ele>
+<accuracy>4.271</accuracy>
+<speed>1.4660642</speed>
+<bearing>70.455444</bearing>
+<bearingAccuracyDegrees>9.83956</bearingAccuracyDegrees>
+<time>1746106221600</time>
+</trkpt>
+<trkpt lat="55.9457996" lon="-4.3078518">
+<ele>136.93631704323664></ele>
+<accuracy>4.375</accuracy>
+<speed>1.5176857</speed>
+<bearing>75.78783</bearing>
+<bearingAccuracyDegrees>9.799641</bearingAccuracyDegrees>
+<time>1746106222528</time>
+</trkpt>
+<trkpt lat="55.9458021" lon="-4.3078119">
+<ele>136.94623141002717></ele>
+<accuracy>4.441</accuracy>
+<speed>1.5401177</speed>
+<bearing>83.92302</bearing>
+<bearingAccuracyDegrees>9.725387</bearingAccuracyDegrees>
+<time>1746106223609</time>
+</trkpt>
+<trkpt lat="55.9458023" lon="-4.3077749">
+<ele>137.1612946853196></ele>
+<accuracy>4.397</accuracy>
+<speed>1.5923138</speed>
+<bearing>89.10873</bearing>
+<bearingAccuracyDegrees>9.6574545</bearingAccuracyDegrees>
+<time>1746106224641</time>
+</trkpt>
+<trkpt lat="55.9458022" lon="-4.3077455">
+<ele>136.64174954280253></ele>
+<accuracy>4.374</accuracy>
+<speed>1.572798</speed>
+<bearing>95.2496</bearing>
+<bearingAccuracyDegrees>11.852632</bearingAccuracyDegrees>
+<time>1746106225610</time>
+</trkpt>
+<trkpt lat="55.9458027" lon="-4.3077167">
+<ele>136.4575223419483></ele>
+<accuracy>4.349</accuracy>
+<speed>1.5407461</speed>
+<bearing>93.61929</bearing>
+<bearingAccuracyDegrees>11.650364</bearingAccuracyDegrees>
+<time>1746106226613</time>
+</trkpt>
+<trkpt lat="55.945804" lon="-4.3076919">
+<ele>136.21787217370414></ele>
+<accuracy>4.297</accuracy>
+<speed>1.48825</speed>
+<bearing>91.88319</bearing>
+<bearingAccuracyDegrees>12.077062</bearingAccuracyDegrees>
+<time>1746106227615</time>
+</trkpt>
+<trkpt lat="55.9458032" lon="-4.3076713">
+<ele>136.11351985529808></ele>
+<accuracy>4.267</accuracy>
+<speed>1.4392526</speed>
+<bearing>94.291824</bearing>
+<bearingAccuracyDegrees>12.296237</bearingAccuracyDegrees>
+<time>1746106228617</time>
+</trkpt>
+<trkpt lat="55.9458029" lon="-4.3076488">
+<ele>136.0122993162335></ele>
+<accuracy>4.169</accuracy>
+<speed>1.277133</speed>
+<bearing>92.74605</bearing>
+<bearingAccuracyDegrees>12.096166</bearingAccuracyDegrees>
+<time>1746106229983</time>
+</trkpt>
+<trkpt lat="55.9458019" lon="-4.3076299">
+<ele>135.961167744253></ele>
+<accuracy>3.946</accuracy>
+<speed>1.2911761</speed>
+<bearing>90.107796</bearing>
+<bearingAccuracyDegrees>9.825988</bearingAccuracyDegrees>
+<time>1746106231586</time>
+</trkpt>
+<trkpt lat="55.9458013" lon="-4.3076064">
+<ele>136.01334282086768></ele>
+<accuracy>3.574</accuracy>
+<speed>1.2902856</speed>
+<bearing>83.67938</bearing>
+<bearingAccuracyDegrees>9.398823</bearingAccuracyDegrees>
+<time>1746106232930</time>
+</trkpt>
+<trkpt lat="55.9458022" lon="-4.3075765">
+<ele>136.06797811241526></ele>
+<accuracy>3.339</accuracy>
+<speed>1.286197</speed>
+<bearing>87.41264</bearing>
+<bearingAccuracyDegrees>10.013207</bearingAccuracyDegrees>
+<time>1746106234142</time>
+</trkpt>
+<trkpt lat="55.9458005" lon="-4.3075498">
+<ele>136.23125943058682></ele>
+<accuracy>3.159</accuracy>
+<speed>1.2752532</speed>
+<bearing>92.79298</bearing>
+<bearingAccuracyDegrees>10.184088</bearingAccuracyDegrees>
+<time>1746106235185</time>
+</trkpt>
+<trkpt lat="55.9457987" lon="-4.3075217">
+<ele>135.89639867203445></ele>
+<accuracy>3.1</accuracy>
+<speed>1.3039825</speed>
+<bearing>96.10707</bearing>
+<bearingAccuracyDegrees>11.635879</bearingAccuracyDegrees>
+<time>1746106236266</time>
+</trkpt>
+<trkpt lat="55.9457953" lon="-4.3074913">
+<ele>135.74613729562742></ele>
+<accuracy>3.263</accuracy>
+<speed>1.3146168</speed>
+<bearing>98.578606</bearing>
+<bearingAccuracyDegrees>11.653476</bearingAccuracyDegrees>
+<time>1746106237370</time>
+</trkpt>
+<trkpt lat="55.945793" lon="-4.3074616">
+<ele>135.69396382065398></ele>
+<accuracy>3.453</accuracy>
+<speed>1.2960104</speed>
+<bearing>99.60983</bearing>
+<bearingAccuracyDegrees>10.065339</bearingAccuracyDegrees>
+<time>1746106238482</time>
+</trkpt>
+<trkpt lat="55.9457902" lon="-4.3074329">
+<ele>135.6595295005615></ele>
+<accuracy>3.733</accuracy>
+<speed>1.3157037</speed>
+<bearing>103.26826</bearing>
+<bearingAccuracyDegrees>10.311656</bearingAccuracyDegrees>
+<time>1746106239508</time>
+</trkpt>
+<trkpt lat="55.9457866" lon="-4.3074043">
+<ele>135.93326017560372></ele>
+<accuracy>3.984</accuracy>
+<speed>1.3596647</speed>
+<bearing>105.41621</bearing>
+<bearingAccuracyDegrees>10.229318</bearingAccuracyDegrees>
+<time>1746106240549</time>
+</trkpt>
+<trkpt lat="55.9457836" lon="-4.3073735">
+<ele>135.67948424432626></ele>
+<accuracy>4.111</accuracy>
+<speed>1.3677536</speed>
+<bearing>99.39262</bearing>
+<bearingAccuracyDegrees>9.812023</bearingAccuracyDegrees>
+<time>1746106241629</time>
+</trkpt>
+<trkpt lat="55.9457816" lon="-4.3073441">
+<ele>135.53406216661176></ele>
+<accuracy>4.174</accuracy>
+<speed>1.3739939</speed>
+<bearing>96.53803</bearing>
+<bearingAccuracyDegrees>9.845983</bearingAccuracyDegrees>
+<time>1746106242622</time>
+</trkpt>
+<trkpt lat="55.9457796" lon="-4.3073183">
+<ele>135.3458738567574></ele>
+<accuracy>4.187</accuracy>
+<speed>1.3774697</speed>
+<bearing>94.034</bearing>
+<bearingAccuracyDegrees>9.777168</bearingAccuracyDegrees>
+<time>1746106243551</time>
+</trkpt>
+<trkpt lat="55.9457805" lon="-4.3072916">
+<ele>135.21616461640104></ele>
+<accuracy>4.166</accuracy>
+<speed>1.3768457</speed>
+<bearing>94.13071</bearing>
+<bearingAccuracyDegrees>11.778193</bearingAccuracyDegrees>
+<time>1746106244552</time>
+</trkpt>
+<trkpt lat="55.9457829" lon="-4.3072715">
+<ele>135.13848557671042></ele>
+<accuracy>3.9</accuracy>
+<speed>1.3425852</speed>
+<bearing>95.080414</bearing>
+<bearingAccuracyDegrees>9.338238</bearingAccuracyDegrees>
+<time>1746106245556</time>
+</trkpt>
+<trkpt lat="55.9457841" lon="-4.3072522">
+<ele>135.09607839458602></ele>
+<accuracy>3.725</accuracy>
+<speed>1.3188522</speed>
+<bearing>96.01665</bearing>
+<bearingAccuracyDegrees>9.614521</bearingAccuracyDegrees>
+<time>1746106246558</time>
+</trkpt>
+<trkpt lat="55.9457837" lon="-4.3072351">
+<ele>135.09607839458602></ele>
+<accuracy>3.564</accuracy>
+<speed>1.2864974</speed>
+<bearing>96.526886</bearing>
+<bearingAccuracyDegrees>9.748746</bearingAccuracyDegrees>
+<time>1746106247483</time>
+</trkpt>
+<trkpt lat="55.9457814" lon="-4.3072151">
+<ele>135.27905877813433></ele>
+<accuracy>3.251</accuracy>
+<speed>1.2628497</speed>
+<bearing>96.5436</bearing>
+<bearingAccuracyDegrees>11.8958645</bearingAccuracyDegrees>
+<time>1746106248563</time>
+</trkpt>
+<trkpt lat="55.9457791" lon="-4.3071963">
+<ele>135.05538613291736></ele>
+<accuracy>3.0</accuracy>
+<speed>1.2441951</speed>
+<bearing>96.435234</bearing>
+<bearingAccuracyDegrees>11.995968</bearingAccuracyDegrees>
+<time>1746106249565</time>
+</trkpt>
+<trkpt lat="55.9457774" lon="-4.3071736">
+<ele>135.05538613291736></ele>
+<accuracy>3.006</accuracy>
+<speed>1.2281433</speed>
+<bearing>95.23307</bearing>
+<bearingAccuracyDegrees>12.921998</bearingAccuracyDegrees>
+<time>1746106250571</time>
+</trkpt>
+<trkpt lat="55.9457758" lon="-4.3071483">
+<ele>135.2706329574553></ele>
+<accuracy>3.063</accuracy>
+<speed>1.2146698</speed>
+<bearing>98.04952</bearing>
+<bearingAccuracyDegrees>12.290762</bearingAccuracyDegrees>
+<time>1746106251624</time>
+</trkpt>
+<trkpt lat="55.9457739" lon="-4.3071249">
+<ele>135.008673920874></ele>
+<accuracy>3.222</accuracy>
+<speed>1.2481201</speed>
+<bearing>107.48574</bearing>
+<bearingAccuracyDegrees>12.926262</bearingAccuracyDegrees>
+<time>1746106252572</time>
+</trkpt>
+<trkpt lat="55.9457696" lon="-4.3070953">
+<ele>135.008673920874></ele>
+<accuracy>3.344</accuracy>
+<speed>1.3587584</speed>
+<bearing>105.41656</bearing>
+<bearingAccuracyDegrees>15.480052</bearingAccuracyDegrees>
+<time>1746106253608</time>
+</trkpt>
+<trkpt lat="55.9457705" lon="-4.3070618">
+<ele>135.0136648107872></ele>
+<accuracy>3.687</accuracy>
+<speed>1.403252</speed>
+<bearing>95.01655</bearing>
+<bearingAccuracyDegrees>15.340748</bearingAccuracyDegrees>
+<time>1746106254649</time>
+</trkpt>
+<trkpt lat="55.945771" lon="-4.3070377">
+<ele>135.3097600217663></ele>
+<accuracy>3.905</accuracy>
+<speed>1.3910806</speed>
+<bearing>117.728035</bearing>
+<bearingAccuracyDegrees>14.981477</bearingAccuracyDegrees>
+<time>1746106255578</time>
+</trkpt>
+<trkpt lat="55.9457697" lon="-4.30701">
+<ele>135.02828764882122></ele>
+<accuracy>4.21</accuracy>
+<speed>1.4135412</speed>
+<bearing>107.38103</bearing>
+<bearingAccuracyDegrees>15.3949375</bearingAccuracyDegrees>
+<time>1746106256581</time>
+</trkpt>
+<trkpt lat="55.9457689" lon="-4.3069816">
+<ele>134.7556461939962></ele>
+<accuracy>4.398</accuracy>
+<speed>1.4349082</speed>
+<bearing>114.458374</bearing>
+<bearingAccuracyDegrees>14.990367</bearingAccuracyDegrees>
+<time>1746106257583</time>
+</trkpt>
+<trkpt lat="55.9457643" lon="-4.3069518">
+<ele>134.6328969043449></ele>
+<accuracy>4.522</accuracy>
+<speed>1.4635772</speed>
+<bearing>119.55311</bearing>
+<bearingAccuracyDegrees>14.690131</bearingAccuracyDegrees>
+<time>1746106258585</time>
+</trkpt>
+<trkpt lat="55.9457576" lon="-4.3069186">
+<ele>134.48891757449945></ele>
+<accuracy>4.638</accuracy>
+<speed>1.5375223</speed>
+<bearing>117.12301</bearing>
+<bearingAccuracyDegrees>15.216496</bearingAccuracyDegrees>
+<time>1746106259588</time>
+</trkpt>
+<trkpt lat="55.9457534" lon="-4.3068845">
+<ele>134.41171226002336></ele>
+<accuracy>4.713</accuracy>
+<speed>1.5680014</speed>
+<bearing>115.00859</bearing>
+<bearingAccuracyDegrees>13.262704</bearingAccuracyDegrees>
+<time>1746106260590</time>
+</trkpt>
+<trkpt lat="55.9457495" lon="-4.3068498">
+<ele>134.41171226002336></ele>
+<accuracy>4.761</accuracy>
+<speed>1.5920461</speed>
+<bearing>113.412056</bearing>
+<bearingAccuracyDegrees>12.820562</bearingAccuracyDegrees>
+<time>1746106261586</time>
+</trkpt>
+<trkpt lat="55.9457492" lon="-4.3068103">
+<ele>134.3569386396403></ele>
+<accuracy>4.56</accuracy>
+<speed>1.5885636</speed>
+<bearing>107.33121</bearing>
+<bearingAccuracyDegrees>9.448556</bearingAccuracyDegrees>
+<time>1746106262587</time>
+</trkpt>
+<trkpt lat="55.9457494" lon="-4.3067812">
+<ele>134.46822142360227></ele>
+<accuracy>4.179</accuracy>
+<speed>1.5022268</speed>
+<bearing>102.04221</bearing>
+<bearingAccuracyDegrees>9.725786</bearingAccuracyDegrees>
+<time>1746106263596</time>
+</trkpt>
+<trkpt lat="55.9457541" lon="-4.3067555">
+<ele>134.46822142360227></ele>
+<accuracy>3.854</accuracy>
+<speed>1.4830629</speed>
+<bearing>103.27747</bearing>
+<bearingAccuracyDegrees>9.91305</bearingAccuracyDegrees>
+<time>1746106264562</time>
+</trkpt>
+<trkpt lat="55.9457579" lon="-4.3067313">
+<ele>134.42857639878906></ele>
+<accuracy>3.478</accuracy>
+<speed>1.4904964</speed>
+<bearing>97.11098</bearing>
+<bearingAccuracyDegrees>9.8383255</bearingAccuracyDegrees>
+<time>1746106265626</time>
+</trkpt>
+<trkpt lat="55.9457616" lon="-4.3067145">
+<ele>134.38549098846667></ele>
+<accuracy>3.32</accuracy>
+<speed>1.4483624</speed>
+<bearing>95.20498</bearing>
+<bearingAccuracyDegrees>9.479353</bearingAccuracyDegrees>
+<time>1746106266603</time>
+</trkpt>
+<trkpt lat="55.9457621" lon="-4.3066967">
+<ele>134.36879845174215></ele>
+<accuracy>3.023</accuracy>
+<speed>1.4414494</speed>
+<bearing>90.473305</bearing>
+<bearingAccuracyDegrees>8.963264</bearingAccuracyDegrees>
+<time>1746106267606</time>
+</trkpt>
+<trkpt lat="55.9457624" lon="-4.3066802">
+<ele>134.17376773990136></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4289643</speed>
+<bearing>90.044975</bearing>
+<bearingAccuracyDegrees>9.488548</bearingAccuracyDegrees>
+<time>1746106268782</time>
+</trkpt>
+<trkpt lat="55.9457627" lon="-4.3066631">
+<ele>134.16281328692733></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3891804</speed>
+<bearing>89.61849</bearing>
+<bearingAccuracyDegrees>9.6121235</bearingAccuracyDegrees>
+<time>1746106269743</time>
+</trkpt>
+<trkpt lat="55.9457625" lon="-4.3066361">
+<ele>134.4276305323479></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3247316</speed>
+<bearing>91.4793</bearing>
+<bearingAccuracyDegrees>9.599289</bearingAccuracyDegrees>
+<time>1746106271084</time>
+</trkpt>
+<trkpt lat="55.9457626" lon="-4.3066171">
+<ele>134.34051776975951></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3417484</speed>
+<bearing>89.89214</bearing>
+<bearingAccuracyDegrees>9.856954</bearingAccuracyDegrees>
+<time>1746106272009</time>
+</trkpt>
+<trkpt lat="55.9457629" lon="-4.3065934">
+<ele>134.35150921234037></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3405471</speed>
+<bearing>89.48369</bearing>
+<bearingAccuracyDegrees>9.757063</bearingAccuracyDegrees>
+<time>1746106273040</time>
+</trkpt>
+<trkpt lat="55.9457637" lon="-4.3065613">
+<ele>134.09633755643748></ele>
+<accuracy>3.05</accuracy>
+<speed>1.3636348</speed>
+<bearing>87.238365</bearing>
+<bearingAccuracyDegrees>9.893393</bearingAccuracyDegrees>
+<time>1746106274305</time>
+</trkpt>
+<trkpt lat="55.9457643" lon="-4.3065334">
+<ele>134.0295695397761></ele>
+<accuracy>3.178</accuracy>
+<speed>1.3785092</speed>
+<bearing>91.23935</bearing>
+<bearingAccuracyDegrees>10.304208</bearingAccuracyDegrees>
+<time>1746106275326</time>
+</trkpt>
+<trkpt lat="55.9457627" lon="-4.3065033">
+<ele>133.8544428062695></ele>
+<accuracy>3.369</accuracy>
+<speed>1.4247857</speed>
+<bearing>94.69022</bearing>
+<bearingAccuracyDegrees>11.651079</bearingAccuracyDegrees>
+<time>1746106276349</time>
+</trkpt>
+<trkpt lat="55.9457605" lon="-4.3064681">
+<ele>133.70534692389867></ele>
+<accuracy>3.603</accuracy>
+<speed>1.4548945</speed>
+<bearing>95.52632</bearing>
+<bearingAccuracyDegrees>12.131575</bearingAccuracyDegrees>
+<time>1746106277452</time>
+</trkpt>
+<trkpt lat="55.9457572" lon="-4.306434">
+<ele>133.70445776478903></ele>
+<accuracy>3.889</accuracy>
+<speed>1.4790869</speed>
+<bearing>97.40516</bearing>
+<bearingAccuracyDegrees>11.590503</bearingAccuracyDegrees>
+<time>1746106278523</time>
+</trkpt>
+<trkpt lat="55.9457548" lon="-4.3064001">
+<ele>133.57911761603137></ele>
+<accuracy>4.062</accuracy>
+<speed>1.5318711</speed>
+<bearing>94.798744</bearing>
+<bearingAccuracyDegrees>9.843728</bearingAccuracyDegrees>
+<time>1746106279588</time>
+</trkpt>
+<trkpt lat="55.9457541" lon="-4.3063663">
+<ele>133.7052465965478></ele>
+<accuracy>4.138</accuracy>
+<speed>1.5438695</speed>
+<bearing>91.69228</bearing>
+<bearingAccuracyDegrees>9.520736</bearingAccuracyDegrees>
+<time>1746106280632</time>
+</trkpt>
+<trkpt lat="55.9457546" lon="-4.3063368">
+<ele>133.51851570687708></ele>
+<accuracy>4.173</accuracy>
+<speed>1.529451</speed>
+<bearing>96.69158</bearing>
+<bearingAccuracyDegrees>9.834139</bearingAccuracyDegrees>
+<time>1746106281637</time>
+</trkpt>
+<trkpt lat="55.9457548" lon="-4.3063088">
+<ele>133.23277894823008></ele>
+<accuracy>4.192</accuracy>
+<speed>1.536505</speed>
+<bearing>94.47708</bearing>
+<bearingAccuracyDegrees>9.753871</bearingAccuracyDegrees>
+<time>1746106282540</time>
+</trkpt>
+<trkpt lat="55.9457552" lon="-4.3062833">
+<ele>133.45376815647307></ele>
+<accuracy>4.23</accuracy>
+<speed>1.5093478</speed>
+<bearing>92.85399</bearing>
+<bearingAccuracyDegrees>10.087154</bearingAccuracyDegrees>
+<time>1746106283542</time>
+</trkpt>
+<trkpt lat="55.9457555" lon="-4.3062588">
+<ele>133.41517111581118></ele>
+<accuracy>4.258</accuracy>
+<speed>1.4401718</speed>
+<bearing>89.794945</bearing>
+<bearingAccuracyDegrees>9.94837</bearingAccuracyDegrees>
+<time>1746106284644</time>
+</trkpt>
+<trkpt lat="55.9457585" lon="-4.3062351">
+<ele>133.39952371624364></ele>
+<accuracy>3.852</accuracy>
+<speed>1.3773915</speed>
+<bearing>84.86954</bearing>
+<bearingAccuracyDegrees>9.944901</bearingAccuracyDegrees>
+<time>1746106286481</time>
+</trkpt>
+<trkpt lat="55.9457631" lon="-4.3062166">
+<ele>133.36562111484432></ele>
+<accuracy>3.521</accuracy>
+<speed>1.3453194</speed>
+<bearing>85.33174</bearing>
+<bearingAccuracyDegrees>10.5143585</bearingAccuracyDegrees>
+<time>1746106287544</time>
+</trkpt>
+<trkpt lat="55.9457693" lon="-4.3061969">
+<ele>133.31711454832816></ele>
+<accuracy>3.208</accuracy>
+<speed>1.3571839</speed>
+<bearing>79.82762</bearing>
+<bearingAccuracyDegrees>11.494854</bearingAccuracyDegrees>
+<time>1746106288605</time>
+</trkpt>
+<trkpt lat="55.9457754" lon="-4.3061778">
+<ele>133.24200814640167></ele>
+<accuracy>3.114</accuracy>
+<speed>1.3575059</speed>
+<bearing>74.923836</bearing>
+<bearingAccuracyDegrees>9.736783</bearingAccuracyDegrees>
+<time>1746106289556</time>
+</trkpt>
+<trkpt lat="55.9457787" lon="-4.3061571">
+<ele>132.97826708665295></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3688195</speed>
+<bearing>80.627884</bearing>
+<bearingAccuracyDegrees>9.578948</bearingAccuracyDegrees>
+<time>1746106290458</time>
+</trkpt>
+<trkpt lat="55.9457798" lon="-4.3061287">
+<ele>132.95798212427752></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3531449</speed>
+<bearing>84.55991</bearing>
+<bearingAccuracyDegrees>9.833431</bearingAccuracyDegrees>
+<time>1746106291560</time>
+</trkpt>
+<trkpt lat="55.945779" lon="-4.3061008">
+<ele>132.9345116405699></ele>
+<accuracy>3.032</accuracy>
+<speed>1.3916585</speed>
+<bearing>87.08952</bearing>
+<bearingAccuracyDegrees>11.829218</bearingAccuracyDegrees>
+<time>1746106292562</time>
+</trkpt>
+<trkpt lat="55.9457764" lon="-4.3060705">
+<ele>133.08440522092806></ele>
+<accuracy>3.139</accuracy>
+<speed>1.4589274</speed>
+<bearing>88.2287</bearing>
+<bearingAccuracyDegrees>12.064794</bearingAccuracyDegrees>
+<time>1746106293565</time>
+</trkpt>
+<trkpt lat="55.9457712" lon="-4.3060385">
+<ele>133.0551977797738></ele>
+<accuracy>3.302</accuracy>
+<speed>1.5224118</speed>
+<bearing>92.82686</bearing>
+<bearingAccuracyDegrees>11.913096</bearingAccuracyDegrees>
+<time>1746106294567</time>
+</trkpt>
+<trkpt lat="55.9457634" lon="-4.3060024">
+<ele>133.04111565608716></ele>
+<accuracy>3.515</accuracy>
+<speed>1.5696297</speed>
+<bearing>96.1687</bearing>
+<bearingAccuracyDegrees>10.2926035</bearingAccuracyDegrees>
+<time>1746106295569</time>
+</trkpt>
+<trkpt lat="55.9457566" lon="-4.3059693">
+<ele>133.04111565608716></ele>
+<accuracy>3.74</accuracy>
+<speed>1.6029307</speed>
+<bearing>97.490074</bearing>
+<bearingAccuracyDegrees>10.186926</bearingAccuracyDegrees>
+<time>1746106296504</time>
+</trkpt>
+<trkpt lat="55.9457518" lon="-4.3059353">
+<ele>132.99678319504588></ele>
+<accuracy>3.992</accuracy>
+<speed>1.6104045</speed>
+<bearing>95.689896</bearing>
+<bearingAccuracyDegrees>9.733147</bearingAccuracyDegrees>
+<time>1746106297527</time>
+</trkpt>
+<trkpt lat="55.9457492" lon="-4.3059001">
+<ele>132.92950260252775></ele>
+<accuracy>4.152</accuracy>
+<speed>1.618489</speed>
+<bearing>100.68558</bearing>
+<bearingAccuracyDegrees>9.312783</bearingAccuracyDegrees>
+<time>1746106298609</time>
+</trkpt>
+<trkpt lat="55.9457486" lon="-4.3058711">
+<ele>132.60481488812687></ele>
+<accuracy>4.247</accuracy>
+<speed>1.6255523</speed>
+<bearing>100.37788</bearing>
+<bearingAccuracyDegrees>9.393286</bearingAccuracyDegrees>
+<time>1746106299578</time>
+</trkpt>
+<trkpt lat="55.9457477" lon="-4.3058421">
+<ele>133.15995971553915></ele>
+<accuracy>4.267</accuracy>
+<speed>1.612004</speed>
+<bearing>101.71372</bearing>
+<bearingAccuracyDegrees>9.238431</bearingAccuracyDegrees>
+<time>1746106300581</time>
+</trkpt>
+<trkpt lat="55.9457469" lon="-4.3058164">
+<ele>132.48694634679663></ele>
+<accuracy>4.187</accuracy>
+<speed>1.5492811</speed>
+<bearing>100.29508</bearing>
+<bearingAccuracyDegrees>9.249095</bearingAccuracyDegrees>
+<time>1746106301583</time>
+</trkpt>
+<trkpt lat="55.9457459" lon="-4.3057946">
+<ele>132.7794188798757></ele>
+<accuracy>4.146</accuracy>
+<speed>1.4873044</speed>
+<bearing>100.12624</bearing>
+<bearingAccuracyDegrees>9.022685</bearingAccuracyDegrees>
+<time>1746106302585</time>
+</trkpt>
+<trkpt lat="55.9457516" lon="-4.3057651">
+<ele>132.45649813247445></ele>
+<accuracy>3.424</accuracy>
+<speed>1.3541228</speed>
+<bearing>84.93193</bearing>
+<bearingAccuracyDegrees>11.26409</bearingAccuracyDegrees>
+<time>1746106305592</time>
+</trkpt>
+<trkpt lat="55.9457558" lon="-4.3057471">
+<ele>132.4176438551213></ele>
+<accuracy>3.271</accuracy>
+<speed>1.3315724</speed>
+<bearing>86.302505</bearing>
+<bearingAccuracyDegrees>10.06665</bearingAccuracyDegrees>
+<time>1746106306594</time>
+</trkpt>
+<trkpt lat="55.9457573" lon="-4.3057279">
+<ele>132.30128059363085></ele>
+<accuracy>3.093</accuracy>
+<speed>1.2843702</speed>
+<bearing>91.710884</bearing>
+<bearingAccuracyDegrees>10.257542</bearingAccuracyDegrees>
+<time>1746106307596</time>
+</trkpt>
+<trkpt lat="55.9457563" lon="-4.305705">
+<ele>132.25815246899012></ele>
+<accuracy>3.001</accuracy>
+<speed>1.2941512</speed>
+<bearing>88.21986</bearing>
+<bearingAccuracyDegrees>10.099858</bearingAccuracyDegrees>
+<time>1746106308598</time>
+</trkpt>
+<trkpt lat="55.9457564" lon="-4.30568">
+<ele>132.2136644392927></ele>
+<accuracy>3.043</accuracy>
+<speed>1.328149</speed>
+<bearing>85.73959</bearing>
+<bearingAccuracyDegrees>11.988532</bearingAccuracyDegrees>
+<time>1746106309601</time>
+</trkpt>
+<trkpt lat="55.9457554" lon="-4.3056513">
+<ele>132.94284068542987></ele>
+<accuracy>3.164</accuracy>
+<speed>1.3837625</speed>
+<bearing>90.92898</bearing>
+<bearingAccuracyDegrees>12.1377325</bearingAccuracyDegrees>
+<time>1746106310603</time>
+</trkpt>
+<trkpt lat="55.9457503" lon="-4.3056176">
+<ele>132.3179016365916></ele>
+<accuracy>3.303</accuracy>
+<speed>1.4700754</speed>
+<bearing>94.98381</bearing>
+<bearingAccuracyDegrees>12.011085</bearingAccuracyDegrees>
+<time>1746106311606</time>
+</trkpt>
+<trkpt lat="55.9457371" lon="-4.3054853">
+<ele>132.2234423390918></ele>
+<accuracy>4.014</accuracy>
+<speed>1.5693594</speed>
+<bearing>94.61319</bearing>
+<bearingAccuracyDegrees>9.515355</bearingAccuracyDegrees>
+<time>1746106315587</time>
+</trkpt>
+<trkpt lat="55.9457361" lon="-4.3054548">
+<ele>132.2635985633222></ele>
+<accuracy>4.112</accuracy>
+<speed>1.5567137</speed>
+<bearing>96.4751</bearing>
+<bearingAccuracyDegrees>9.393799</bearingAccuracyDegrees>
+<time>1746106316548</time>
+</trkpt>
+<trkpt lat="55.9457364" lon="-4.3054222">
+<ele>132.20623258610507></ele>
+<accuracy>4.153</accuracy>
+<speed>1.5302167</speed>
+<bearing>94.94904</bearing>
+<bearingAccuracyDegrees>9.754072</bearingAccuracyDegrees>
+<time>1746106317603</time>
+</trkpt>
+<trkpt lat="55.9457387" lon="-4.3053971">
+<ele>132.13947993068393></ele>
+<accuracy>4.197</accuracy>
+<speed>1.4920758</speed>
+<bearing>94.159454</bearing>
+<bearingAccuracyDegrees>9.532106</bearingAccuracyDegrees>
+<time>1746106318622</time>
+</trkpt>
+<trkpt lat="55.9457408" lon="-4.3053735">
+<ele>131.82641157284243></ele>
+<accuracy>4.192</accuracy>
+<speed>1.4638522</speed>
+<bearing>100.42973</bearing>
+<bearingAccuracyDegrees>9.715256</bearingAccuracyDegrees>
+<time>1746106319623</time>
+</trkpt>
+<trkpt lat="55.9457476" lon="-4.3053595">
+<ele>132.04194219672598></ele>
+<accuracy>3.715</accuracy>
+<speed>1.3610468</speed>
+<bearing>91.78161</bearing>
+<bearingAccuracyDegrees>11.584006</bearingAccuracyDegrees>
+<time>1746106321550</time>
+</trkpt>
+<trkpt lat="55.9457493" lon="-4.3053435">
+<ele>132.01847483416674></ele>
+<accuracy>3.463</accuracy>
+<speed>1.3191693</speed>
+<bearing>88.01088</bearing>
+<bearingAccuracyDegrees>12.108738</bearingAccuracyDegrees>
+<time>1746106322603</time>
+</trkpt>
+<trkpt lat="55.94575" lon="-4.3053274">
+<ele>131.7798429365331></ele>
+<accuracy>3.251</accuracy>
+<speed>1.3063129</speed>
+<bearing>88.01017</bearing>
+<bearingAccuracyDegrees>11.935227</bearingAccuracyDegrees>
+<time>1746106323633</time>
+</trkpt>
+<trkpt lat="55.9457478" lon="-4.3053056">
+<ele>131.7798429365331></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3272923</speed>
+<bearing>92.34956</bearing>
+<bearingAccuracyDegrees>11.985694</bearingAccuracyDegrees>
+<time>1746106324558</time>
+</trkpt>
+<trkpt lat="55.9457453" lon="-4.3052799">
+<ele>131.90523362540438></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3688774</speed>
+<bearing>91.898155</bearing>
+<bearingAccuracyDegrees>12.980638</bearingAccuracyDegrees>
+<time>1746106325611</time>
+</trkpt>
+<trkpt lat="55.9457426" lon="-4.3052543">
+<ele>131.90523362540438></ele>
+<accuracy>3.053</accuracy>
+<speed>1.4037937</speed>
+<bearing>92.431496</bearing>
+<bearingAccuracyDegrees>12.737381</bearingAccuracyDegrees>
+<time>1746106326540</time>
+</trkpt>
+<trkpt lat="55.9457385" lon="-4.3052251">
+<ele>132.61646172506155></ele>
+<accuracy>3.204</accuracy>
+<speed>1.4108634</speed>
+<bearing>98.18464</bearing>
+<bearingAccuracyDegrees>12.067733</bearingAccuracyDegrees>
+<time>1746106327542</time>
+</trkpt>
+<trkpt lat="55.9457347" lon="-4.3051936">
+<ele>132.5987310057728></ele>
+<accuracy>3.456</accuracy>
+<speed>1.4567645</speed>
+<bearing>92.96377</bearing>
+<bearingAccuracyDegrees>11.745603</bearingAccuracyDegrees>
+<time>1746106328543</time>
+</trkpt>
+<trkpt lat="55.9457317" lon="-4.3051589">
+<ele>132.5653556333371></ele>
+<accuracy>3.631</accuracy>
+<speed>1.5117021</speed>
+<bearing>91.351814</bearing>
+<bearingAccuracyDegrees>12.394639</bearingAccuracyDegrees>
+<time>1746106329546</time>
+</trkpt>
+<trkpt lat="55.9457296" lon="-4.3051215">
+<ele>132.5653556333371></ele>
+<accuracy>3.933</accuracy>
+<speed>1.5308436</speed>
+<bearing>97.435646</bearing>
+<bearingAccuracyDegrees>12.69072</bearingAccuracyDegrees>
+<time>1746106330622</time>
+</trkpt>
+<trkpt lat="55.9457288" lon="-4.3050907">
+<ele>132.19411969768208></ele>
+<accuracy>4.135</accuracy>
+<speed>1.5458734</speed>
+<bearing>98.452545</bearing>
+<bearingAccuracyDegrees>12.359165</bearingAccuracyDegrees>
+<time>1746106331550</time>
+</trkpt>
+<trkpt lat="55.9457275" lon="-4.3050607">
+<ele>132.19411969768208></ele>
+<accuracy>4.286</accuracy>
+<speed>1.5252932</speed>
+<bearing>99.9594</bearing>
+<bearingAccuracyDegrees>11.992638</bearingAccuracyDegrees>
+<time>1746106332509</time>
+</trkpt>
+<trkpt lat="55.9457294" lon="-4.3050314">
+<ele>131.79481530071465></ele>
+<accuracy>4.427</accuracy>
+<speed>1.4905083</speed>
+<bearing>95.29153</bearing>
+<bearingAccuracyDegrees>12.152478</bearingAccuracyDegrees>
+<time>1746106333554</time>
+</trkpt>
+<trkpt lat="55.9457471" lon="-4.304954">
+<ele>131.39994791379291></ele>
+<accuracy>4.18</accuracy>
+<speed>1.3240435</speed>
+<bearing>72.00348</bearing>
+<bearingAccuracyDegrees>16.09101</bearingAccuracyDegrees>
+<time>1746106337899</time>
+</trkpt>
+<trkpt lat="55.9457558" lon="-4.3049324">
+<ele>131.3723103856582></ele>
+<accuracy>3.834</accuracy>
+<speed>1.3511924</speed>
+<bearing>59.802837</bearing>
+<bearingAccuracyDegrees>13.091841</bearingAccuracyDegrees>
+<time>1746106339141</time>
+</trkpt>
+<trkpt lat="55.9457647" lon="-4.3049115">
+<ele>131.3755735115522></ele>
+<accuracy>3.519</accuracy>
+<speed>1.3535206</speed>
+<bearing>50.04251</bearing>
+<bearingAccuracyDegrees>12.629967</bearingAccuracyDegrees>
+<time>1746106340184</time>
+</trkpt>
+<trkpt lat="55.9457749" lon="-4.304892">
+<ele>131.9280283351368></ele>
+<accuracy>3.23</accuracy>
+<speed>1.3577718</speed>
+<bearing>43.47923</bearing>
+<bearingAccuracyDegrees>12.5883665</bearingAccuracyDegrees>
+<time>1746106341265</time>
+</trkpt>
+<trkpt lat="55.9457847" lon="-4.3048712">
+<ele>131.32577789043816></ele>
+<accuracy>3.147</accuracy>
+<speed>1.3917089</speed>
+<bearing>36.010353</bearing>
+<bearingAccuracyDegrees>12.55029</bearingAccuracyDegrees>
+<time>1746106342307</time>
+</trkpt>
+<trkpt lat="55.9457965" lon="-4.3048518">
+<ele>131.1601528780801></ele>
+<accuracy>3.3</accuracy>
+<speed>1.4548914</speed>
+<bearing>19.758104</bearing>
+<bearingAccuracyDegrees>12.313244</bearingAccuracyDegrees>
+<time>1746106343370</time>
+</trkpt>
+<trkpt lat="55.9458114" lon="-4.3048395">
+<ele>131.04960752128343></ele>
+<accuracy>3.5</accuracy>
+<speed>1.482675</speed>
+<bearing>3.0562294</bearing>
+<bearingAccuracyDegrees>12.458985</bearingAccuracyDegrees>
+<time>1746106344486</time>
+</trkpt>
+<trkpt lat="55.9458291" lon="-4.3048333">
+<ele>130.72955826679623></ele>
+<accuracy>3.818</accuracy>
+<speed>1.52904</speed>
+<bearing>359.45856</bearing>
+<bearingAccuracyDegrees>11.814826</bearingAccuracyDegrees>
+<time>1746106345545</time>
+</trkpt>
+<trkpt lat="55.9458487" lon="-4.3048314">
+<ele>130.97034946084594></ele>
+<accuracy>4.03</accuracy>
+<speed>1.5891832</speed>
+<bearing>356.51608</bearing>
+<bearingAccuracyDegrees>11.603801</bearingAccuracyDegrees>
+<time>1746106346608</time>
+</trkpt>
+<trkpt lat="55.945868" lon="-4.3048335">
+<ele>130.97556378448027></ele>
+<accuracy>4.13</accuracy>
+<speed>1.6397328</speed>
+<bearing>357.98264</bearing>
+<bearingAccuracyDegrees>10.221221</bearingAccuracyDegrees>
+<time>1746106347631</time>
+</trkpt>
+<trkpt lat="55.9458832" lon="-4.3048343">
+<ele>130.75969342990018></ele>
+<accuracy>4.171</accuracy>
+<speed>1.6033336</speed>
+<bearing>356.9549</bearing>
+<bearingAccuracyDegrees>10.236375</bearingAccuracyDegrees>
+<time>1746106348590</time>
+</trkpt>
+<trkpt lat="55.9458998" lon="-4.304834">
+<ele>130.5850011607904></ele>
+<accuracy>4.188</accuracy>
+<speed>1.5620849</speed>
+<bearing>357.1635</bearing>
+<bearingAccuracyDegrees>9.930374</bearingAccuracyDegrees>
+<time>1746106349592</time>
+</trkpt>
+<trkpt lat="55.9459145" lon="-4.3048337">
+<ele>130.51200416622868></ele>
+<accuracy>4.182</accuracy>
+<speed>1.5322801</speed>
+<bearing>355.98395</bearing>
+<bearingAccuracyDegrees>9.927624</bearingAccuracyDegrees>
+<time>1746106350594</time>
+</trkpt>
+<trkpt lat="55.9459277" lon="-4.3048341">
+<ele>130.43788362729478></ele>
+<accuracy>4.149</accuracy>
+<speed>1.4973558</speed>
+<bearing>0.10015028</bearing>
+<bearingAccuracyDegrees>9.972196</bearingAccuracyDegrees>
+<time>1746106351596</time>
+</trkpt>
+<trkpt lat="55.9459387" lon="-4.3048314">
+<ele>130.20534154330633></ele>
+<accuracy>4.079</accuracy>
+<speed>1.4492351</speed>
+<bearing>359.94272</bearing>
+<bearingAccuracyDegrees>11.860732</bearingAccuracyDegrees>
+<time>1746106352599</time>
+</trkpt>
+<trkpt lat="55.9459488" lon="-4.304837">
+<ele>130.07186731303952></ele>
+<accuracy>3.641</accuracy>
+<speed>1.381427</speed>
+<bearing>348.23022</bearing>
+<bearingAccuracyDegrees>13.111746</bearingAccuracyDegrees>
+<time>1746106354567</time>
+</trkpt>
+<trkpt lat="55.94596" lon="-4.3048439">
+<ele>129.86853164712446></ele>
+<accuracy>3.403</accuracy>
+<speed>1.3653064</speed>
+<bearing>345.7077</bearing>
+<bearingAccuracyDegrees>13.24147</bearingAccuracyDegrees>
+<time>1746106355646</time>
+</trkpt>
+<trkpt lat="55.9459708" lon="-4.304852">
+<ele>130.43219651799643></ele>
+<accuracy>3.202</accuracy>
+<speed>1.3590195</speed>
+<bearing>349.23517</bearing>
+<bearingAccuracyDegrees>12.932543</bearingAccuracyDegrees>
+<time>1746106356608</time>
+</trkpt>
+<trkpt lat="55.9459851" lon="-4.3048609">
+<ele>130.23305080780048></ele>
+<accuracy>3.0</accuracy>
+<speed>1.388225</speed>
+<bearing>350.3388</bearing>
+<bearingAccuracyDegrees>11.909773</bearingAccuracyDegrees>
+<time>1746106357609</time>
+</trkpt>
+<trkpt lat="55.9459999" lon="-4.304866">
+<ele>130.19707788659434></ele>
+<accuracy>3.011</accuracy>
+<speed>1.3626353</speed>
+<bearing>351.7997</bearing>
+<bearingAccuracyDegrees>12.155818</bearingAccuracyDegrees>
+<time>1746106358611</time>
+</trkpt>
+<trkpt lat="55.9460154" lon="-4.3048668">
+<ele>130.03598360692968></ele>
+<accuracy>3.067</accuracy>
+<speed>1.3998208</speed>
+<bearing>357.07492</bearing>
+<bearingAccuracyDegrees>12.049558</bearingAccuracyDegrees>
+<time>1746106359615</time>
+</trkpt>
+<trkpt lat="55.946031" lon="-4.3048641">
+<ele>129.91294923159603></ele>
+<accuracy>3.185</accuracy>
+<speed>1.4231949</speed>
+<bearing>358.30078</bearing>
+<bearingAccuracyDegrees>12.051122</bearingAccuracyDegrees>
+<time>1746106360617</time>
+</trkpt>
+<trkpt lat="55.9460462" lon="-4.3048607">
+<ele>129.91502083850628></ele>
+<accuracy>3.328</accuracy>
+<speed>1.4066927</speed>
+<bearing>353.58652</bearing>
+<bearingAccuracyDegrees>12.304592</bearingAccuracyDegrees>
+<time>1746106361619</time>
+</trkpt>
+<trkpt lat="55.9460613" lon="-4.304863">
+<ele>129.05437264473827></ele>
+<accuracy>3.538</accuracy>
+<speed>1.4396456</speed>
+<bearing>353.7029</bearing>
+<bearingAccuracyDegrees>12.468415</bearingAccuracyDegrees>
+<time>1746106362622</time>
+</trkpt>
+<trkpt lat="55.9460788" lon="-4.3048628">
+<ele>129.03299895573997></ele>
+<accuracy>3.777</accuracy>
+<speed>1.4794791</speed>
+<bearing>354.51123</bearing>
+<bearingAccuracyDegrees>11.922178</bearingAccuracyDegrees>
+<time>1746106363624</time>
+</trkpt>
+<trkpt lat="55.9460967" lon="-4.3048641">
+<ele>129.041861210586></ele>
+<accuracy>4.018</accuracy>
+<speed>1.5237124</speed>
+<bearing>352.95563</bearing>
+<bearingAccuracyDegrees>9.569237</bearingAccuracyDegrees>
+<time>1746106364626</time>
+</trkpt>
+<trkpt lat="55.9461137" lon="-4.304866">
+<ele>128.8701784813355></ele>
+<accuracy>4.204</accuracy>
+<speed>1.5378304</speed>
+<bearing>354.12088</bearing>
+<bearingAccuracyDegrees>9.068659</bearingAccuracyDegrees>
+<time>1746106365628</time>
+</trkpt>
+<trkpt lat="55.9461694" lon="-4.3048642">
+<ele>129.3247948728306></ele>
+<accuracy>4.091</accuracy>
+<speed>1.3882471</speed>
+<bearing>354.37003</bearing>
+<bearingAccuracyDegrees>9.544604</bearingAccuracyDegrees>
+<time>1746106369637</time>
+</trkpt>
+<trkpt lat="55.9461787" lon="-4.3048625">
+<ele>129.2815272711734></ele>
+<accuracy>3.815</accuracy>
+<speed>1.3111887</speed>
+<bearing>355.0338</bearing>
+<bearingAccuracyDegrees>8.918746</bearingAccuracyDegrees>
+<time>1746106371025</time>
+</trkpt>
+<trkpt lat="55.9461889" lon="-4.3048626">
+<ele>128.62578845369293></ele>
+<accuracy>3.661</accuracy>
+<speed>1.304369</speed>
+<bearing>352.9207</bearing>
+<bearingAccuracyDegrees>9.197114</bearingAccuracyDegrees>
+<time>1746106372027</time>
+</trkpt>
+<trkpt lat="55.9462022" lon="-4.3048636">
+<ele>128.61432007979874></ele>
+<accuracy>3.464</accuracy>
+<speed>1.3059182</speed>
+<bearing>354.7517</bearing>
+<bearingAccuracyDegrees>9.057273</bearingAccuracyDegrees>
+<time>1746106373088</time>
+</trkpt>
+<trkpt lat="55.9462157" lon="-4.3048639">
+<ele>128.62422458362477></ele>
+<accuracy>3.206</accuracy>
+<speed>1.2975602</speed>
+<bearing>352.9329</bearing>
+<bearingAccuracyDegrees>9.478405</bearingAccuracyDegrees>
+<time>1746106374070</time>
+</trkpt>
+<trkpt lat="55.946228" lon="-4.3048667">
+<ele>128.62318200373633></ele>
+<accuracy>3.061</accuracy>
+<speed>1.2957022</speed>
+<bearing>351.1038</bearing>
+<bearingAccuracyDegrees>10.111941</bearingAccuracyDegrees>
+<time>1746106375023</time>
+</trkpt>
+<trkpt lat="55.946243" lon="-4.3048682">
+<ele>128.59242595392325></ele>
+<accuracy>3.184</accuracy>
+<speed>1.3832383</speed>
+<bearing>339.19632</bearing>
+<bearingAccuracyDegrees>10.275706</bearingAccuracyDegrees>
+<time>1746106376085</time>
+</trkpt>
+<trkpt lat="55.9462614" lon="-4.3048727">
+<ele>128.54757491304707></ele>
+<accuracy>3.354</accuracy>
+<speed>1.4020787</speed>
+<bearing>356.6719</bearing>
+<bearingAccuracyDegrees>14.824509</bearingAccuracyDegrees>
+<time>1746106377307</time>
+</trkpt>
+<trkpt lat="55.9462807" lon="-4.3048621">
+<ele>128.57989469364588></ele>
+<accuracy>3.641</accuracy>
+<speed>1.3943155</speed>
+<bearing>2.0724702</bearing>
+<bearingAccuracyDegrees>18.068026</bearingAccuracyDegrees>
+<time>1746106378410</time>
+</trkpt>
+<trkpt lat="55.946299" lon="-4.3048579">
+<ele>129.06725825513652></ele>
+<accuracy>3.978</accuracy>
+<speed>1.4611735</speed>
+<bearing>357.16763</bearing>
+<bearingAccuracyDegrees>18.49711</bearingAccuracyDegrees>
+<time>1746106379423</time>
+</trkpt>
+<trkpt lat="55.94632" lon="-4.3048521">
+<ele>128.4072631492872></ele>
+<accuracy>4.329</accuracy>
+<speed>1.5347016</speed>
+<bearing>354.03903</bearing>
+<bearingAccuracyDegrees>15.997981</bearingAccuracyDegrees>
+<time>1746106380446</time>
+</trkpt>
+<trkpt lat="55.9463415" lon="-4.3048513">
+<ele>128.41612489274004></ele>
+<accuracy>4.59</accuracy>
+<speed>1.5765132</speed>
+<bearing>336.2142</bearing>
+<bearingAccuracyDegrees>15.943199</bearingAccuracyDegrees>
+<time>1746106381510</time>
+</trkpt>
+<trkpt lat="55.9463564" lon="-4.3048669">
+<ele>128.48597660198797></ele>
+<accuracy>4.729</accuracy>
+<speed>1.5244927</speed>
+<bearing>302.75098</bearing>
+<bearingAccuracyDegrees>14.778163</bearingAccuracyDegrees>
+<time>1746106382591</time>
+</trkpt>
+<trkpt lat="55.9463637" lon="-4.3048906">
+<ele>129.50215826312433></ele>
+<accuracy>4.749</accuracy>
+<speed>1.4957316</speed>
+<bearing>280.43915</bearing>
+<bearingAccuracyDegrees>12.185571</bearingAccuracyDegrees>
+<time>1746106383569</time>
+</trkpt>
+<trkpt lat="55.9463648" lon="-4.3049239">
+<ele>129.4932962747256></ele>
+<accuracy>4.621</accuracy>
+<speed>1.501353</speed>
+<bearing>274.45258</bearing>
+<bearingAccuracyDegrees>11.935645</bearingAccuracyDegrees>
+<time>1746106384571</time>
+</trkpt>
+<trkpt lat="55.9463648" lon="-4.3049621">
+<ele>129.48756166352527></ele>
+<accuracy>4.412</accuracy>
+<speed>1.5725311</speed>
+<bearing>274.9105</bearing>
+<bearingAccuracyDegrees>10.335772</bearingAccuracyDegrees>
+<time>1746106385574</time>
+</trkpt>
+<trkpt lat="55.9463636" lon="-4.3050057">
+<ele>129.3603675445645></ele>
+<accuracy>4.098</accuracy>
+<speed>1.5983559</speed>
+<bearing>270.6978</bearing>
+<bearingAccuracyDegrees>9.971237</bearingAccuracyDegrees>
+<time>1746106386576</time>
+</trkpt>
+<trkpt lat="55.9463625" lon="-4.3050414">
+<ele>129.30666361851019></ele>
+<accuracy>3.808</accuracy>
+<speed>1.6051124</speed>
+<bearing>268.28485</bearing>
+<bearingAccuracyDegrees>9.299373</bearingAccuracyDegrees>
+<time>1746106387578</time>
+</trkpt>
+<trkpt lat="55.9463624" lon="-4.305073">
+<ele>129.4197824837725></ele>
+<accuracy>3.517</accuracy>
+<speed>1.6193557</speed>
+<bearing>272.9071</bearing>
+<bearingAccuracyDegrees>9.313634</bearingAccuracyDegrees>
+<time>1746106388581</time>
+</trkpt>
+<trkpt lat="55.9463618" lon="-4.305098">
+<ele>129.4197824837725></ele>
+<accuracy>3.352</accuracy>
+<speed>1.5746489</speed>
+<bearing>272.71024</bearing>
+<bearingAccuracyDegrees>7.226647</bearingAccuracyDegrees>
+<time>1746106389490</time>
+</trkpt>
+<trkpt lat="55.9463608" lon="-4.3051189">
+<ele>129.4302082605273></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5461042</speed>
+<bearing>271.08438</bearing>
+<bearingAccuracyDegrees>9.071432</bearingAccuracyDegrees>
+<time>1746106390507</time>
+</trkpt>
+<trkpt lat="55.9463598" lon="-4.3051401">
+<ele>129.58346863732658></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5082744</speed>
+<bearing>268.49246</bearing>
+<bearingAccuracyDegrees>9.119977</bearingAccuracyDegrees>
+<time>1746106391570</time>
+</trkpt>
+<trkpt lat="55.9463576" lon="-4.3051598">
+<ele>129.26693102092372></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4590608</speed>
+<bearing>264.04535</bearing>
+<bearingAccuracyDegrees>9.264364</bearingAccuracyDegrees>
+<time>1746106392589</time>
+</trkpt>
+<trkpt lat="55.9463516" lon="-4.3052687">
+<ele>129.2116740122466></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4510046</speed>
+<bearing>273.03064</bearing>
+<bearingAccuracyDegrees>9.561473</bearingAccuracyDegrees>
+<time>1746106396581</time>
+</trkpt>
+<trkpt lat="55.9463525" lon="-4.3053015">
+<ele>129.25233479544661></ele>
+<accuracy>3.0</accuracy>
+<speed>1.460612</speed>
+<bearing>271.35034</bearing>
+<bearingAccuracyDegrees>9.052523</bearingAccuracyDegrees>
+<time>1746106397651</time>
+</trkpt>
+<trkpt lat="55.9463533" lon="-4.3053339">
+<ele>129.35629089667242></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5118486</speed>
+<bearing>267.2365</bearing>
+<bearingAccuracyDegrees>9.533818</bearingAccuracyDegrees>
+<time>1746106398603</time>
+</trkpt>
+<trkpt lat="55.946354" lon="-4.3053728">
+<ele>129.38166191429482></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5735011</speed>
+<bearing>270.90607</bearing>
+<bearingAccuracyDegrees>9.151583</bearingAccuracyDegrees>
+<time>1746106399606</time>
+</trkpt>
+<trkpt lat="55.9463566" lon="-4.3054183">
+<ele>129.38166191429482></ele>
+<accuracy>3.0</accuracy>
+<speed>1.6270697</speed>
+<bearing>278.04916</bearing>
+<bearingAccuracyDegrees>6.8734856</bearingAccuracyDegrees>
+<time>1746106400657</time>
+</trkpt>
+<trkpt lat="55.946359" lon="-4.3054588">
+<ele>128.54446758725214></ele>
+<accuracy>3.0</accuracy>
+<speed>1.700395</speed>
+<bearing>277.8682</bearing>
+<bearingAccuracyDegrees>6.8509965</bearingAccuracyDegrees>
+<time>1746106401610</time>
+</trkpt>
+<trkpt lat="55.9463608" lon="-4.3055023">
+<ele>128.51058411985161></ele>
+<accuracy>3.0</accuracy>
+<speed>1.7749779</speed>
+<bearing>274.04886</bearing>
+<bearingAccuracyDegrees>6.940138</bearingAccuracyDegrees>
+<time>1746106402612</time>
+</trkpt>
+<trkpt lat="55.9463619" lon="-4.305541">
+<ele>128.44542398083647></ele>
+<accuracy>3.0</accuracy>
+<speed>1.8206497</speed>
+<bearing>275.8229</bearing>
+<bearingAccuracyDegrees>8.622826</bearingAccuracyDegrees>
+<time>1746106403615</time>
+</trkpt>
+<trkpt lat="55.9463648" lon="-4.3055729">
+<ele>128.2791375436721></ele>
+<accuracy>3.0</accuracy>
+<speed>1.8057629</speed>
+<bearing>287.36646</bearing>
+<bearingAccuracyDegrees>8.472033</bearingAccuracyDegrees>
+<time>1746106404617</time>
+</trkpt>
+<trkpt lat="55.9463735" lon="-4.3055858">
+<ele>128.1753849026922></ele>
+<accuracy>3.0</accuracy>
+<speed>1.7083387</speed>
+<bearing>336.56845</bearing>
+<bearingAccuracyDegrees>9.184941</bearingAccuracyDegrees>
+<time>1746106405618</time>
+</trkpt>
+<trkpt lat="55.9463839" lon="-4.3055778">
+<ele>128.15870449504064></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5867897</speed>
+<bearing>348.0622</bearing>
+<bearingAccuracyDegrees>9.458562</bearingAccuracyDegrees>
+<time>1746106406622</time>
+</trkpt>
+<trkpt lat="55.9463959" lon="-4.3055633">
+<ele>128.11795830469308></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5052032</speed>
+<bearing>352.357</bearing>
+<bearingAccuracyDegrees>7.2260046</bearingAccuracyDegrees>
+<time>1746106408148</time>
+</trkpt>
+<trkpt lat="55.9464127" lon="-4.3055464">
+<ele>128.12525596490556></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5687602</speed>
+<bearing>359.45993</bearing>
+<bearingAccuracyDegrees>6.758565</bearingAccuracyDegrees>
+<time>1746106409212</time>
+</trkpt>
+<trkpt lat="55.9464356" lon="-4.3055356">
+<ele>128.84780142103529></ele>
+<accuracy>3.0</accuracy>
+<speed>1.7302654</speed>
+<bearing>357.6741</bearing>
+<bearingAccuracyDegrees>7.29136</bearingAccuracyDegrees>
+<time>1746106410240</time>
+</trkpt>
+<trkpt lat="55.9464553" lon="-4.305534">
+<ele>128.93078913322893></ele>
+<accuracy>3.0</accuracy>
+<speed>1.6818454</speed>
+<bearing>354.2599</bearing>
+<bearingAccuracyDegrees>8.793029</bearingAccuracyDegrees>
+<time>1746106411264</time>
+</trkpt>
+<trkpt lat="55.9464717" lon="-4.3055377">
+<ele>128.36347584507402></ele>
+<accuracy>3.0</accuracy>
+<speed>1.6339024</speed>
+<bearing>345.86816</bearing>
+<bearingAccuracyDegrees>9.293975</bearingAccuracyDegrees>
+<time>1746106412328</time>
+</trkpt>
+<trkpt lat="55.946487" lon="-4.3055505">
+<ele>129.61042224684437></ele>
+<accuracy>3.0</accuracy>
+<speed>1.5458887</speed>
+<bearing>347.29324</bearing>
+<bearingAccuracyDegrees>9.520229</bearingAccuracyDegrees>
+<time>1746106413637</time>
+</trkpt>
+<trkpt lat="55.946496" lon="-4.3055538">
+<ele>129.6312728120157></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4215512</speed>
+<bearing>0.016083142</bearing>
+<bearingAccuracyDegrees>8.628153</bearingAccuracyDegrees>
+<time>1746106414763</time>
+</trkpt>
+<trkpt lat="55.9465066" lon="-4.3055562">
+<ele>129.62084752310992></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3779744</speed>
+<bearing>4.259718</bearing>
+<bearingAccuracyDegrees>8.668891</bearingAccuracyDegrees>
+<time>1746106415826</time>
+</trkpt>
+<trkpt lat="55.9465182" lon="-4.3055592">
+<ele>129.0069318843673></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3732041</speed>
+<bearing>2.5092359</bearing>
+<bearingAccuracyDegrees>8.44994</bearingAccuracyDegrees>
+<time>1746106416908</time>
+</trkpt>
+<trkpt lat="55.9465319" lon="-4.3055597">
+<ele>129.01631463243825></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3460597</speed>
+<bearing>4.156793</bearing>
+<bearingAccuracyDegrees>9.208091</bearingAccuracyDegrees>
+<time>1746106417990</time>
+</trkpt>
+<trkpt lat="55.9465455" lon="-4.3055608">
+<ele>129.04029281290605></ele>
+<accuracy>3.005</accuracy>
+<speed>1.3556938</speed>
+<bearing>354.79434</bearing>
+<bearingAccuracyDegrees>9.5503435</bearingAccuracyDegrees>
+<time>1746106419041</time>
+</trkpt>
+<trkpt lat="55.9465591" lon="-4.3055667">
+<ele>129.100759825736></ele>
+<accuracy>3.089</accuracy>
+<speed>1.353441</speed>
+<bearing>348.9217</bearing>
+<bearingAccuracyDegrees>10.136669</bearingAccuracyDegrees>
+<time>1746106420146</time>
+</trkpt>
+<trkpt lat="55.9465744" lon="-4.3055729">
+<ele>130.71198294731926></ele>
+<accuracy>3.229</accuracy>
+<speed>1.3781588</speed>
+<bearing>350.51785</bearing>
+<bearingAccuracyDegrees>9.956055</bearingAccuracyDegrees>
+<time>1746106421227</time>
+</trkpt>
+<trkpt lat="55.9465911" lon="-4.3055748">
+<ele>129.05227916169866></ele>
+<accuracy>3.438</accuracy>
+<speed>1.4233284</speed>
+<bearing>357.1026</bearing>
+<bearingAccuracyDegrees>11.670284</bearingAccuracyDegrees>
+<time>1746106422332</time>
+</trkpt>
+<trkpt lat="55.9466088" lon="-4.3055714">
+<ele>130.76254670949015></ele>
+<accuracy>3.661</accuracy>
+<speed>1.4213817</speed>
+<bearing>3.2384307</bearing>
+<bearingAccuracyDegrees>9.845215</bearingAccuracyDegrees>
+<time>1746106423442</time>
+</trkpt>
+<trkpt lat="55.9466271" lon="-4.3055683">
+<ele>130.8172810139306></ele>
+<accuracy>3.965</accuracy>
+<speed>1.4245224</speed>
+<bearing>356.6407</bearing>
+<bearingAccuracyDegrees>10.353663</bearingAccuracyDegrees>
+<time>1746106424577</time>
+</trkpt>
+<trkpt lat="55.9466409" lon="-4.3055671">
+<ele>131.0530124041813></ele>
+<accuracy>4.042</accuracy>
+<speed>1.4200604</speed>
+<bearing>355.4712</bearing>
+<bearingAccuracyDegrees>11.501602</bearingAccuracyDegrees>
+<time>1746106425564</time>
+</trkpt>
+<trkpt lat="55.9466546" lon="-4.3055664">
+<ele>130.86523244795583></ele>
+<accuracy>4.109</accuracy>
+<speed>1.4165446</speed>
+<bearing>353.48172</bearing>
+<bearingAccuracyDegrees>12.091131</bearingAccuracyDegrees>
+<time>1746106426567</time>
+</trkpt>
+<trkpt lat="55.9466682" lon="-4.3055696">
+<ele>129.4400468445128></ele>
+<accuracy>4.173</accuracy>
+<speed>1.4030069</speed>
+<bearing>351.41864</bearing>
+<bearingAccuracyDegrees>12.439183</bearingAccuracyDegrees>
+<time>1746106427569</time>
+</trkpt>
+<trkpt lat="55.9466807" lon="-4.3055745">
+<ele>129.4400468445128></ele>
+<accuracy>4.223</accuracy>
+<speed>1.3811086</speed>
+<bearing>358.26657</bearing>
+<bearingAccuracyDegrees>12.659652</bearingAccuracyDegrees>
+<time>1746106428504</time>
+</trkpt>
+<trkpt lat="55.9466948" lon="-4.305571">
+<ele>129.49719961501526></ele>
+<accuracy>4.287</accuracy>
+<speed>1.3960724</speed>
+<bearing>7.784023</bearing>
+<bearingAccuracyDegrees>12.944013</bearingAccuracyDegrees>
+<time>1746106429574</time>
+</trkpt>
+<trkpt lat="55.9467084" lon="-4.3055745">
+<ele>129.5360078769377></ele>
+<accuracy>4.053</accuracy>
+<speed>1.4156947</speed>
+<bearing>344.53055</bearing>
+<bearingAccuracyDegrees>12.396287</bearingAccuracyDegrees>
+<time>1746106430576</time>
+</trkpt>
+<trkpt lat="55.9467214" lon="-4.3055788">
+<ele>129.1210282793958></ele>
+<accuracy>3.79</accuracy>
+<speed>1.405371</speed>
+<bearing>357.4668</bearing>
+<bearingAccuracyDegrees>12.542637</bearingAccuracyDegrees>
+<time>1746106431578</time>
+</trkpt>
+<trkpt lat="55.9467337" lon="-4.3055748">
+<ele>129.1210282793958></ele>
+<accuracy>3.6</accuracy>
+<speed>1.4109547</speed>
+<bearing>358.79153</bearing>
+<bearingAccuracyDegrees>12.421553</bearingAccuracyDegrees>
+<time>1746106432482</time>
+</trkpt>
+<trkpt lat="55.9467486" lon="-4.305574">
+<ele>129.15595679635072></ele>
+<accuracy>3.179</accuracy>
+<speed>1.4162745</speed>
+<bearing>359.26523</bearing>
+<bearingAccuracyDegrees>12.204621</bearingAccuracyDegrees>
+<time>1746106433566</time>
+</trkpt>
+<trkpt lat="55.9467606" lon="-4.3055709">
+<ele>129.24508360442843></ele>
+<accuracy>3.044</accuracy>
+<speed>1.3775959</speed>
+<bearing>1.4814239</bearing>
+<bearingAccuracyDegrees>11.673987</bearingAccuracyDegrees>
+<time>1746106434584</time>
+</trkpt>
+<trkpt lat="55.9467715" lon="-4.3055707">
+<ele>129.3430938429493></ele>
+<accuracy>3.024</accuracy>
+<speed>1.3549316</speed>
+<bearing>339.88828</bearing>
+<bearingAccuracyDegrees>11.958977</bearingAccuracyDegrees>
+<time>1746106435586</time>
+</trkpt>
+<trkpt lat="55.9467822" lon="-4.3055814">
+<ele>130.1157724682809></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3577639</speed>
+<bearing>336.1933</bearing>
+<bearingAccuracyDegrees>9.623498</bearingAccuracyDegrees>
+<time>1746106436590</time>
+</trkpt>
+<trkpt lat="55.9467918" lon="-4.3055926">
+<ele>130.1157724682809></ele>
+<accuracy>3.0</accuracy>
+<speed>1.343193</speed>
+<bearing>334.9184</bearing>
+<bearingAccuracyDegrees>10.043932</bearingAccuracyDegrees>
+<time>1746106437565</time>
+</trkpt>
+<trkpt lat="55.946799" lon="-4.3056058">
+<ele>130.30747705967497></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3299868</speed>
+<bearing>328.48743</bearing>
+<bearingAccuracyDegrees>10.106114</bearingAccuracyDegrees>
+<time>1746106438493</time>
+</trkpt>
+<trkpt lat="55.9468117" lon="-4.3056201">
+<ele>130.323220873842></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3269922</speed>
+<bearing>326.83984</bearing>
+<bearingAccuracyDegrees>11.571001</bearingAccuracyDegrees>
+<time>1746106439532</time>
+</trkpt>
+<trkpt lat="55.9468227" lon="-4.305633">
+<ele>130.48185158516134></ele>
+<accuracy>3.013</accuracy>
+<speed>1.3219819</speed>
+<bearing>323.12628</bearing>
+<bearingAccuracyDegrees>12.18874</bearingAccuracyDegrees>
+<time>1746106440542</time>
+</trkpt>
+<trkpt lat="55.9468344" lon="-4.305648">
+<ele>130.7950638301438></ele>
+<accuracy>3.096</accuracy>
+<speed>1.313055</speed>
+<bearing>317.79175</bearing>
+<bearingAccuracyDegrees>12.6859255</bearingAccuracyDegrees>
+<time>1746106441645</time>
+</trkpt>
+<trkpt lat="55.9468458" lon="-4.3056615">
+<ele>131.77550206199692></ele>
+<accuracy>3.187</accuracy>
+<speed>1.3774359</speed>
+<bearing>321.155</bearing>
+<bearingAccuracyDegrees>11.533675</bearingAccuracyDegrees>
+<time>1746106442603</time>
+</trkpt>
+<trkpt lat="55.9468609" lon="-4.3056764">
+<ele>131.82712029655283></ele>
+<accuracy>3.371</accuracy>
+<speed>1.4055091</speed>
+<bearing>318.89554</bearing>
+<bearingAccuracyDegrees>10.225882</bearingAccuracyDegrees>
+<time>1746106443605</time>
+</trkpt>
+<trkpt lat="55.9468769" lon="-4.3056902">
+<ele>133.01506073514895></ele>
+<accuracy>3.509</accuracy>
+<speed>1.4202</speed>
+<bearing>323.65488</bearing>
+<bearingAccuracyDegrees>11.885116</bearingAccuracyDegrees>
+<time>1746106444608</time>
+</trkpt>
+<trkpt lat="55.9468928" lon="-4.3057034">
+<ele>131.9136727790751></ele>
+<accuracy>3.732</accuracy>
+<speed>1.4345734</speed>
+<bearing>328.37878</bearing>
+<bearingAccuracyDegrees>9.675658</bearingAccuracyDegrees>
+<time>1746106445609</time>
+</trkpt>
+<trkpt lat="55.946909" lon="-4.3057127">
+<ele>131.3967357702166></ele>
+<accuracy>3.849</accuracy>
+<speed>1.4275012</speed>
+<bearing>336.9538</bearing>
+<bearingAccuracyDegrees>9.383851</bearingAccuracyDegrees>
+<time>1746106446629</time>
+</trkpt>
+<trkpt lat="55.9469231" lon="-4.3057182">
+<ele>131.47025466442008></ele>
+<accuracy>3.896</accuracy>
+<speed>1.4059016</speed>
+<bearing>338.61142</bearing>
+<bearingAccuracyDegrees>9.6643715</bearingAccuracyDegrees>
+<time>1746106447615</time>
+</trkpt>
+<trkpt lat="55.9469361" lon="-4.3057258">
+<ele>131.4629981555276></ele>
+<accuracy>3.941</accuracy>
+<speed>1.392791</speed>
+<bearing>345.26614</bearing>
+<bearingAccuracyDegrees>9.566386</bearingAccuracyDegrees>
+<time>1746106448617</time>
+</trkpt>
+<trkpt lat="55.9469477" lon="-4.3057313">
+<ele>133.16962143865132></ele>
+<accuracy>3.951</accuracy>
+<speed>1.3577261</speed>
+<bearing>350.0946</bearing>
+<bearingAccuracyDegrees>9.444596</bearingAccuracyDegrees>
+<time>1746106449619</time>
+</trkpt>
+<trkpt lat="55.9469576" lon="-4.3057377">
+<ele>133.22906390634787></ele>
+<accuracy>3.94</accuracy>
+<speed>1.3331145</speed>
+<bearing>347.81018</bearing>
+<bearingAccuracyDegrees>9.609682</bearingAccuracyDegrees>
+<time>1746106450621</time>
+</trkpt>
+<trkpt lat="55.9470028" lon="-4.3057593">
+<ele>134.90000915527344></ele>
+<accuracy>3.157</accuracy>
+<speed>1.3092391</speed>
+<bearing>353.2072</bearing>
+<bearingAccuracyDegrees>11.993694</bearingAccuracyDegrees>
+<time>1746106455263</time>
+</trkpt>
+<trkpt lat="55.9470174" lon="-4.3057615">
+<ele>134.90000915527344></ele>
+<accuracy>3.098</accuracy>
+<speed>1.3791738</speed>
+<bearing>353.6306</bearing>
+<bearingAccuracyDegrees>12.002399</bearingAccuracyDegrees>
+<time>1746106456307</time>
+</trkpt>
+<trkpt lat="55.9470359" lon="-4.3057669">
+<ele>134.90000915527344></ele>
+<accuracy>3.246</accuracy>
+<speed>1.4221785</speed>
+<bearing>347.83713</bearing>
+<bearingAccuracyDegrees>12.264955</bearingAccuracyDegrees>
+<time>1746106457409</time>
+</trkpt>
+<trkpt lat="55.9470547" lon="-4.3057748">
+<ele>134.90000915527344></ele>
+<accuracy>3.414</accuracy>
+<speed>1.4430586</speed>
+<bearing>346.23685</bearing>
+<bearingAccuracyDegrees>12.012674</bearingAccuracyDegrees>
+<time>1746106458482</time>
+</trkpt>
+<trkpt lat="55.9470717" lon="-4.3057798">
+<ele>134.90000915527344></ele>
+<accuracy>3.672</accuracy>
+<speed>1.4196138</speed>
+<bearing>343.04358</bearing>
+<bearingAccuracyDegrees>11.7625675</bearingAccuracyDegrees>
+<time>1746106459566</time>
+</trkpt>
+<trkpt lat="55.947084" lon="-4.3057807">
+<ele>131.69882110385055></ele>
+<accuracy>3.85</accuracy>
+<speed>1.3206013</speed>
+<bearing>350.48608</bearing>
+<bearingAccuracyDegrees>10.012464</bearingAccuracyDegrees>
+<time>1746106460544</time>
+</trkpt>
+<trkpt lat="55.9470967" lon="-4.3057798">
+<ele>131.79060143571814></ele>
+<accuracy>3.968</accuracy>
+<speed>1.2868121</speed>
+<bearing>351.31192</bearing>
+<bearingAccuracyDegrees>10.371815</bearingAccuracyDegrees>
+<time>1746106461545</time>
+</trkpt>
+<trkpt lat="55.9471096" lon="-4.3057832">
+<ele>132.47138070698952></ele>
+<accuracy>4.033</accuracy>
+<speed>1.317026</speed>
+<bearing>355.29333</bearing>
+<bearingAccuracyDegrees>9.815131</bearingAccuracyDegrees>
+<time>1746106462648</time>
+</trkpt>
+<trkpt lat="55.9471219" lon="-4.3057886">
+<ele>132.47138070698952></ele>
+<accuracy>4.016</accuracy>
+<speed>1.3418151</speed>
+<bearing>354.39697</bearing>
+<bearingAccuracyDegrees>10.134785</bearingAccuracyDegrees>
+<time>1746106463551</time>
+</trkpt>
+<trkpt lat="55.9471349" lon="-4.305795">
+<ele>132.47138070698952></ele>
+<accuracy>4.028</accuracy>
+<speed>1.3368349</speed>
+<bearing>354.57697</bearing>
+<bearingAccuracyDegrees>9.902078</bearingAccuracyDegrees>
+<time>1746106464470</time>
+</trkpt>
+<trkpt lat="55.9471503" lon="-4.3057996">
+<ele>132.01378136934008></ele>
+<accuracy>4.05</accuracy>
+<speed>1.3361509</speed>
+<bearing>356.08688</bearing>
+<bearingAccuracyDegrees>10.34517</bearingAccuracyDegrees>
+<time>1746106465568</time>
+</trkpt>
+<trkpt lat="55.9471639" lon="-4.3058046">
+<ele>132.82067866661458></ele>
+<accuracy>4.093</accuracy>
+<speed>1.3213052</speed>
+<bearing>349.55594</bearing>
+<bearingAccuracyDegrees>11.8506155</bearingAccuracyDegrees>
+<time>1746106466558</time>
+</trkpt>
+<trkpt lat="55.9471791" lon="-4.3058138">
+<ele>132.85989816979395></ele>
+<accuracy>4.156</accuracy>
+<speed>1.3705719</speed>
+<bearing>345.2873</bearing>
+<bearingAccuracyDegrees>11.968027</bearingAccuracyDegrees>
+<time>1746106467560</time>
+</trkpt>
+<trkpt lat="55.9471962" lon="-4.3058246">
+<ele>133.01227914267014></ele>
+<accuracy>4.24</accuracy>
+<speed>1.4396862</speed>
+<bearing>347.65326</bearing>
+<bearingAccuracyDegrees>12.097511</bearingAccuracyDegrees>
+<time>1746106468561</time>
+</trkpt>
+<trkpt lat="55.9472144" lon="-4.3058354">
+<ele>133.01227914267014></ele>
+<accuracy>4.289</accuracy>
+<speed>1.4364139</speed>
+<bearing>340.506</bearing>
+<bearingAccuracyDegrees>10.4194355</bearingAccuracyDegrees>
+<time>1746106469607</time>
+</trkpt>
+<trkpt lat="55.9472305" lon="-4.3058429">
+<ele>134.90000915527344></ele>
+<accuracy>4.109</accuracy>
+<speed>1.3919426</speed>
+<bearing>19.013222</bearing>
+<bearingAccuracyDegrees>9.692531</bearingAccuracyDegrees>
+<time>1746106470567</time>
+</trkpt>
+<trkpt lat="55.9472404" lon="-4.3058425">
+<ele>134.90000915527344></ele>
+<accuracy>3.878</accuracy>
+<speed>1.3652823</speed>
+<bearing>339.71378</bearing>
+<bearingAccuracyDegrees>9.428385</bearingAccuracyDegrees>
+<time>1746106471569</time>
+</trkpt>
+<trkpt lat="55.947247" lon="-4.3058642">
+<ele>134.90000915527344></ele>
+<accuracy>3.549</accuracy>
+<speed>1.3465306</speed>
+<bearing>319.7747</bearing>
+<bearingAccuracyDegrees>10.133443</bearingAccuracyDegrees>
+<time>1746106472607</time>
+</trkpt>
+<trkpt lat="55.9472535" lon="-4.3058848">
+<ele>134.90000915527344></ele>
+<accuracy>3.237</accuracy>
+<speed>1.3280089</speed>
+<bearing>304.7758</bearing>
+<bearingAccuracyDegrees>9.972223</bearingAccuracyDegrees>
+<time>1746106473573</time>
+</trkpt>
+<trkpt lat="55.947263" lon="-4.3059069">
+<ele>136.3000030517578></ele>
+<accuracy>3.113</accuracy>
+<speed>1.368418</speed>
+<bearing>305.54102</bearing>
+<bearingAccuracyDegrees>9.701149</bearingAccuracyDegrees>
+<time>1746106474575</time>
+</trkpt>
+<trkpt lat="55.947276" lon="-4.3059235">
+<ele>134.90000915527344></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3974944</speed>
+<bearing>312.31866</bearing>
+<bearingAccuracyDegrees>9.741511</bearingAccuracyDegrees>
+<time>1746106475578</time>
+</trkpt>
+<trkpt lat="55.9472898" lon="-4.3059388">
+<ele>134.90000915527344></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4204198</speed>
+<bearing>314.5082</bearing>
+<bearingAccuracyDegrees>9.85457</bearingAccuracyDegrees>
+<time>1746106476580</time>
+</trkpt>
+<trkpt lat="55.9473035" lon="-4.3059515">
+<ele>134.90000915527344></ele>
+<accuracy>3.0</accuracy>
+<speed>1.4430933</speed>
+<bearing>329.24615</bearing>
+<bearingAccuracyDegrees>9.525213</bearingAccuracyDegrees>
+<time>1746106477583</time>
+</trkpt>
+<trkpt lat="55.9473146" lon="-4.3059577">
+<ele>134.90000915527344></ele>
+<accuracy>3.0</accuracy>
+<speed>1.3860223</speed>
+<bearing>303.78345</bearing>
+<bearingAccuracyDegrees>9.208561</bearingAccuracyDegrees>
+<time>1746106478585</time>
+</trkpt>
+<trkpt lat="55.9473209" lon="-4.3059711">
+<ele>136.3000030517578></ele>
+<accuracy>3.0</accuracy>
+<speed>1.2723515</speed>
+<bearing>340.419</bearing>
+<bearingAccuracyDegrees>9.620757</bearingAccuracyDegrees>
+<time>1746106480011</time>
+</trkpt>
+<trkpt lat="55.9473307" lon="-4.3059737">
+<ele>136.3000030517578></ele>
+<accuracy>3.0</accuracy>
+<speed>1.1595483</speed>
+<bearing>326.0267</bearing>
+<bearingAccuracyDegrees>27.681643</bearingAccuracyDegrees>
+<time>1746106481592</time>
+</trkpt>
+<trkpt lat="55.9473381" lon="-4.3059633">
+<ele>137.00001525878906></ele>
+<accuracy>3.022</accuracy>
+<speed>1.0125028</speed>
+<bearing>7.3083506</bearing>
+<bearingAccuracyDegrees>27.939045</bearingAccuracyDegrees>
+<time>1746106483389</time>
+</trkpt>
+<trkpt lat="55.9473481" lon="-4.3059525">
+<ele>137.00001525878906></ele>
+<accuracy>3.179</accuracy>
+<speed>1.0878795</speed>
+<bearing>16.90696</bearing>
+<bearingAccuracyDegrees>27.267553</bearingAccuracyDegrees>
+<time>1746106484540</time>
+</trkpt>
+<trkpt lat="55.9473548" lon="-4.3059339">
+<ele>137.00001525878906></ele>
+<accuracy>3.347</accuracy>
+<speed>1.1457667</speed>
+<bearing>28.832743</bearing>
+<bearingAccuracyDegrees>18.957289</bearingAccuracyDegrees>
+<time>1746106485507</time>
+</trkpt>
+<trkpt lat="55.9473625" lon="-4.3059176">
+<ele>137.00001525878906></ele>
+<accuracy>3.56</accuracy>
+<speed>1.1317347</speed>
+<bearing>30.906895</bearing>
+<bearingAccuracyDegrees>20.888842</bearingAccuracyDegrees>
+<time>1746106486603</time>
+</trkpt>
+<trkpt lat="55.9473689" lon="-4.3059059">
+<ele>137.00001525878906></ele>
+<accuracy>3.761</accuracy>
+<speed>1.0072321</speed>
+<bearing>15.486752</bearing>
+<bearingAccuracyDegrees>18.835855</bearingAccuracyDegrees>
+<time>1746106487605</time>
+</trkpt>
+<trkpt lat="55.9473694" lon="-4.3059227">
+<ele>136.3000030517578></ele>
+<accuracy>4.082</accuracy>
+<speed>0.76588774</speed>
+<bearing>250.1334</bearing>
+<bearingAccuracyDegrees>18.269709</bearingAccuracyDegrees>
+<time>1746106491212</time>
+</trkpt>
+<trkpt lat="55.9473585" lon="-4.3059574">
+<ele>136.3000030517578></ele>
+<accuracy>3.978</accuracy>
+<speed>0.77688205</speed>
+<bearing>220.7244</bearing>
+<bearingAccuracyDegrees>18.231216</bearingAccuracyDegrees>
+<time>1746106494621</time>
+</trkpt>
+<trkpt lat="55.9473499" lon="-4.3059644">
+<ele>136.3000030517578></ele>
+<accuracy>4.635</accuracy>
+<speed>0.5996426</speed>
+<bearing>238.70708</bearing>
+<bearingAccuracyDegrees>19.002699</bearingAccuracyDegrees>
+<time>1746106496626</time>
+</trkpt>
+<trkpt lat="55.9473569" lon="-4.3059527">
+<ele>136.3000030517578></ele>
+<accuracy>5.025</accuracy>
+<speed>0.2775047</speed>
+<bearing>313.10303</bearing>
+<bearingAccuracyDegrees>18.450684</bearingAccuracyDegrees>
+<time>1746106498585</time>
+</trkpt>
+<trkpt lat="55.9473638" lon="-4.3059402">
+<ele>136.3000030517578></ele>
+<accuracy>5.045</accuracy>
+<speed>0.26978496</speed>
+<bearing>230.36755</bearing>
+<bearingAccuracyDegrees>39.881016</bearingAccuracyDegrees>
+<time>1746106499631</time>
+</trkpt>
+<trkpt lat="55.9473655" lon="-4.3059221">
+<ele>137.00001525878906></ele>
+<accuracy>4.858</accuracy>
+<speed>0.297283</speed>
+<bearing>133.15019</bearing>
+<bearingAccuracyDegrees>64.37305</bearingAccuracyDegrees>
+<time>1746106501637</time>
+</trkpt>
+<trkpt lat="55.9473582" lon="-4.3059119">
+<ele>136.3000030517578></ele>
+<accuracy>4.788</accuracy>
+<speed>0.44240293</speed>
+<bearing>221.69197</bearing>
+<bearingAccuracyDegrees>54.629845</bearingAccuracyDegrees>
+<time>1746106504761</time>
+</trkpt>
+<trkpt lat="55.9473697" lon="-4.3059116">
+<ele>136.3000030517578></ele>
+<accuracy>5.254</accuracy>
+<speed>0.31498122</speed>
+<bearing>312.27423</bearing>
+<bearingAccuracyDegrees>64.06174</bearingAccuracyDegrees>
+<time>1746106507362</time>
+</trkpt>
+</trkseg>
+</trk>
+</gpx>


### PR DESCRIPTION
Allow map matching to jump between sidewalks and their associated way at will, ignoring Dijkstra. This is to allow 'jaywalking' behaviour.
Treat crossings in the same way as the sidewalks that they join.