### PR TITLE
Improve name confection for un-named Ways

### DIFF
--- a/app/src/androidTest/java/org/scottishtecharmy/soundscape/MvtPerformanceTest.kt
+++ b/app/src/androidTest/java/org/scottishtecharmy/soundscape/MvtPerformanceTest.kt
@@ -124,8 +124,8 @@ class MvtPerformanceTest {
         val endLocation = LngLatAlt(-4.316699, 55.939225)
 
         // Find the nearest ways to each location
-        val startWay = roadTree.getNearestFeature(startLocation) as Way
-        val endWay = roadTree.getNearestFeature(endLocation) as Way
+        val startWay = roadTree.getNearestFeature(startLocation, gridState.ruler) as Way
+        val endWay = roadTree.getNearestFeature(endLocation, gridState.ruler) as Way
 
         Debug.startMethodTracing("Test2")
 
@@ -225,7 +225,7 @@ class MvtPerformanceTest {
         val edinburgh = BoundingBox(-3.3568399, 55.9005448, -3.0921694, 55.9919155)
         testGridCache(edinburgh, 1)
 
-        // London results in OOM - needs investigating
+        // London results simply take too long as it's a huge area
 //        val london = BoundingBox(-0.5111412, 51.3083029, 0.1582387, 51.6369422)
 //        testGridCache(london)
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -1033,7 +1033,7 @@ fun localReverseGeocode(location: LngLatAlt,
     }
 
     // Check if the location is alongside a road/path
-    val nearestRoad = gridState.getNearestFeature(TreeId.ROADS_AND_PATHS, location, 100.0) as Way?
+    val nearestRoad = gridState.getNearestFeature(TreeId.ROADS_AND_PATHS, gridState.ruler, location, 100.0) as Way?
     if(nearestRoad != null) {
         // We only want 'interesting' non-generic names i.e. no "Path" or "Service"
         val roadName = nearestRoad.getName(null, gridState, localizedContext, true)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
@@ -21,6 +21,7 @@ import org.scottishtecharmy.soundscape.geoengine.utils.TileGrid.Companion.getTil
 import org.scottishtecharmy.soundscape.geoengine.utils.getLatLonTileWithOffset
 import org.scottishtecharmy.soundscape.geoengine.utils.getPoiFeatureCollectionBySuperCategory
 import org.scottishtecharmy.soundscape.geoengine.utils.pointIsWithinBoundingBox
+import org.scottishtecharmy.soundscape.geoengine.utils.rulers.Ruler
 import org.scottishtecharmy.soundscape.geoengine.utils.traverseIntersectionsConfectingNames
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
@@ -472,11 +473,12 @@ open class GridState {
     }
 
     internal fun getNearestFeature(id: TreeId,
+                                   ruler: Ruler,
                                    location: LngLatAlt = LngLatAlt(),
                                    distance : Double = Double.POSITIVE_INFINITY
     ): Feature? {
         checkContext()
-        return featureTrees[id.id].getNearestFeature(location, distance)
+        return featureTrees[id.id].getNearestFeature(location, ruler, distance)
     }
 
     internal fun processTileFeatureCollection(tileFeatureCollection: FeatureCollection): Array<FeatureCollection> {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/StreetPreview.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/StreetPreview.kt
@@ -6,6 +6,7 @@ import org.scottishtecharmy.soundscape.geoengine.mvttranslation.Way
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.WayEnd
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.WayType
 import org.scottishtecharmy.soundscape.geoengine.utils.calculateHeadingOffset
+import org.scottishtecharmy.soundscape.geoengine.utils.rulers.CheapRuler
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 
 data class StreetPreviewChoice(
@@ -48,7 +49,7 @@ class StreetPreview {
 
             PreviewState.INITIAL -> {
                 // Jump to an intersection on the nearest road or path
-                val road : Way? = engine.gridState.getNearestFeature(TreeId.ROADS_AND_PATHS, userGeometry.location, Double.POSITIVE_INFINITY) as Way?
+                val road : Way? = engine.gridState.getNearestFeature(TreeId.ROADS_AND_PATHS, userGeometry.ruler, userGeometry.location, Double.POSITIVE_INFINITY) as Way?
                 if(road == null)
                     return null
                 var nearestDistance = Double.POSITIVE_INFINITY
@@ -161,7 +162,8 @@ class StreetPreview {
     fun getDirectionChoices(engine: GeoEngine, location: LngLatAlt): List<StreetPreviewChoice> {
         val choices = mutableListOf<StreetPreviewChoice>()
 
-        val nearestIntersection = engine.gridState.getNearestFeature(TreeId.INTERSECTIONS, location, 1.0) as Intersection?
+        val ruler = CheapRuler(location.latitude)
+        val nearestIntersection = engine.gridState.getNearestFeature(TreeId.INTERSECTIONS, ruler, location, 1.0) as Intersection?
         if(nearestIntersection != null) {
             for(member in nearestIntersection.members) {
                 choices.add(

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/IntersectionUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/IntersectionUtils.kt
@@ -63,7 +63,7 @@ fun getRoadsDescriptionFromFov(gridState: GridState,
         if (userGeometry.inStreetPreview) {
             // In StreetPreview mode, the road we're on is that matching the heading into the
             // intersection that we're at.
-            val intersection = intersectionTree.getNearestFeature(userGeometry.location) as Intersection?
+            val intersection = intersectionTree.getNearestFeature(userGeometry.location, userGeometry.ruler) as Intersection?
             val userHeading = userGeometry.heading()
             if((userHeading != null) && (intersection != null)) {
                 for (member in intersection.members) {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/FeatureTree.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/FeatureTree.kt
@@ -492,15 +492,15 @@ class FeatureTree(featureCollection: FeatureCollection?) {
      * @result Feature that is the nearest member of the rtree that is also within distance
      */
     fun getNearestFeature(location: LngLatAlt,
-                          distance: Double = Double.POSITIVE_INFINITY,
-                          ruler: Ruler? = null): Feature? {
+                          ruler: Ruler,
+                          distance: Double = Double.POSITIVE_INFINITY): Feature? {
         if(tree != null) {
             val distanceResults = Iterables.toList(
                 nearestWithinDistance(
                     Geometries.pointGeographic(location.longitude, location.latitude),
                     distance,
                     1,
-                    ruler ?: location.createCheapRuler()
+                    ruler
                 )
             )
 

--- a/app/src/test/java/org/scottishtecharmy/soundscape/BusStopTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/BusStopTest.kt
@@ -48,7 +48,7 @@ class BusStopTest {
         Assert.assertEquals(2, fovBusStopFeatureCollection.features.size)
         // we can detect the nearest bus stop and give a distance/direction but as mentioned above the OSM
         // bus stop location data for this example is rubbish so not sure how useful this is to the user?
-        val nearestBusStop = FeatureTree(fovBusStopFeatureCollection).getNearestFeature(userGeometry.location)
+        val nearestBusStop = FeatureTree(fovBusStopFeatureCollection).getNearestFeature(userGeometry.location, userGeometry.ruler)
         val busStopLocation = nearestBusStop!!.geometry as Point
         val distanceToBusStop = userGeometry.ruler.distance(userGeometry.location, busStopLocation.coordinates)
         Assert.assertEquals(9.08, distanceToBusStop, 0.1)

--- a/app/src/test/java/org/scottishtecharmy/soundscape/ComplexIntersections.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/ComplexIntersections.kt
@@ -23,7 +23,7 @@ class ComplexIntersections {
             location,
             320.0,
             50.0,
-            mapMatchedWay = gridState.getNearestFeature(TreeId.ROADS, LngLatAlt(-2.697291022799874,51.44378095087524)) as Way
+            mapMatchedWay = gridState.getNearestFeature(TreeId.ROADS, gridState.ruler, LngLatAlt(-2.697291022799874,51.44378095087524)) as Way
         )
 
         val intersection = getRoadsDescriptionFromFov(
@@ -67,7 +67,7 @@ class ComplexIntersections {
             location,
             45.0,
             50.0,
-            mapMatchedWay = gridState.getNearestFeature(TreeId.ROADS, location) as Way
+            mapMatchedWay = gridState.getNearestFeature(TreeId.ROADS, gridState.ruler, location) as Way
         )
 
         val intersection = getRoadsDescriptionFromFov(

--- a/app/src/test/java/org/scottishtecharmy/soundscape/CrossingTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/CrossingTest.kt
@@ -33,7 +33,7 @@ class CrossingTest {
             location,
             45.0,
             50.0,
-            mapMatchedWay = gridState.getFeatureTree(TreeId.ROADS).getNearestFeature(location) as Way
+            mapMatchedWay = gridState.getFeatureTree(TreeId.ROADS).getNearestFeature(location, gridState.ruler) as Way
         )
 
         // We can reuse the intersection code as crossings are GeoJSON Points just like Intersections
@@ -42,12 +42,12 @@ class CrossingTest {
         val fovCrossingFeatureCollection = crossingsTree.getAllWithinTriangle(triangle)
         Assert.assertEquals(1, fovCrossingFeatureCollection.features.size)
 
-        val nearestCrossing = FeatureTree(fovCrossingFeatureCollection).getNearestFeature(userGeometry.location)
+        val nearestCrossing = FeatureTree(fovCrossingFeatureCollection).getNearestFeature(userGeometry.location, userGeometry.ruler)
         val crossingLocation = nearestCrossing!!.geometry as Point
         val distanceToCrossing = userGeometry.ruler.distance(userGeometry.location, crossingLocation.coordinates)
 
         // Confirm which road the crossing is on
-        val nearestRoadToCrossing = roadsTree.getNearestFeature(crossingLocation.coordinates)
+        val nearestRoadToCrossing = roadsTree.getNearestFeature(crossingLocation.coordinates, userGeometry.ruler)
 
         Assert.assertEquals(24.58, distanceToCrossing, 0.2)
         Assert.assertEquals("Belmont Drive", nearestRoadToCrossing!!.properties?.get("name"))

--- a/app/src/test/java/org/scottishtecharmy/soundscape/DijkstraTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/DijkstraTest.kt
@@ -37,8 +37,8 @@ class DijkstraTest {
         val shortestRoutes = FeatureCollection()
 
         // We should already have these values in the real code, so don't time them
-        val startIntersection = intersectionsTree.getNearestFeature(startLocation) as Intersection
-        val endIntersection = intersectionsTree.getNearestFeature(endLocation) as Intersection
+        val startIntersection = intersectionsTree.getNearestFeature(startLocation, gridState.ruler) as Intersection
+        val endIntersection = intersectionsTree.getNearestFeature(endLocation, gridState.ruler) as Intersection
         var shortestPath : Double
         val timeTakenUsingNewAlgorithm = measureTime {
             /**
@@ -85,8 +85,8 @@ class DijkstraTest {
         val endLocation = LngLatAlt(-4.316699, 55.939225)
 
         // Find the nearest ways to each location
-        val startWay = roadTree.getNearestFeature(startLocation) as Way
-        val endWay = roadTree.getNearestFeature(endLocation) as Way
+        val startWay = roadTree.getNearestFeature(startLocation, gridState.ruler) as Way
+        val endWay = roadTree.getNearestFeature(endLocation, gridState.ruler) as Way
 
         var shortestPath : Double
         val shortestRoute = FeatureCollection()
@@ -117,8 +117,8 @@ class DijkstraTest {
         val endLocation = LngLatAlt(-4.316699, 55.939225)
 
         // Find the nearest ways to each location
-        val startWay = roadTree.getNearestFeature(startLocation) as Way
-        val endWay = roadTree.getNearestFeature(endLocation) as Way
+        val startWay = roadTree.getNearestFeature(startLocation, gridState.ruler) as Way
+        val endWay = roadTree.getNearestFeature(endLocation, gridState.ruler) as Way
 
         var shortestPath : Double
         val shortestRoute = FeatureCollection()

--- a/app/src/test/java/org/scottishtecharmy/soundscape/TileUtilsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/TileUtilsTest.kt
@@ -466,7 +466,7 @@ class TileUtilsTest {
         // This should pick up four road segments in the FoV
         Assert.assertEquals(4, fovRoadsFeatureCollection.features.size)
         val nearestRoad = gridState.getFeatureTree(TreeId.ROADS_AND_PATHS)
-            .getNearestFeature(userGeometry.location)
+            .getNearestFeature(userGeometry.location, userGeometry.ruler)
         // Should only be the nearest road in this Feature Collection
         assert(nearestRoad != null)
         // The nearest road to the current location should be Weston Road

--- a/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckIntersectionLayers.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/VisuallyCheckIntersectionLayers.kt
@@ -59,7 +59,7 @@ class VisuallyCheckIntersectionLayers {
             fovIntersectionsFeatureCollection
         )
         // Get the nearest Road in the FoV
-        val testNearestRoad = gridState.getFeatureTree(TreeId.ROADS_AND_PATHS).getNearestFeature(userGeometry.location)
+        val testNearestRoad = gridState.getFeatureTree(TreeId.ROADS_AND_PATHS).getNearestFeature(userGeometry.location, userGeometry.ruler)
 
         val intersectionsNeedsFurtherCheckingFC = FeatureCollection()
         for (i in 0 until intersectionsSortedByDistance.features.size) {
@@ -106,7 +106,7 @@ class VisuallyCheckIntersectionLayers {
         val nearestCrossing = FeatureTree(fovCrossingsFeatureCollection).getNearestFeatureWithinTriangle(triangle, userGeometry.ruler)
         // Confirm which road the crossing is on
         val crossingLocation = nearestCrossing!!.geometry as Point
-        val nearestRoadToCrossing = gridState.getFeatureTree(TreeId.ROADS_AND_PATHS).getNearestFeature(crossingLocation.coordinates)
+        val nearestRoadToCrossing = gridState.getFeatureTree(TreeId.ROADS_AND_PATHS).getNearestFeature(crossingLocation.coordinates, userGeometry.ruler)
         // *** End of Crossing
 
         // Road with nearest crossing


### PR DESCRIPTION
The previous code had a few drawbacks which this change fixes:

* Ways weren't followed to their ends, so when they cross a bridge, go
down steps or cross a tile boundary the name confection was happening at
that point instead of at the furthest known extent. The code now uses
FollowWays to get a better start and end location for confecting the names.

* Ways that cross into polygons such as parks weren't being well described
because both ends were being marked as in the park. The code now takes more
care when a Way starts and ends in/out of a Polygon to ensure that the
later feature tree searches don't end up masking that fact. It can also use
features that are within large polygons such as parks, so that paths within
parks can be named as "to cafe" etc.

* The POI used to confect were only Landmarks, but now it's landmarks and
places which makes more sense e.g. service to "Kwik Fit"

* Entrances are added as high priority POI. It's relatively few buildings
that have their entrances mapped, but it's useful to use them in name
confection as they have much more precision than large POI polygons like
supermarkets etc.

One side issue was ensuring that rulers were passed into FeatureTree for
searching which resulted in a lot of API changes in unit tests.