### PR TITLE
Fix distanceToLineString in CheapRuler to avoid lint warnings

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/rulers/CheapRuler.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/rulers/CheapRuler.kt
@@ -320,10 +320,9 @@ class CheapRuler(val lat: Double) : Ruler() {
             }
         }
 
-        val nearestPoint = cheapInterpolate(line.coordinates[minI], line.coordinates[minI+1], max(0.0, min(1.0, minT)))
         return PointAndDistanceAndHeading(
-            nearestPoint,
-            this.distance(p, nearestPoint),
+            LngLatAlt(minX, minY),
+            sqrt(minDist),
             bearingFromTwoPoints(line.coordinates[minI], line.coordinates[minI + 1]),
             minI,
             minI.toDouble() + max(0.0, min(1.0, minT))


### PR DESCRIPTION
distanceToLineString wasn't using values it had already saved which was throwing up a lint warning. Fixing it should make the code even more efficient.