### PR TITLE
Close foreground service when app is swiped away

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,6 +99,7 @@
 
         <service
             android:name=".services.SoundscapeService"
+            android:stopWithTask="true"
             android:enabled="true"
             android:exported="true"
             android:foregroundServiceType="location|mediaPlayback"


### PR DESCRIPTION
This means that closing the app will now stop all of the audio. This is actually what the iOS app does, it's just we didn't have an iPhone to use when we first started work on this!