### PR TITLE
Drive audio focus abandonment from C++ AudioEngine

### DIFF
--- a/app/src/main/cpp/AudioBeacon.h
+++ b/app/src/main/cpp/AudioBeacon.h
@@ -23,6 +23,7 @@ namespace soundscape {
         void PlayNow();
         void Mute(bool mute);
 
+        AudioEngine *m_pEngine;
     protected:
         void Init(double degrees_off_axis);
         void InitFmodSound();
@@ -37,7 +38,6 @@ namespace soundscape {
         FMOD::System *m_pSystem = nullptr;
         FMOD::Sound *m_pSound = nullptr;
         FMOD::Channel *m_pChannel = nullptr;
-        AudioEngine *m_pEngine;
         bool m_Dimmable = false;
     };
 

--- a/app/src/main/cpp/AudioEngine.h
+++ b/app/src/main/cpp/AudioEngine.h
@@ -4,6 +4,7 @@
 #include <list>
 #include <thread>
 #include <mutex>
+#include <jni.h>
 #include "fmod.hpp"
 #include "fmod.h"
 #include "BeaconDescriptor.h"
@@ -83,6 +84,11 @@ namespace soundscape {
         bool ToggleBeaconMute();
 
         void Eof(long long id);
+        void BeaconDestroyed();
+
+        // Method to be called from Kotlin to set up the callback
+        void SetBeaconEventsListener(JNIEnv *env, jobject listener_obj);
+        void ClearBeaconEventsListener(JNIEnv *env); // To release the global ref
 
         const static BeaconDescriptor msc_BeaconDescriptors[];
 
@@ -119,6 +125,14 @@ namespace soundscape {
         std::list<PositionedAudio *> m_QueuedBeacons;
 
         bool m_BeaconMute = false;
+
+        // For JNI callbacks
+        JavaVM *m_pJvm = nullptr;
+        jobject m_jBeaconListener = nullptr;
+        jmethodID m_jMethodId_onAllBeaconsCleared = nullptr;
+
+        // Helper to notify Kotlin
+        void NotifyAllBeaconsCleared(int line);
     };
 
 } // soundscape

--- a/app/src/main/java/org/scottishtecharmy/soundscape/audio/AudioEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/audio/AudioEngine.kt
@@ -21,4 +21,5 @@ interface AudioEngine {
     fun setSpeechLanguage(language : String) : Boolean
     fun updateSpeech(sharedPreferences: SharedPreferences): Boolean
     fun updateBeaconType(sharedPreferences: SharedPreferences): Boolean
+    fun onAllBeaconsCleared()
 }


### PR DESCRIPTION
Instead of trying to figure out whether audio is playing from the service, add a callback from the AudioEngine to tell us when no more audio is playing. When called we can abandon the audio focus knowing that there's nothing playing.
The callback is called:

1. When the size of the audio beacons list goes down to zero during UpdateGeometry. This happens when text to speech audio ends.
2. When a beacon is destroyed via a call to destroyNativeBeacon. This happens when an audio beacon is stopped from the app.