### PR TITLE
Add setting to switch to alternate map styling

### DIFF
--- a/app/src/main/assets/osm-liberty-accessible/originalStyle.json
+++ b/app/src/main/assets/osm-liberty-accessible/originalStyle.json
@@ -18,7 +18,7 @@
     {
       "id": "background",
       "type": "background",
-      "paint": {"background-color": "rgba(255, 255, 255, 1)"}
+      "paint": {"background-color": "rgb(239,239,239)"}
     },
     {
       "id": "park",
@@ -26,9 +26,9 @@
       "source": "openmaptiles",
       "source-layer": "park",
       "paint": {
-        "fill-color": "rgba(102, 247, 77, 1)",
+        "fill-color": "#d8e8c8",
         "fill-opacity": 0.7,
-        "fill-outline-color": "rgba(19, 170, 19, 1)"
+        "fill-outline-color": "rgba(95, 208, 100, 1)"
       }
     },
     {
@@ -52,8 +52,8 @@
         "fill-color": {
           "base": 1,
           "stops": [
-            [9, "rgba(242, 238, 238, 0.84)"],
-            [12, "rgba(255, 4, 175, 1)"]
+            [9, "hsla(0, 3%, 85%, 0.84)"],
+            [12, "hsla(35, 57%, 88%, 0.49)"]
           ]
         }
       }
@@ -66,7 +66,7 @@
       "filter": ["all", ["==", "class", "wood"]],
       "paint": {
         "fill-antialias": false,
-        "fill-color": "rgba(96, 255, 96, 0.7)",
+        "fill-color": "hsla(98, 61%, 72%, 0.7)",
         "fill-opacity": 0.4
       }
     },
@@ -78,7 +78,7 @@
       "filter": ["all", ["==", "class", "grass"]],
       "paint": {
         "fill-antialias": false,
-        "fill-color": "rgba(43, 255, 4, 1)",
+        "fill-color": "rgba(176, 213, 154, 1)",
         "fill-opacity": 0.3
       }
     },
@@ -146,7 +146,7 @@
       "source": "openmaptiles",
       "source-layer": "landuse",
       "filter": ["==", "class", "school"],
-      "paint": {"fill-color": "rgba(247, 247, 194, 1)"}
+      "paint": {"fill-color": "rgb(236,238,204)"}
     },
     {
       "id": "waterway_tunnel",
@@ -170,7 +170,7 @@
       "filter": ["all", ["==", "class", "river"], ["!=", "brunnel", "tunnel"]],
       "layout": {"line-cap": "round"},
       "paint": {
-        "line-color": "rgba(5, 127, 248, 1)",
+        "line-color": "#a0c8f0",
         "line-width": {"base": 1.2, "stops": [[11, 0.5], [20, 6]]}
       }
     },
@@ -182,7 +182,7 @@
       "filter": ["all", ["!=", "class", "river"], ["!=", "brunnel", "tunnel"]],
       "layout": {"line-cap": "round"},
       "paint": {
-        "line-color": "rgba(6, 128, 250, 1)",
+        "line-color": "#a0c8f0",
         "line-width": {"base": 1.3, "stops": [[13, 0.5], [20, 6]]}
       }
     },
@@ -192,7 +192,7 @@
       "source": "openmaptiles",
       "source-layer": "water",
       "filter": ["all", ["!=", "brunnel", "tunnel"]],
-      "paint": {"fill-color": "rgba(116, 148, 244, 1)"}
+      "paint": {"fill-color": "rgb(158,189,255)"}
     },
     {
       "id": "landcover_sand",
@@ -384,7 +384,7 @@
         ["in", "class", "path", "pedestrian"]
       ],
       "paint": {
-        "line-color": "rgba(0, 0, 0, 1)",
+        "line-color": "hsl(0, 0%, 100%)",
         "line-dasharray": [1, 0.75],
         "line-width": {"base": 1.2, "stops": [[14, 0.5], [20, 10]]}
       }
