### PR TITLE
Tidyup audio engines used in onboarding screens

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -25,3 +25,8 @@
 # Fix SimpleRouteData GSON generation and parsing
 -keep class org.scottishtecharmy.soundscape.screens.markers_routes.screens.addandeditroutescreen.*  { *; }
 -keep class com.google.gson.internal.LinkedTreeMap  { *; }
+
+# Ensure that we can callback from the AudioEngine
+-keep class org.scottishtecharmy.soundscape.audio.NativeAudioEngine {
+    public void onAllBeaconsCleared();
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/audiobeacons/AudioBeaconsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/audiobeacons/AudioBeaconsViewModel.kt
@@ -25,6 +25,11 @@ class AudioBeaconsViewModel @Inject constructor(@param:ApplicationContext val co
     )
     private var beacon : Long = 0
 
+    override fun onCleared() {
+        super.onCleared()
+        audioEngine.destroy()
+    }
+
     private val _state: MutableStateFlow<AudioBeaconsUiState> = MutableStateFlow(
         AudioBeaconsUiState(
             beaconTypes = audioEngine.getListOfBeaconTypes().toList(),

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/hearing/HearingViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/hearing/HearingViewModel.kt
@@ -9,6 +9,11 @@ import javax.inject.Inject
 @HiltViewModel
 class HearingViewModel @Inject constructor(private val audioEngine : NativeAudioEngine): ViewModel() {
 
+    override fun onCleared() {
+        super.onCleared()
+        audioEngine.destroy()
+    }
+
     fun playSpeech(speechText: String) {
         // Set our listener position, and play the speech
         // TODO: If updateGeometry isn't called, then the audioEngine doesn't move on to   the next

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/language/LanguageViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/language/LanguageViewModel.kt
@@ -29,6 +29,11 @@ class LanguageViewModel @Inject constructor(private val audioEngine : NativeAudi
         var selectedLanguageIndex: Int = -1
     )
 
+    override fun onCleared() {
+        super.onCleared()
+        audioEngine.destroy()
+    }
+
     private fun addIfSpeechSupports(allLanguages: MutableList<Language>, language: Language) {
         // TODO: The idea here is to add the language only if it's supported by the text to speech
         //  engine. However, the audioEngine appears to be struggling to initialize the TextToSpeech.


### PR DESCRIPTION
This is important as we have to uninstall the audio focus callback. Also change the proguard rules to prevent our callback function from being obfusctated or removed.