### PR TITLE
Lock MainActivity to portrait mode for now

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:screenOrientation="userPortrait"
             android:launchMode="singleTask"
             android:theme="@style/SplashTheme.Soundscape">
 


### PR DESCRIPTION
Until we fix all of the GUI to work in landscape, lock the orientation to portrait. This will be ignored in API 36, but perhaps we'll have fixed the GUI by then.