@@ -596,7 +596,7 @@
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-color": "rgba(0, 0, 0, 1)",
+        "line-color": "#cfcdca",
         "line-width": {"base": 1.2, "stops": [[15, 1], [16, 4], [20, 11]]}
       }
     },
@@ -635,11 +635,11 @@
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-color": "rgba(0, 0, 0, 1)",
+        "line-color": "#cfcdca",
         "line-opacity": {"stops": [[12, 0], [12.5, 1]]},
         "line-width": {
-          "stops": [[12, 0.5], [13, 1], [14, 4], [20, 20]],
-          "base": 0.8
+          "base": 1.2,
+          "stops": [[12, 0.5], [13, 1], [14, 4], [20, 20]]
         }
       }
     },
@@ -672,10 +672,10 @@
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "rgba(0, 0, 0, 1)",
+        "line-color": "#e9ac77",
         "line-width": {
-          "stops": [[5, 0.4], [6, 0.7], [7, 1.2], [20, 20]],
-          "base": 1
+          "base": 1.2,
+          "stops": [[5, 0.4], [6, 0.7], [7, 1.75], [20, 22]]
         }
       }
     },
@@ -693,10 +693,10 @@
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-color": "rgba(11, 11, 11, 1)",
+        "line-color": "#e9ac77",
         "line-width": {
           "base": 1.2,
-          "stops": [[5, 0.4], [6, 0.7], [7, 1.75], [20, 48]]
+          "stops": [[5, 0.4], [6, 0.7], [7, 1.75], [20, 22]]
         }
       }
     },
@@ -714,7 +714,7 @@
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "rgba(11, 11, 11, 1)",
+        "line-color": "hsl(0, 0%, 100%)",
         "line-dasharray": [1, 0.7],
         "line-width": {"base": 1.2, "stops": [[14, 1], [20, 10]]}
       }
@@ -752,7 +752,7 @@
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-color": "rgba(0, 0, 0, 1)",
+        "line-color": "#fff",
         "line-width": {"base": 1.2, "stops": [[15.5, 0], [16, 2], [20, 7.5]]}
       }
     },
@@ -806,7 +806,7 @@
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-color": "rgba(255, 213, 36, 1)",
+        "line-color": "#fea",
         "line-width": {"base": 1.2, "stops": [[6.5, 0], [8, 0.5], [20, 13]]}
       }
     },
@@ -822,8 +822,8 @@
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "rgba(250, 209, 42, 1)",
-        "line-width": {"base": 1, "stops": [[5, 0], [7, 1], [20, 18]]}
+        "line-color": "#fea",
+        "line-width": {"base": 1.2, "stops": [[5, 0], [7, 1], [20, 18]]}
       }
     },
     {
@@ -842,9 +842,9 @@
       "paint": {
         "line-color": {
           "base": 1,
-          "stops": [[5, "rgba(242, 126, 38, 1)"], [6, "rgba(250, 166, 46, 1)"]]
+          "stops": [[5, "hsl(26, 87%, 62%)"], [6, "#fc8"]]
         },
-        "line-width": {"base": 1.2, "stops": [[5, 0], [7, 1], [20, 40]]}
+        "line-width": {"base": 1.2, "stops": [[5, 0], [7, 1], [20, 18]]}
       }
     },
     {
@@ -1014,7 +1014,7 @@
         ["in", "class", "path", "pedestrian"]
       ],
       "paint": {
-        "line-color": "rgba(255, 255, 255, 1)",
+        "line-color": "hsl(35, 6%, 80%)",
         "line-dasharray": [1, 0],
         "line-width": {"base": 1.2, "stops": [[14, 1.5], [20, 18]]}
       }
@@ -1086,7 +1086,7 @@
         ["in", "class", "path", "pedestrian"]
       ],
       "paint": {
-        "line-color": "rgba(5, 5, 5, 1)",
+        "line-color": "hsl(0, 0%, 100%)",
         "line-dasharray": [1, 0.3],
         "line-width": {"base": 1.2, "stops": [[14, 0.5], [20, 10]]}
       }
