### PR TITLE
Remove Talkback descriptions from lists in Settings

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
@@ -90,13 +90,14 @@ fun ListPreferenceItem(description: String,
                 if (value == currentValue) stringResource(R.string.settings_keep_value)
                 else stringResource(R.string.settings_use_value)
             )
-            .talkbackDescription(
-                stringResource(R.string.settings_list_item_description).format(
-                    value,
-                    index + 1,
-                    listSize
-                )
-            ),
+//            .talkbackDescription(
+//                stringResource(R.string.settings_list_item_description).format(
+//                    value,
+//                    index + 1,
+//                    listSize
+//                )
+//            )
+            ,
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {


### PR DESCRIPTION
These were too noisey and didn't really add anything. The default behaviour is much better.