### PR TITLE
Alter directions segments so that Left/Right/Ahead/Behind are 60 degr…

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/TileUtils.kt
@@ -370,12 +370,17 @@ fun sortedByDistanceTo(
 }
 
 /**
- * This represent the original iOS COMBINED direction type which they described like this:
+ * This is based on the original iOS COMBINED direction type which they described like this:
  *
  *  Ahead, Right, Behind, and Left all get a 150 degree window centered in their respective
  *  directions (e.g. right is 15 degrees to 165 degrees). In the areas where these windows
  *  overlap, the relative directions get combined. For example, 0 degrees is "ahead", while
  *  20 degrees is "ahead to the right."
+ *
+ *  However, this gives a very small Ahead window which leads to less good intersection
+ *  descriptions, especially when all ahead/behind Left are reduced to Left. As a result, we've
+ *  biased ahead over ahead left/right so that it's 60 degrees, and the ahead/behind left/right are
+ *  only 30 degrees. This is basically shrinking the 150 degree window to 120 degrees.
 
  * @param heading
  * Direction the device is pointing in degrees
@@ -385,22 +390,22 @@ fun getCombinedDirectionSegments(
     heading: Double
 ): Array<Segment> {
     return arrayOf(
-            // 30 degree "behind" triangle
-            Segment(heading + 180.0, 30.0),
-            // 60 degree "behind left" triangle
-            Segment(heading + 225.0, 60.0),
-            // 30 degree "left" triangle
-            Segment(heading + 270.0, 30.0),
-            // 60 degree "ahead left" triangle
-            Segment(heading + 315.0, 60.0),
-            // 30 degree "ahead" triangle
-            Segment(heading, 30.0),
-            // 60 degree "ahead right" triangle
-            Segment(heading + 45, 60.0),
-            // 30 degree "right" triangle
-            Segment(heading + 90, 30.0),
-            // 60 degree "behind right" triangle
-            Segment(heading + 135, 60.0)
+            // "behind" triangle
+            Segment(heading + 180.0, 60.0),
+            // "behind left" triangle
+            Segment(heading + 225.0, 30.0),
+            // "left" triangle
+            Segment(heading + 270.0, 60.0),
+            // "ahead left" triangle
+            Segment(heading + 315.0, 30.0),
+            // "ahead" triangle
+            Segment(heading, 60.0),
+            // "ahead right" triangle
+            Segment(heading + 45, 30.0),
+            // "right" triangle
+            Segment(heading + 90, 60.0),
+            // "behind right" triangle
+            Segment(heading + 135, 30.0)
         )
 }
 

--- a/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTestMvt.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTestMvt.kt
@@ -69,7 +69,7 @@ class IntersectionsTestMvt {
         val indexLA = 0
         Assert.assertEquals(Direction.BEHIND, intersection.members[indexWR].direction(intersection, deviceHeading))
         Assert.assertEquals("Weston Road", intersection.members[indexWR].properties!!["name"])
-        Assert.assertEquals(Direction.AHEAD_LEFT, intersection.members[indexLA].direction(intersection, deviceHeading))
+        Assert.assertEquals(Direction.AHEAD, intersection.members[indexLA].direction(intersection, deviceHeading))
         Assert.assertEquals("Long Ashton Road", intersection.members[indexLA].properties!!["name"])
 
     }
@@ -427,11 +427,11 @@ class IntersectionsTestMvt {
         val indexBS = 3
         Assert.assertEquals(Direction.BEHIND, intersection.members[indexSMB].direction(intersection, deviceHeading))
         Assert.assertEquals("St Mary's Butts", intersection.members[indexSMB].properties!!["name"])
-        Assert.assertEquals(Direction.AHEAD_LEFT, intersection.members[indexOR].direction(intersection, deviceHeading))
+        Assert.assertEquals(Direction.LEFT, intersection.members[indexOR].direction(intersection, deviceHeading))
         Assert.assertEquals("Oxford Road", intersection.members[indexOR].properties!!["name"])
         Assert.assertEquals(Direction.AHEAD, intersection.members[indexWS].direction(intersection, deviceHeading))
         Assert.assertEquals("West Street", intersection.members[indexWS].properties!!["name"])
-        Assert.assertEquals(Direction.BEHIND_RIGHT, intersection.members[indexBS].direction(intersection, deviceHeading))
+        Assert.assertEquals(Direction.RIGHT, intersection.members[indexBS].direction(intersection, deviceHeading))
         Assert.assertEquals("Broad Street", intersection.members[indexBS].properties!!["name"])
 
     }

--- a/app/src/test/java/org/scottishtecharmy/soundscape/RoundaboutsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/RoundaboutsTest.kt
@@ -211,7 +211,7 @@ class RoundaboutsTest {
         Assert.assertEquals("Elm Lodge Road", roadRelativeDirections.features[0].properties!!["name"])
         Assert.assertEquals(2, roadRelativeDirections.features[1].properties!!["Direction"])
         Assert.assertEquals("Elm Lodge Road", roadRelativeDirections.features[1].properties!!["name"])
-        Assert.assertEquals(5, roadRelativeDirections.features[2].properties!!["Direction"])
+        Assert.assertEquals(4, roadRelativeDirections.features[2].properties!!["Direction"])
         Assert.assertEquals("Green Pastures Road", roadRelativeDirections.features[2].properties!!["name"])
     }
 

--- a/app/src/test/java/org/scottishtecharmy/soundscape/TileUtilsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/TileUtilsTest.kt
@@ -618,7 +618,7 @@ class TileUtilsTest {
             val iAmHere6 =
                 polygonContainsCoordinates(testBeaconBehindLeft, (feature.geometry as Polygon))
             if (iAmHere6) {
-                Assert.assertEquals(1, feature.properties!!["Direction"])
+                Assert.assertEquals(2, feature.properties!!["Direction"])
             }
         }
         // Location to test relative directions. Placed in "Left" triangle


### PR DESCRIPTION
…ees #501

The direction descriptions were previously very biased away from the 0,90,180,270 degrees with only 30 degree windows to describe as Ahead, Behind, Left or Right. This changes those windows to 60 degrees and shrinks the "Ahead Left", "Behind Left", "Ahead Right" and "Behind Right" to 30 degrees. This gives us better tolerance when describing roads as continuing ahead.