@@ -1265,12 +1265,11 @@
       "minzoom": 13,
       "maxzoom": 14,
       "paint": {
-        "fill-color": "rgba(253, 139, 139,1)",
+        "fill-color": "hsl(35, 8%, 85%)",
         "fill-outline-color": {
           "base": 1,
           "stops": [[13, "hsla(35, 6%, 79%, 0.32)"], [14, "hsl(35, 6%, 79%)"]]
-        },
-        "fill-opacity": 0.3
+        }
       }
     },
     {
@@ -1280,7 +1279,7 @@
       "source-layer": "building",
       "minzoom": 14,
       "paint": {
-        "fill-extrusion-color": "rgba(253, 139, 139, 1)",
+        "fill-extrusion-color": "hsl(35, 8%, 85%)",
         "fill-extrusion-height": {
           "property": "render_height",
           "type": "identity"
@@ -1289,7 +1288,7 @@
           "property": "render_min_height",
           "type": "identity"
         },
-        "fill-extrusion-opacity": 0.3
+        "fill-extrusion-opacity": 0.8
       }
     },
     {
@@ -1342,15 +1341,15 @@
       "filter": ["all", ["==", "$type", "LineString"]],
       "layout": {
         "text-field": "{name}",
-        "text-font": ["Roboto Bold"],
+        "text-font": ["Roboto Regular"],
         "text-max-width": 5,
-        "text-size": {"stops": [[13, 10], [20, 40]], "base": 1},
+        "text-size": 12,
         "symbol-placement": "line"
       },
       "paint": {
-        "text-color": "rgba(249, 249, 249, 1)",
+        "text-color": "#5d60be",
         "text-halo-color": "rgba(255,255,255,0.7)",
-        "text-halo-width": 0
+        "text-halo-width": 1
       }
     },
     {
@@ -1361,14 +1360,13 @@
       "filter": ["==", "$type", "Point"],
       "layout": {
         "text-field": "{name}",
-        "text-font": ["Roboto Bold"],
+        "text-font": ["Roboto Regular"],
         "text-max-width": 5,
-        "text-size": {"stops": [[13, 10], [20, 40]], "base": 1}
+        "text-size": 12
       },
       "paint": {
-        "text-color": "rgba(253, 253, 255, 1)",
+        "text-color": "#5d60be",
         "text-halo-color": "rgba(255,255,255,0.7)",
-        "text-halo-blur": 0,
         "text-halo-width": 1
       }
     },
@@ -1389,14 +1387,13 @@
         ],
         "text-anchor": "top",
         "text-field": "{name}",
-        "text-font": ["Roboto Condensed Bold Italic"],
+        "text-font": ["Roboto Condensed Italic"],
         "text-max-width": 9,
         "text-offset": [0, 0.6],
-        "text-size": 18,
-        "icon-size": 1
+        "text-size": 12
       },
       "paint": {
-        "text-color": "rgba(0, 0, 0, 1)",
+        "text-color": "#666",
         "text-halo-blur": 0.5,
         "text-halo-color": "#ffffff",
         "text-halo-width": 1
@@ -1424,14 +1421,13 @@
         ],
         "text-anchor": "top",
         "text-field": "{name}",
-        "text-font": ["Roboto Condensed Bold Italic"],
+        "text-font": ["Roboto Condensed Italic"],
         "text-max-width": 9,
         "text-offset": [0, 0.6],
-        "text-size": 18,
-        "icon-size": 1.4
+        "text-size": 12
       },
       "paint": {
-        "text-color": "rgba(0, 0, 0, 1)",
+        "text-color": "#666",
         "text-halo-blur": 0.5,
         "text-halo-color": "#ffffff",
         "text-halo-width": 1
@@ -1459,14 +1455,13 @@
         ],
         "text-anchor": "top",
         "text-field": "{name}",
