### PR TITLE
Add option for writing resources in Markdown and move copyright notices to use it

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -282,4 +282,7 @@ dependencies {
     ksp(libs.androidx.room.compiler)
 
     implementation(libs.symbol.processing.api)
+
+    // Markdown to HTML converter for Help screens
+    implementation(libs.commonmark)
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HelpScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HelpScreen.kt
@@ -31,13 +31,15 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import org.commonmark.node.Node
+import org.commonmark.parser.Parser
+import org.commonmark.renderer.html.HtmlRenderer
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.screens.home.HomeRoutes
 import org.scottishtecharmy.soundscape.screens.markers_routes.components.CustomAppBar
 import org.scottishtecharmy.soundscape.ui.theme.mediumPadding
 import org.scottishtecharmy.soundscape.ui.theme.spacing
-import kotlin.text.split
-import kotlin.text.startsWith
+
 
 enum class SectionType{
     Title,          // A non-clickable title of a group of other text
@@ -49,6 +51,7 @@ data class Section(
     val textId: Int,                      // There's always text, this is the resource id for it
     val type: SectionType,
     val skipTalkback: Boolean = false,
+    val markdown: Boolean = false,
     val faqAnswer: Int = -1             // The resource id of the answer to a FAQ question
 )
 data class Sections(
@@ -305,25 +308,25 @@ val helpPages = listOf(
     Sections(
         R.string.settings_about_app,
         listOf(
-            Section(R.string.about_soundscape, SectionType.Paragraph, skipTalkback = false),
-            Section(R.string.copyright_notices, SectionType.Paragraph, skipTalkback = true),
-            Section(R.string.osm_copyright, SectionType.Paragraph, skipTalkback = true),
-            Section(R.string.openmaptiles_copyright, SectionType.Paragraph, skipTalkback = true),
-            Section(R.string.fmod_copyright, SectionType.Paragraph, skipTalkback = true),
-            Section(R.string.maplibre_copyright, SectionType.Paragraph, skipTalkback = true),
-            Section(R.string.junit_copyright, SectionType.Paragraph, skipTalkback = true),
+            Section(R.string.about_soundscape, SectionType.Paragraph, skipTalkback = false, markdown = true),
+            Section(R.string.copyright_notices, SectionType.Paragraph, skipTalkback = true, markdown = true),
+            Section(R.string.osm_copyright, SectionType.Paragraph, skipTalkback = true, markdown = true),
+            Section(R.string.openmaptiles_copyright, SectionType.Paragraph, skipTalkback = true, markdown = true),
+            Section(R.string.fmod_copyright, SectionType.Paragraph, skipTalkback = true, markdown = true),
+            Section(R.string.maplibre_copyright, SectionType.Paragraph, skipTalkback = true, markdown = true),
+            Section(R.string.junit_copyright, SectionType.Paragraph, skipTalkback = true, markdown = true),
 
             Section(R.string.apache_notices, SectionType.Title, skipTalkback = true),
-            Section(R.string.rtree_copyright, SectionType.Paragraph, skipTalkback = true),
-            Section(R.string.realm_copyright, SectionType.Paragraph, skipTalkback = true),
-            Section(R.string.moshi_copyright, SectionType.Paragraph, skipTalkback = true),
-            Section(R.string.retrofit_copyright, SectionType.Paragraph, skipTalkback = true),
-            Section(R.string.okhttp_copyright, SectionType.Paragraph, skipTalkback = true),
-            Section(R.string.otto_copyright, SectionType.Paragraph, skipTalkback = true),
-            Section(R.string.leak_canary_copyright, SectionType.Paragraph, skipTalkback = true),
-            Section(R.string.gpx_parser_copyright, SectionType.Paragraph, skipTalkback = true),
-            Section(R.string.preferences_copyright, SectionType.Paragraph, skipTalkback = true),
-            Section(R.string.dokka_mermaid_copyright, SectionType.Paragraph, skipTalkback = true),
+            Section(R.string.rtree_copyright, SectionType.Paragraph, skipTalkback = true, markdown = true),
+            Section(R.string.realm_copyright, SectionType.Paragraph, skipTalkback = true, markdown = true),
+            Section(R.string.moshi_copyright, SectionType.Paragraph, skipTalkback = true, markdown = true),
+            Section(R.string.retrofit_copyright, SectionType.Paragraph, skipTalkback = true, markdown = true),
+            Section(R.string.okhttp_copyright, SectionType.Paragraph, skipTalkback = true, markdown = true),
+            Section(R.string.otto_copyright, SectionType.Paragraph, skipTalkback = true, markdown = true),
+            Section(R.string.leak_canary_copyright, SectionType.Paragraph, skipTalkback = true, markdown = true),
+            Section(R.string.gpx_parser_copyright, SectionType.Paragraph, skipTalkback = true, markdown = true),
+            Section(R.string.preferences_copyright, SectionType.Paragraph, skipTalkback = true, markdown = true),
+            Section(R.string.dokka_mermaid_copyright, SectionType.Paragraph, skipTalkback = true, markdown = true),
         )
     )
 )
@@ -395,7 +398,7 @@ fun HelpScreen(
                                         .padding(top = spacing.medium)
                                         .semantics {
                                             heading()
-                                            if(section.skipTalkback)
+                                            if (section.skipTalkback)
                                                 hideFromAccessibility()
                                         },
                                     color = MaterialTheme.colorScheme.onSurface,
@@ -403,9 +406,16 @@ fun HelpScreen(
                             }
 
                             SectionType.Paragraph -> {
+                                var htmlText = stringResource(section.textId)
+                                if(section.markdown) {
+                                    val parser: Parser = Parser.builder().build()
+                                    val document: Node? = parser.parse(htmlText)
+                                    val renderer = HtmlRenderer.builder().build()
+                                    htmlText = renderer.render(document)
+                                }
                                 Text(
                                     text = AnnotatedString.fromHtml(
-                                        stringResource(section.textId),
+                                        htmlString = htmlText,
                                         linkStyles = TextLinkStyles(
                                             style = SpanStyle(
                                                 textDecoration = TextDecoration.Underline,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1072,23 +1072,23 @@
   <string name="about_soundscape" tools:ignore="MissingTranslation">Soundscape explores the use of innovative audio-based technology to enable people to build a richer awareness of their surroundings, thus becoming more confident and empowered to get around.</string>
     <!-- Licensing strings -->
   <string name="copyright_notices" translatable="false">Soundscape wouldn\'t be possible without these fantastic third party libraries and data. Click on the links to see their licenses:</string>
-    <string name="osm_copyright" translatable="false">&lt;a href="https://www.openstreetmap.org/copyright"&gt;©OpenStreetMap contributors&lt;/a&gt; provide all of the geo data for mapping and audio used in Soundscape.</string>
-    <string name="openmaptiles_copyright" translatable="false">&lt;a href="https://github.com/openmaptiles/openmaptiles/blob/master/LICENSE.md"&gt;©OpenMapTiles&lt;/a&gt; is used to generate the mapping tiles that we use.</string>
-    <string name="fmod_copyright" translatable="false">&lt;a href="https://www.fmod.com/legal"&gt;Audio Engine: FMOD Studio by Firelight Technologies Pty Ltd.&lt;/a&gt; takes care of the audio playback.</string>
+    <string name="osm_copyright" translatable="false">[©OpenStreetMap contributors](https://www.openstreetmap.org/copyright) provide all of the geo data for mapping and audio used in Soundscape.</string>
+    <string name="openmaptiles_copyright" translatable="false">[©OpenMapTiles](https://github.com/openmaptiles/openmaptiles/blob/master/LICENSE.md) is used to generate the mapping tiles that we use.</string>
+    <string name="fmod_copyright" translatable="false">[Audio Engine: FMOD Studio by Firelight Technologies Pty Ltd.](https://www.fmod.com/legal) takes care of the audio playback.</string>
     <!-- BSD 2-clause -->
-  <string name="maplibre_copyright" translatable="false">&lt;a href="https://github.com/maplibre/maplibre-native/blob/main/LICENSE.md"&gt;©MapLibre&lt;/a&gt; performs the map rendering for the UI.</string>
+  <string name="maplibre_copyright" translatable="false">[©MapLibre](https://github.com/maplibre/maplibre-native/blob/main/LICENSE.md) performs the map rendering for the UI.</string>
     <!-- Eclipse -->
-  <string name="junit_copyright" translatable="false">&lt;a href="https://github.com/junit-team/junit4/blob/main/LICENSE-junit.txt"&gt;junit-team/junit4&lt;/a&gt; for unit testing.</string>
+  <string name="junit_copyright" translatable="false">[junit-team/junit4](https://github.com/junit-team/junit4/blob/main/LICENSE-junit.txt) for unit testing.</string>
     <!-- Apache 2.0 -->
   <string name="apache_notices" translatable="false">The remainder of the licenses are all Apache 2.0:</string>
-    <string name="rtree_copyright" translatable="false">&lt;a href="https://github.com/davidmoten/rtree2/blob/master/LICENCE"&gt;rtree2&lt;/a&gt; makes our local geo-search much more efficient.</string>
-    <string name="realm_copyright" translatable="false">&lt;a href="https://github.com/realm/realm-kotlin/blob/main/LICENSE"&gt;Realm&lt;/a&gt; takes care of our database.</string>
-    <string name="moshi_copyright" translatable="false">&lt;a href="https://github.com/square/moshi/blob/master/LICENSE.txt"&gt;square/moshi&lt;/a&gt; for GeoJSON parsing.</string>
-    <string name="retrofit_copyright" translatable="false">&lt;a href="https://github.com/square/retrofit/blob/trunk/LICENSE.txt"&gt;square/retrofit&lt;/a&gt; HTTP client abstraction.</string>
-    <string name="okhttp_copyright" translatable="false">&lt;a href="https://github.com/square/okhttp/blob/master/LICENSE.txt"&gt;square/okhttp&lt;/a&gt; underlying HTTP client.</string>
-    <string name="otto_copyright" translatable="false">&lt;a href="https://github.com/square/otto/blob/master/LICENSE.txt"&gt;square/otto&lt;/a&gt; to provide an event bus.</string>
-    <string name="leak_canary_copyright" translatable="false">&lt;a href="https://github.com/square/leakcanary/blob/main/LICENSE.txt"&gt;square/leakcanary&lt;/a&gt; for adding mermaid diagrams to Dokka documentation.</string>
-    <string name="gpx_parser_copyright" translatable="false">&lt;a href="https://github.com/ticofab/android-gpx-parser/blob/master/LICENSE"&gt;ticofab/android-gpx-parser&lt;/a&gt; for GPX parsing.</string>
-    <string name="preferences_copyright" translatable="false">&lt;a href="https://github.com/zhanghai/ComposePreference/blob/master/LICENSE"&gt;zhanghai/ComposePreference&lt;/a&gt; for a simple settings UI.</string>
-    <string name="dokka_mermaid_copyright" translatable="false">&lt;a href="https://github.com/glureau/dokka-mermaid/blob/main/LICENSE"&gt;glureau/dokka-mermaid&lt;/a&gt; for adding mermaid diagrams to Dokka documentation.</string>
+    <string name="rtree_copyright" translatable="false">[rtree2](https://github.com/davidmoten/rtree2/blob/master/LICENCE) makes our local geo-search much more efficient.</string>
+    <string name="realm_copyright" translatable="false">[Realm](https://github.com/realm/realm-kotlin/blob/main/LICENSE) takes care of our database.</string>
+    <string name="moshi_copyright" translatable="false">[square/moshi](https://github.com/square/moshi/blob/master/LICENSE.txt) for GeoJSON parsing.</string>
+    <string name="retrofit_copyright" translatable="false">[square/retrofit](https://github.com/square/retrofit/blob/trunk/LICENSE.txt) HTTP client abstraction.</string>
+    <string name="okhttp_copyright" translatable="false">[square/okhttp](https://github.com/square/okhttp/blob/master/LICENSE.txt) underlying HTTP client.</string>
+    <string name="otto_copyright" translatable="false">[square/otto](https://github.com/square/otto/blob/master/LICENSE.txt) to provide an event bus.</string>
+    <string name="leak_canary_copyright" translatable="false">[square/leakcanary](https://github.com/square/leakcanary/blob/main/LICENSE.txt) for adding mermaid diagrams to Dokka documentation.</string>
+    <string name="gpx_parser_copyright" translatable="false">[ticofab/android-gpx-parser](github.com/ticofab/android-gpx-parser/blob/master/LICENSE) for GPX parsing.</string>
+    <string name="preferences_copyright" translatable="false">[zhanghai/ComposePreference](https://github.com/zhanghai/ComposePreference/blob/master/LICENSE) for a simple settings UI.</string>
+    <string name="dokka_mermaid_copyright" translatable="false">[glureau/dokka-mermaid](https://github.com/glureau/dokka-mermaid/blob/main/LICENSE) for adding mermaid diagrams to Dokka documentation.</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.11.0"
+commonmark = "0.25.0"
 kotlin = "2.2.0"
 protobuf-plugin = "0.9.5"
 dagger-hilt = "2.56.2"
@@ -82,6 +83,7 @@ androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRunt
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntime" }
 androidx-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "uiautomator" }
+commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }
 converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "converterMoshi" }
 converter-protobuf = { module = "com.squareup.retrofit2:converter-protobuf", version.ref = "converterProtobuf" }
 converter-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "converterScalars" }


### PR DESCRIPTION
The original iOS resources were all in HTML, but we want to use the same resources for both in app help and website help where Markdown is used. Markdown is much easier to write and so we'll slowly switch all of our resources to use that.