### PR TITLE
Switch to using `last buffer` style GPX recording and more MapMatchFilter tweaks

### DIFF
--- a/app/src/androidTest/java/org/scottishtecharmy/soundscape/MvtPerformanceTest.kt
+++ b/app/src/androidTest/java/org/scottishtecharmy/soundscape/MvtPerformanceTest.kt
@@ -131,9 +131,10 @@ class MvtPerformanceTest {
         val measureTime = measureTime {
             val result = findShortestDistance(
                 startLocation,
-                endLocation,
                 startWay,
+                endLocation,
                 endWay,
+                null,
                 null,
                 200.0
             )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -255,6 +255,7 @@ class MainActivity : AppCompatActivity() {
                 }
                 HomeScreen(
                     navController = navController,
+                    preferences = sharedPreferences,
                     rateSoundscape = {
                         this.rateSoundscape()
                     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/filters/MapMatchFilter.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/filters/MapMatchFilter.kt
@@ -636,7 +636,7 @@ class MapMatchFilter {
     fun extendFollowerList(location: LngLatAlt, gridState: GridState) {
         var roadTree = gridState.featureTrees[TreeId.ROADS_AND_PATHS.id]
 
-        var roads = roadTree.getNearestCollection(location, 20.0, 4, gridState.ruler)
+        var roads = roadTree.getNearestCollection(location, 20.0, 8, gridState.ruler)
 
         if (followerList.isEmpty()) {
             if(roads.features.isNotEmpty()) {
@@ -788,9 +788,10 @@ class MapMatchFilter {
                             val testDistance = (follower.averagePointGap * 3) + 10.0
                             val shortestDistance = findShortestDistance(
                                 matchedLocation!!.point,
-                                follower.chosen()!!.point,
                                 matched,
+                                follower.chosen()!!.point,
                                 way,
+                                null,
                                 null,
                                 testDistance
                             )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/filters/MapMatchFilter.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/filters/MapMatchFilter.kt
@@ -100,7 +100,8 @@ class IndexedLineString {
         if(nextIntersection == null) {
             // We can get here if the tile grid is recalculated, and tiles rejoined and the route is
             // left with out of date and disconnected ways.
-            assert(false)
+            line = null
+            return
         }
         var firstIntersection = route[0].getOtherIntersection(nextIntersection!!)
         var forwards = nextIntersection != route[0].intersections[WayEnd.START.id]
@@ -390,9 +391,11 @@ class RoadFollower(val parent: MapMatchFilter,
         ruler: CheapRuler
     ) : RoadFollowerStatus {
 
+        if(ils.line == null)
+            return RoadFollowerStatus(Double.MAX_VALUE, RoadFollowerState.DISTANT)
         if(trimRoute(gpsLocation, ruler)) {
             // The route was trimmed
-            if (route.isEmpty()) {
+            if (route.isEmpty() || ils.line == null) {
                 return RoadFollowerStatus(Double.MAX_VALUE, RoadFollowerState.DISTANT)
             }
             // Reset nearestPoint so that the pointAlongLine is based on our newly trimmed line

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/filters/MapMatchFilter.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/filters/MapMatchFilter.kt
@@ -35,7 +35,7 @@ import kotlin.math.pow
 import kotlin.math.sign
 import kotlin.math.sqrt
 
-private const val FRECHET_QUEUE_SIZE = 24
+private const val FRECHET_QUEUE_SIZE = 12
 
 enum class RoadFollowerState {
     LOCKED,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/DrawerContent.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/DrawerContent.kt
@@ -1,5 +1,6 @@
 package org.scottishtecharmy.soundscape.screens.home
 
+import android.content.SharedPreferences
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -20,6 +21,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import kotlinx.coroutines.launch
+import org.scottishtecharmy.soundscape.MainActivity.Companion.RECORD_TRAVEL_DEFAULT
+import org.scottishtecharmy.soundscape.MainActivity.Companion.RECORD_TRAVEL_KEY
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.components.DrawerMenuItem
 import org.scottishtecharmy.soundscape.ui.theme.spacing
@@ -29,9 +32,12 @@ fun DrawerContent(
     drawerState: DrawerState,
     onNavigate: (String) -> Unit,
     rateSoundscape: () -> Unit,
-    shareRecording: () -> Unit
+    shareRecording: () -> Unit,
+    preferences: SharedPreferences?
 ) {
     val scope = rememberCoroutineScope()
+    val recordingEnabled = preferences?.getBoolean(RECORD_TRAVEL_KEY, RECORD_TRAVEL_DEFAULT) == true
+
     ModalDrawerSheet(
         drawerContainerColor = MaterialTheme.colorScheme.background,
         drawerContentColor = MaterialTheme.colorScheme.onBackground,
@@ -93,17 +99,20 @@ fun DrawerContent(
 //            label = stringResource(R.string.share_title),
 //            icon = Icons.Rounded.IosShare,
 //        )
-        DrawerMenuItem(
-            onClick = { shareRecording() },
-            label = "Share recorded route",
-            icon = Icons.Rounded.Share,
-        )
 
         DrawerMenuItem(
             onClick = { onNavigate(HomeRoutes.Help.route + "/page${R.string.settings_about_app}") },
             label = stringResource(R.string.settings_about_app),
             Icons.AutoMirrored.Rounded.HelpOutline,
         )
+
+        if(recordingEnabled) {
+            DrawerMenuItem(
+                onClick = { shareRecording() },
+                label = stringResource(R.string.menu_share_recorded_route),
+                icon = Icons.Rounded.Share,
+            )
+        }
     }
 }
 @Preview
@@ -113,6 +122,7 @@ fun PreviewDrawerContent() {
         DrawerState(DrawerValue.Open) { true },
         { },
         { },
-        { }
+        { },
+        null
     )
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
@@ -1,5 +1,6 @@
 package org.scottishtecharmy.soundscape.screens.home
 
+import android.content.SharedPreferences
 import android.util.Log
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.safeDrawing
@@ -72,6 +73,7 @@ data class StreetPreviewFunctions(val viewModel: HomeViewModel?) {
 @Composable
 fun HomeScreen(
     navController: NavHostController,
+    preferences: SharedPreferences,
     viewModel: HomeViewModel = hiltViewModel(),
     rateSoundscape: () -> Unit
 ) {
@@ -90,6 +92,7 @@ fun HomeScreen(
             Home(
                 state = state.value,
                 onNavigate = { dest -> navController.navigate(dest) },
+                preferences = preferences,
                 onMapLongClick = { latLong ->
                     val location = LngLatAlt(latLong.longitude, latLong.latitude)
                     val ld = viewModel.getLocationDescription(location) ?: LocationDescription("", location)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
@@ -1,5 +1,6 @@
 package org.scottishtecharmy.soundscape.screens.home.home
 
+import android.content.SharedPreferences
 import androidx.compose.animation.shrinkOut
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
@@ -50,6 +51,7 @@ import org.scottishtecharmy.soundscape.viewmodels.home.HomeState
 fun Home(
     state: HomeState,
     onNavigate: (String) -> Unit,
+    preferences: SharedPreferences?,
     onMapLongClick: (LatLng) -> Boolean,
     bottomButtonFunctions: BottomButtonFunctions,
     getCurrentLocationDescription: () -> LocationDescription,
@@ -72,7 +74,8 @@ fun Home(
                 onNavigate = onNavigate,
                 drawerState = drawerState,
                 rateSoundscape = rateSoundscape,
-                shareRecording = { (context as MainActivity).shareRecording() }
+                shareRecording = { (context as MainActivity).shareRecording() },
+                preferences = preferences
             )
         },
         modifier = modifier,
@@ -177,6 +180,7 @@ fun HomePreview() {
     Home(
         state = HomeState(),
         onNavigate = {},
+        preferences = null,
         onMapLongClick = { false },
         bottomButtonFunctions = BottomButtonFunctions(null),
         getCurrentLocationDescription = { LocationDescription("Current Location", LngLatAlt()) },
@@ -196,6 +200,7 @@ fun HomeSearchPreview() {
     Home(
         state = HomeState(),
         onNavigate = {},
+        preferences = null,
         onMapLongClick = { false },
         bottomButtonFunctions = BottomButtonFunctions(null),
         getCurrentLocationDescription = { LocationDescription("Current Location", LngLatAlt()) },
@@ -226,6 +231,7 @@ fun HomeRoutePreview() {
             currentRouteData = routePlayerState
         ),
         onNavigate = {},
+        preferences = null,
         onMapLongClick = { false },
         bottomButtonFunctions = BottomButtonFunctions(null),
         getCurrentLocationDescription = { LocationDescription("Current Location", LngLatAlt()) },

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
@@ -273,7 +273,7 @@ fun Settings(
 
             item {
                 Text(
-                    text = "Developer settings",
+                    text = stringResource(R.string.settings_debug_heading),
                     style = MaterialTheme.typography.headlineSmall,
                     color = textColor,
                     modifier = Modifier.semantics { heading() },
@@ -282,7 +282,12 @@ fun Settings(
             switchPreference(
                 key = MainActivity.RECORD_TRAVEL_KEY,
                 defaultValue = MainActivity.RECORD_TRAVEL_DEFAULT,
-                title = { Text(text = "Record travel") },
+                title = {
+                    Text(
+                        text = stringResource(R.string.settings_travel_recording),
+                        color = textColor
+                    )
+                },
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3601,6 +3601,9 @@ Alternatively, you may continue previewing the app with a predefined test locati
   <string name="settings_theme_is_light" translatable="false">"Use light theme"</string>
   <string name="settings_theme_contrast" translatable="false">"Theme contrast"</string>
   <string name="street_preview_exit" translatable="false">"Exit Street Preview"</string>
+  <string name="settings_travel_recording" translatable="false">"Enable recording of travel"</string>
+  <string name="settings_debug_heading" translatable="false">"Debug settings"</string>
+  <string name="menu_share_recorded_route" translatable="false">"Share recording of travel"</string>
 
   <string name="confect_name_to_via" translatable="false">"%s to %s via %s"</string>
   <string name="confect_name_to" translatable="false">"%s to %s"</string>

--- a/app/src/test/java/org/scottishtecharmy/soundscape/DijkstraTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/DijkstraTest.kt
@@ -91,7 +91,7 @@ class DijkstraTest {
         var shortestPath : Double
         val shortestRoute = FeatureCollection()
         val timeTaken = measureTime {
-            val results = findShortestDistance(startLocation, endLocation, startWay, endWay, shortestRoute)
+            val results = findShortestDistance(startLocation, startWay, endLocation, endWay, null, shortestRoute)
             shortestPath = results.distance
             results.tidy()
         }
@@ -124,7 +124,7 @@ class DijkstraTest {
         val shortestRoute = FeatureCollection()
         val shortestRouteAsSingleLine = FeatureCollection()
         val timeTaken = measureTime {
-            val results = findShortestDistance(startLocation, endLocation, startWay, endWay, shortestRoute)
+            val results = findShortestDistance(startLocation, startWay, endLocation, endWay, null, shortestRoute)
             shortestPath = results.distance
 
             val route = getPathWays(results.endIntersection)


### PR DESCRIPTION
If the "Enable recording of travel" setting is switched on, then each GPS location is saved to a buffer. The buffer stores up to the last hour of locations and those can be shared to another application via the "Share recording of travel" option in the menu. No location is shared otherwise, so it's purely a user decision. The aim of the shared GPX file is to aid debugging. With the option enabled, a user can share their movement if there's some behaviour that they didn't expect.