-        "text-font": ["Roboto Condensed Bold Italic"],
+        "text-font": ["Roboto Condensed Italic"],
         "text-max-width": 9,
         "text-offset": [0, 0.6],
-        "text-size": {"stops": [[14, 14], [18, 30]]},
-        "icon-size": 1
+        "text-size": 12
       },
       "paint": {
-        "text-color": "rgba(0, 0, 0, 1)",
+        "text-color": "#666",
         "text-halo-blur": 0.5,
         "text-halo-color": "#ffffff",
         "text-halo-width": 1
@@ -1482,18 +1477,16 @@
         "icon-image": "{class}",
         "text-anchor": "left",
         "text-field": "{name_en}",
-        "text-font": ["Roboto Condensed Bold Italic"],
+        "text-font": ["Roboto Condensed Italic"],
         "text-max-width": 9,
         "text-offset": [0.9, 0],
-        "text-size": 16
+        "text-size": 12
       },
       "paint": {
-        "text-color": "rgba(37, 129, 242, 1)",
+        "text-color": "#4898ff",
+        "text-halo-blur": 0.5,
         "text-halo-color": "#ffffff",
-        "text-halo-width": 2,
-        "icon-halo-width": 2,
-        "icon-halo-color": "rgba(158, 49, 49, 1)",
-        "text-halo-blur": 1
+        "text-halo-width": 1
       }
     },
     {
@@ -1506,16 +1499,14 @@
         "symbol-placement": "line",
         "text-anchor": "center",
         "text-field": "{name}",
-        "text-font": ["Roboto Bold"],
-        "text-size": {"stops": [[13, 10], [20, 40]], "base": 1},
-        "text-line-height": 1,
-        "text-offset": [0, 0]
+        "text-font": ["Roboto Regular"],
+        "text-offset": [0, 0.15],
+        "text-size": {"base": 1, "stops": [[13, 12], [14, 13]]}
       },
       "paint": {
-        "text-color": "rgba(0, 0, 0, 1)",
-        "text-halo-width": 4,
-        "text-halo-color": "rgba(255, 255, 255, 1)",
-        "text-halo-blur": 2
+        "text-color": "#765",
+        "text-halo-blur": 0.5,
+        "text-halo-width": 1
       }
     },
     {
@@ -1531,11 +1522,11 @@
         "symbol-placement": {"base": 1, "stops": [[10, "point"], [11, "line"]]},
         "symbol-spacing": 500,
         "text-field": "{ref}",
-        "text-font": ["Roboto Bold"],
+        "text-font": ["Roboto Regular"],
         "text-offset": [0, 0.1],
         "text-rotation-alignment": "viewport",
-        "text-size": 12,
-        "icon-size": 1.0
+        "text-size": 10,
+        "icon-size": 0.8
       }
     },
     {
@@ -1558,14 +1549,14 @@
       ],
       "layout": {
         "text-field": "{name_en}",
-        "text-font": ["Roboto Condensed Bold Italic"],
+        "text-font": ["Roboto Condensed Italic"],
         "text-letter-spacing": 0.1,
         "text-max-width": 9,
         "text-size": {"base": 1.2, "stops": [[12, 10], [15, 14]]},
         "text-transform": "uppercase"
       },
       "paint": {
-        "text-color": "rgba(0, 0, 0, 1)",
+        "text-color": "#633",
         "text-halo-color": "rgba(255,255,255,0.8)",
         "text-halo-width": 1.2
       }
@@ -1578,7 +1569,7 @@
       "filter": ["all", ["==", "class", "village"]],
       "layout": {
         "text-field": "{name_en}",
-        "text-font": ["Roboto Bold"],
+        "text-font": ["Roboto Regular"],
         "text-max-width": 8,
         "text-size": {"base": 1.2, "stops": [[10, 12], [15, 22]]}
       },
