### PR TITLE
Fix memory leak from TextToSpeech setOnUtteranceProgressListener

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/audio/NativeAudioEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/audio/NativeAudioEngine.kt
@@ -81,6 +81,7 @@ class NativeAudioEngine @Inject constructor(val service: SoundscapeService? = nu
             }
             ttsSockets.clear()
 
+            textToSpeech.setOnUtteranceProgressListener(null)
             textToSpeech.shutdown()
             org.fmod.FMOD.close()
         }


### PR DESCRIPTION
I think this leak must have been around for a little while, but LeakCanary only started reporting it recently. A simple fix, remove the callback before destroying the TextToSpeech engine.