### PR TITLE
Fix up route and marker editing so that it works correctly

### DIFF
--- a/app/src/androidTest/java/org/scottishtecharmy/soundscape/GpxTest.kt
+++ b/app/src/androidTest/java/org/scottishtecharmy/soundscape/GpxTest.kt
@@ -10,7 +10,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.scottishtecharmy.soundscape.database.local.MarkersAndRoutesDatabase
 import org.scottishtecharmy.soundscape.database.local.model.MarkerEntity
-import org.scottishtecharmy.soundscape.database.local.model.RouteWithMarkers
 import org.scottishtecharmy.soundscape.utils.parseGpxFile
 
 // The GPX parsing code requires various pieces of Android infrastructure, so
@@ -247,6 +246,10 @@ class GpxTest {
     @Test
     fun soundscapeDuplicateDatabase() {
         val expectedValues = expectedSoundscapeValues()
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val roomDb = MarkersAndRoutesDatabase.getMarkersInstance(context)
+        roomDb.clearAllTables()
+
         val id1 = testParsing("gpx/soundscape.gpx", expectedValues, "Soundscape", "Soundscape description")
         val id2 = testParsing("gpx/soundscape.gpx", expectedValues, "Soundscape", "Soundscape description", "Soundscape2")
         testDatabase(id2, expectedValues)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -257,6 +257,8 @@ class MainActivity : AppCompatActivity() {
                     if(destination != "") {
                         if (navController.currentDestination?.route != destination) {
                             navController.navigate(destination)
+                            // Reset the destination state ready for another
+                            navigator.destination.value = ""
                         }
                     }
                 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/database/local/model/MarkerData.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/database/local/model/MarkerData.kt
@@ -2,11 +2,15 @@ package org.scottishtecharmy.soundscape.database.local.model
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import kotlin.jvm.javaClass
 
-@Entity(tableName = "markers")
+@Entity(
+    tableName = "markers",
+    indices = [Index("latitude", "longitude", name = "location_index")]
+)
 class MarkerEntity(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "marker_id")

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/data/LocationDescription.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/data/LocationDescription.kt
@@ -6,5 +6,6 @@ data class LocationDescription(
     var name: String = "",
     var location: LngLatAlt,
     var description: String? = null,
+    var orderId: Long = 0L,
     var databaseId: Long = 0
 )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/AddAndEditRouteScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/AddAndEditRouteScreen.kt
@@ -180,8 +180,16 @@ fun AddAndEditRouteScreen(
     val context = LocalContext.current
     var addWaypointDialog by remember { mutableStateOf(false) }
     var routeMembers by remember(uiState.routeMembers) {
-        mutableStateOf(uiState.routeMembers.toList())
+        val members = uiState.routeMembers.toList()
+        for((index, marker) in members.withIndex()) {
+            marker.orderId = index.toLong()
+        }
+        mutableStateOf(members)
     }
+    val editableRouteList = remember(routeMembers) {
+        routeMembers.toMutableList()
+    }
+
     val lazyListState = rememberLazyListState()
     val location by remember(userLocation) {mutableStateOf(userLocation)}
     val reorderableLazyListState = rememberReorderableLazyListState(lazyListState) { from, to ->
@@ -229,7 +237,13 @@ fun AddAndEditRouteScreen(
         AddWaypointsDialog(
             uiState = uiState,
             placesNearbyUiState = placesNearbyUiState,
+            routeList = editableRouteList,
             onAddWaypointComplete = {
+                // Update indices
+                for((index, marker) in editableRouteList.withIndex()) {
+                    marker.orderId = index.toLong()
+                }
+                routeMembers = editableRouteList
                 addWaypointDialog = false
             },
             onClickFolder = onClickFolder,
@@ -257,6 +271,7 @@ fun AddAndEditRouteScreen(
                     onNavigateUp = { navController.popBackStack() },
                     navigationButtonTitle = stringResource(R.string.general_alert_cancel),
                     onRightButton = {
+                        // Update the route
                         uiState.routeMembers = routeMembers
                         onEditComplete()
                     },
@@ -355,8 +370,8 @@ fun AddAndEditRouteScreen(
                                 state = lazyListState,
                                 verticalArrangement = Arrangement.spacedBy(spacing.tiny),
                             ) {
-                                itemsIndexed(routeMembers, key = { _,item -> item.databaseId.toString() }) { index, item ->
-                                    ReorderableItem(reorderableLazyListState, item.databaseId.toString()) { _ ->
+                                itemsIndexed(routeMembers, key = { _,item -> item.orderId.toString() }) { index, item ->
+                                    ReorderableItem(reorderableLazyListState, item.orderId.toString()) { _ ->
                                         Row(modifier = Modifier
                                             .background(MaterialTheme.colorScheme.surface)
                                         ) {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/AddWaypointsDialog.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/AddWaypointsDialog.kt
@@ -25,6 +25,7 @@ import org.scottishtecharmy.soundscape.ui.theme.extraSmallPadding
 fun AddWaypointsDialog(
     uiState: AddAndEditRouteUiState,
     placesNearbyUiState: PlacesNearbyUiState,
+    routeList: MutableList<LocationDescription>,
     modifier: Modifier,
     onAddWaypointComplete: () -> Unit,
     onClickFolder: (String, String) -> Unit,
@@ -58,7 +59,10 @@ fun AddWaypointsDialog(
                 title = stringResource(R.string.route_detail_edit_waypoints_button),
                 onNavigateUp = { onClickBack() },
                 navigationButtonTitle = stringResource(R.string.ui_back_button_title),
-                onRightButton = onAddWaypointComplete,
+                onRightButton = {
+                    // Update the list of waypoints in the route
+                    onAddWaypointComplete()
+                },
                 rightButtonTitle = stringResource(R.string.general_alert_done)
             )
 
@@ -68,6 +72,7 @@ fun AddWaypointsDialog(
             AddWaypointsList(
                 uiState = uiState,
                 placesNearbyUiState = placesNearbyUiState,
+                routeList = routeList,
                 onClickFolder = onClickFolder,
                 onSelectLocation = { location ->
                     saveMarkerDialog.value = true
@@ -112,6 +117,7 @@ fun AddWaypointsScreenPopulatedPreview() {
                 )
             ),
         placesNearbyUiState = PlacesNearbyUiState(),
+        routeList = emptyList<LocationDescription>().toMutableList(),
         onClickFolder = {_,_ -> },
         onClickBack = {},
         onSelectLocation = {_ -> },
@@ -128,6 +134,7 @@ fun AddWaypointsScreenPreview() {
         uiState = AddAndEditRouteUiState(),
         userLocation = null,
         placesNearbyUiState = PlacesNearbyUiState(),
+        routeList = emptyList<LocationDescription>().toMutableList(),
         onClickFolder = {_,_ -> },
         onClickBack = {},
         onSelectLocation = {_ -> },

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/AddWaypointsList.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/AddWaypointsList.kt
@@ -40,6 +40,7 @@ import org.scottishtecharmy.soundscape.screens.home.placesnearby.PlacesNearbyUiS
 fun AddWaypointsList(
     uiState: AddAndEditRouteUiState,
     placesNearbyUiState: PlacesNearbyUiState,
+    routeList: MutableList<LocationDescription>,
     onClickFolder: (String, String) -> Unit,
     userLocation: LngLatAlt?,
     onSelectLocation: (LocationDescription) -> Unit
@@ -48,9 +49,9 @@ fun AddWaypointsList(
     val locations = remember(uiState) {
         mutableStateListOf<LocationDescription>()
             .apply {
-                addAll(uiState.routeMembers)
+                addAll(routeList)
                 addAll(uiState.markers.filter { marker ->
-                    uiState.routeMembers.none { routeMember ->
+                    routeList.none { routeMember ->
                         routeMember.databaseId == marker.databaseId
                     }
                 }
@@ -62,7 +63,7 @@ fun AddWaypointsList(
         mutableStateMapOf<LocationDescription, Boolean>()
             .apply {
                 uiState.markers.associateWith { false }.also { putAll(it) }
-                uiState.routeMembers.associateWith { true }.also { putAll(it) }
+                routeList.associateWith { true }.also { putAll(it) }
             }
     }
 
@@ -173,12 +174,10 @@ fun AddWaypointsList(
                             enabled = true,
                             functionBoolean = {
                                 routeMember[locationDescription] = it
-                                val updatedList = uiState.routeMembers.toMutableList()
                                 if (it)
-                                    updatedList.add(locationDescription)
+                                    routeList.add(locationDescription)
                                 else
-                                    updatedList.remove(locationDescription)
-                                uiState.routeMembers = updatedList
+                                    routeList.remove(locationDescription)
                             },
                             value = routeMember[locationDescription] == true,
                             hintWhenOn = stringResource(R.string.location_detail_add_waypoint_existing_hint),

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
@@ -138,7 +138,7 @@ fun createMarker(
                 latitude = locationDescription.location.latitude
             )
             try {
-                routeDao.insertMarker(markerData)
+                routeDao.updateMarker(markerData)
                 onSuccess()
                 updated = true
             } catch (e: Exception) {


### PR DESCRIPTION
Several things going on here:

1. The orderId is now used as the unique identifier for re-ordering routes. This means that in theory we could have the same marker in a route twice which might be useful. The main reason for the change is that until markers have been added to the database they don't have a database id.

2. Route editing was getting confused as it was changing the uiState underneath the add waypoint list. I couldn't reproduce issues prior to the Room DB changes, but the problem isn't new.

3. Using intents to add routes wasn't working more than once. Resetting the navigator destination resolves this.

4. Disallow creating a duplicate marker at the same location when importing from a GPX file. This should make it easier to import a load of routes that share markers.