@@ -1598,10 +1589,10 @@
         "icon-image": {"base": 1, "stops": [[0, "dot_9"], [8, ""]]},
         "text-anchor": "bottom",
         "text-field": "{name_en}",
-        "text-font": ["Roboto Bold"],
+        "text-font": ["Roboto Regular"],
         "text-max-width": 8,
         "text-offset": [0, 0],
-        "text-size": {"base": 1.2, "stops": [[7, 12], [11, 25]]}
+        "text-size": {"base": 1.2, "stops": [[7, 12], [11, 16]]}
       },
       "paint": {
         "text-color": "#333",
@@ -1620,7 +1611,7 @@
         "icon-image": {"base": 1, "stops": [[0, "dot_9"], [8, ""]]},
         "text-anchor": "bottom",
         "text-field": "{name_en}",
-        "text-font": ["Roboto Bold"],
+        "text-font": ["Roboto Medium"],
         "text-max-width": 8,
         "text-offset": [0, 0],
         "text-size": {"base": 1.2, "stops": [[7, 14], [11, 24]]},

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -1012,23 +1012,15 @@ fun localReverseGeocode(location: LngLatAlt,
     if(!gridState.isLocationWithinGrid(location)) return null
 
     // Check if we're inside a POI
-    val gridPoiCollection = gridState.getFeatureCollection(TreeId.POIS, location, 200.0)
-    val gridPoiFeatureCollection = removeDuplicateOsmIds(gridPoiCollection)
-    for(poi in gridPoiFeatureCollection) {
-        // We can only be inside polygons
-        if(poi.geometry.type == "Polygon") {
-            val polygon = poi.geometry as Polygon
-
-            if(polygonContainsCoordinates(location, polygon)) {
-                // We've found a POI that contains the location. We could return the c
-                val name = poi.properties?.get("name")
-                if(name != null) {
-                    return LocationDescription(
-                        name = localizedContext?.getString(R.string.directions_at_poi)?.format(name as String) ?: "At $name",
-                        location = location,
-                    )
-                }
-            }
+    val gridPoiTree = gridState.getFeatureTree(TreeId.POIS)
+    val insidePois = gridPoiTree.getContainingPolygons(location)
+    for(poi in insidePois) {
+        val name = poi.properties?.get("name")
+        if(name != null) {
+            return LocationDescription(
+                name = localizedContext?.getString(R.string.directions_at_poi)?.format(name as String) ?: "At $name",
+                location = location,
+            )
         }
     }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
@@ -191,7 +191,7 @@ fun LocationDetails(
                     modifier =
                     modifier
                         .fillMaxWidth()
-                        .aspectRatio(1.7f)
+                        .aspectRatio(1.0f)
                 )
             }
         }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
@@ -292,6 +292,16 @@ fun Settings(
                     )
                 },
             )
+            switchPreference(
+                key = MainActivity.ACCESSIBLE_MAP_KEY,
+                defaultValue = MainActivity.ACCESSIBLE_MAP_DEFAULT,
+                title = {
+                    Text(
+                        text = stringResource(R.string.settings_accessible_map),
+                        color = textColor
+                    )
+                },
+            )
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1421,6 +1421,9 @@
   <!-- Settings option for enabling recording of travel locations -->
   <string name="settings_travel_recording" tools:ignore="MissingTranslation">"Enable recording of travel"</string>
 
+  <!-- Settings option for enabling a map styling which has improved accessibility -->
+  <string name="settings_accessible_map" tools:ignore="MissingTranslation">"Enable accessible map styling"</string>
+
   <!-- Settings title for various debugging options to aid developers -->
   <string name="settings_debug_heading" tools:ignore="MissingTranslation">"Debug settings"</string>
 


### PR DESCRIPTION
The OSM Liberty map styling is excellent, but lacks contrast. This is the start of customizing it with the aim of better supporting visually impaired users. The map is enabled via the Settings "Enable accessible map styling". With that option enabled, the styling will switch based on the light/dark theme with higher contrast and larger text labels. More work is required before we turn this on as the default.