### PR TITLE
Add busway and bus_guideway to our GUI map styling

### DIFF
--- a/app/src/main/assets/osm-liberty-accessible/originalStyle.json
+++ b/app/src/main/assets/osm-liberty-accessible/originalStyle.json
@@ -324,7 +324,7 @@
       "filter": [
         "all",
         ["==", "brunnel", "tunnel"],
-        ["in", "class", "secondary", "tertiary"]
+        ["in", "class", "secondary", "tertiary", "busway", "bus_guideway"]
       ],
       "layout": {"line-join": "round"},
       "paint": {
@@ -460,7 +460,7 @@
       "filter": [
         "all",
         ["==", "brunnel", "tunnel"],
-        ["in", "class", "secondary", "tertiary"]
+        ["in", "class", "secondary", "tertiary", "busway", "bus_guideway"]
       ],
       "layout": {"line-join": "round"},
       "paint": {
@@ -651,7 +651,7 @@
       "filter": [
         "all",
         ["!in", "brunnel", "bridge", "tunnel"],
-        ["in", "class", "secondary", "tertiary"],
+        ["in", "class", "secondary", "tertiary", "busway", "bus_guideway"],
         ["!=", "ramp", 1]
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
@@ -802,7 +802,7 @@
       "filter": [
         "all",
         ["!in", "brunnel", "bridge", "tunnel"],
-        ["in", "class", "secondary", "tertiary"]
+        ["in", "class", "secondary", "tertiary", "busway", "bus_guideway"]
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
@@ -1027,7 +1027,7 @@
       "filter": [
         "all",
         ["==", "brunnel", "bridge"],
-        ["in", "class", "secondary", "tertiary"]
+        ["in", "class", "secondary", "tertiary", "busway", "bus_guideway"]
       ],
       "layout": {"line-join": "round"},
       "paint": {
@@ -1162,7 +1162,7 @@
       "filter": [
         "all",
         ["==", "brunnel", "bridge"],
-        ["in", "class", "secondary", "tertiary"]
+        ["in", "class", "secondary", "tertiary", "busway", "bus_guideway"]
       ],
       "layout": {"line-join": "round"},
       "paint": {

--- a/app/src/main/assets/osm-liberty-accessible/style.json
+++ b/app/src/main/assets/osm-liberty-accessible/style.json
@@ -324,7 +324,7 @@
       "filter": [
         "all",
         ["==", "brunnel", "tunnel"],
-        ["in", "class", "secondary", "tertiary"]
+        ["in", "class", "secondary", "tertiary", "busway", "bus_guideway"]
       ],
       "layout": {"line-join": "round"},
       "paint": {
@@ -460,7 +460,7 @@
       "filter": [
         "all",
         ["==", "brunnel", "tunnel"],
-        ["in", "class", "secondary", "tertiary"]
+        ["in", "class", "secondary", "tertiary", "busway", "bus_guideway"]
       ],
       "layout": {"line-join": "round"},
       "paint": {
@@ -651,7 +651,7 @@
       "filter": [
         "all",
         ["!in", "brunnel", "bridge", "tunnel"],
-        ["in", "class", "secondary", "tertiary"],
+        ["in", "class", "secondary", "tertiary", "busway", "bus_guideway"],
         ["!=", "ramp", 1]
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
@@ -802,7 +802,7 @@
       "filter": [
         "all",
         ["!in", "brunnel", "bridge", "tunnel"],
-        ["in", "class", "secondary", "tertiary"]
+        ["in", "class", "secondary", "tertiary", "busway", "bus_guideway"]
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
@@ -1027,7 +1027,7 @@
       "filter": [
         "all",
         ["==", "brunnel", "bridge"],
-        ["in", "class", "secondary", "tertiary"]
+        ["in", "class", "secondary", "tertiary", "busway", "bus_guideway"]
       ],
       "layout": {"line-join": "round"},
       "paint": {
@@ -1162,7 +1162,7 @@
       "filter": [
         "all",
         ["==", "brunnel", "bridge"],
-        ["in", "class", "secondary", "tertiary"]
+        ["in", "class", "secondary", "tertiary", "busway", "bus_guideway"]
       ],
       "layout": {"line-join": "round"},
       "paint": {


### PR DESCRIPTION
With these in place, the fastlink busway along the Clyde and the Cambridge guided busway are both rendered correctly on the map. This addresses #530.