### PR TITLE
More crashlytics logging aimed and changes aimed at foreground start

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -28,6 +28,8 @@ import androidx.preference.PreferenceManager
 import com.google.android.play.core.review.ReviewException
 import com.google.android.play.core.review.ReviewManagerFactory
 import com.google.android.play.core.review.model.ReviewErrorCode
+import com.google.firebase.Firebase
+import com.google.firebase.crashlytics.crashlytics
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -181,6 +183,13 @@ class MainActivity : AppCompatActivity() {
             when(locationPermissionGranted) {
                 0 -> setServiceState(false)
                 1 -> setServiceState(true)
+            }
+        } else {
+            if(soundscapeServiceConnection.soundscapeService?.running == false) {
+                // This can happen if the service failed to move to the foreground.
+                // Simply start the service now
+                Firebase.crashlytics.log("Attempt to start non-running service from onResume")
+                setServiceState(true)
             }
         }
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/audio/TtsEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/audio/TtsEngine.kt
@@ -14,6 +14,7 @@ import android.util.Log
 import androidx.preference.PreferenceManager
 import com.google.firebase.Firebase
 import com.google.firebase.analytics.analytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import org.scottishtecharmy.soundscape.MainActivity
 import org.scottishtecharmy.soundscape.utils.getCurrentLocale
 import java.util.Collections
@@ -86,7 +87,10 @@ class TtsEngine(val audioEngine: NativeAudioEngine,
                 putString("engine", engineLabelAndName)
                 putString("voice", textToSpeechVoiceType)
             }
+            // Log an event so that we can get statistics
             Firebase.analytics.logEvent("TTSEngine", bundle)
+            // And set a custom key so that any crashes we get we know which TTS engine is in use
+            FirebaseCrashlytics.getInstance().setCustomKey("TTSEngine", "$engineLabelAndName - $textToSpeechVoiceType")
             TextToSpeech(context, this, engineLabelAndName.substringAfter(":::"))
         }
     }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -7,11 +7,23 @@ has_toc: false
 
 # Release notes
 
-# 0.0.110
+# 0.0.114
 We keep track of issues in GitHub [here](https://github.com/Scottish-Tech-Army/Soundscape-Android/milestones).
-Issues tagged _user-facing_ are those which describe issues from a user perspective. 
 
-## New since 0.0.96
+## New changes since 0.0.110
+* *Current Location* now appears as an option in the *Add Waypoint* screen
+* Improvements have been made to deal with cases where permissions (location and notifications) have been revoked.
+* Initial Persian language support has been added and various additions to other languages.
+* The *Search* feature was broken for many languages, it is now fixed. There's also a new *Settings* option to force *Search* results to use English. A use case for this would be a Spanish speaker travelling in Japan. Instead of getting results in the local Japanese language it may be easier to have the English results e.g. Tokyo instead of 東京都.
+* Street Preview calls out a single POI after each jump
+* Marker callouts now use a field-of-view to prevent calling out markers which have been passed
+* Distance to beacons is now adaptive for long journeys. The frequency of the callouts increases as the beacon gets closer.
+* GPS location filtering had been broken and so although the map matching to the current street worked well, beacons were unstable. The filtering has been re-instated and the beacons behaviour is back to what it should be.
+* *Save Marker* screen wasn't reflecting the user direction
+* A long term issue where the graphical map wasn't updating beacons and routes immediately has been fixed.
+* More analytics added to track text to speech engine usage and startup errors.
+
+## Changes between 0.0.96 and 0.0.110
 * A new option in settings to select miles and feet instead of kilometers and meters.
 * Improved light and dark themes and defaulting to use the system setting.
 * Improved handling of locations shared from Google Maps especially those of places with names containing non-ASCII characters.
@@ -33,6 +45,8 @@ Issues tagged _user-facing_ are those which describe issues from a user perspect
 
 ### Longer term known issues
 The largest issues which are being worked on are:
+* [Offline mapping](https://github.com/Scottish-Tech-Army/Soundscape-Android/issues/236) has been tested as a proof of concept but still requires a lot of work.
+* [Route playback](https://github.com/Scottish-Tech-Army/Soundscape-Android/issues/667) has various imperfections which are being worked on.
 * [Improving mapping data](https://github.com/Scottish-Tech-Army/Soundscape-Android/issues/605) to try and improve both search, the graphical maps and the contents of Places Nearby.
 * [Callouts for roundabouts need work](https://github.com/Scottish-Tech-Army/Soundscape-Android/issues/442). We have a plan for this, but it's not yet implemented.
 * [Support for Street Preview is very preliminary](https://github.com/Scottish-Tech-Army/Soundscape-Android/issues/528), especially when it comes to use by people with a visual impairment.

--- a/docs/testing/test-instructions.md
+++ b/docs/testing/test-instructions.md
@@ -5,42 +5,32 @@ parent: Testing
 has_toc: false
 ---
 
-# How to easily test the Soundscape app
-These instructions are aimed at an initial test of the Soundscape Android app with the following 
-aims:
-
-1. Check that it runs on a wide variety of phones
-1. Have a larger number of users running it to spot things that we have missed
-1. Test the audio callouts in different geographical locations
-
+# Testing the Soundscape app
 The app is a port of the Soundscape iOS app and the UI is designed to be pretty much the same.
 Whilst we're interested in improving the UI in the long term, matching the iOS behaviour is the 
 most important goal for this initial release.
 
+Unless you are an STA member and can ping us on Slack, all feedback should go via the Help Desk by emailing <soundscapeAndroid@scottishtecharmy.support>.
+
 ## Requirements
-The app currently requires Android 11 (API 30 - see [https://apilevels.com/](https://apilevels.com/)). We are hoping to drop this to Android 9 with some more work, but for now we only support Android 11 and later.
+The app currently requires Android 11 (API 30 - see <https://apilevels.com/>). We are hoping to drop this to Android 9 with some more work, but for now we only support Android 11 and later.
 We don't know of any other requirements, but that's one of the thing this testing should help us understand.
 
 ## Installing the app
-The app is freely available on play store [here](https://play.google.com/store/apps/details?id=org.scottishtecharmy.soundscape).
+The app is freely available on the Play Store [here](https://play.google.com/store/apps/details?id=org.scottishtecharmy.soundscape).
 
 ## Running the app the first time
 The first time you run the Soundscape app you will see a series of onboarding screens which let 
-you select various initial settings. US and UK English are currently the only languages fully 
-supported by the app, though unless you are visually impaired all of the other languages should 
-work well (we have some new [Talkback](https://support.google.
-com/accessibility/android/answer/6283677?hl=en-GB) strings which are yet to be translated).
+you select various initial settings. English is US English and is the base for all translations. If a string is missing in the language being used then it will be replaced by the English string instead. We already know about these, but all other language issues are of interest e.g. text that is difficult to understand or where there's a problem with the ordering of phrases.
 
 Things we're interested in on the initial screens:
 
 * Is there any text on the screens that you are unable to read or where words are split across 
   lines?
-* Do you just hear silence when you click the **Listen** button on the **Hear Your 
-  Surroundings** page?
-* Do you only hear silence when selecting the different beacon sounds on the **Choose an Audio 
-  Beacon** page?
+* Do you just hear silence when you click the **Listen** button on the **Hear Your Surroundings** page?
+* Do you only hear silence when selecting the different beacon sounds on the **Choose an Audio Beacon** page?
 
-Please report any of these issues on the Slack channel.
+Please report any of these issues via the Help Desk.
 
 ## Main app operation
 Now that you're past the onboarding screens, you shouldn't see them again and you should be on 
@@ -57,55 +47,35 @@ Things that should happen on the Home screen and we're interested if they do not
 
 * The map should show your current location with a red triangle. (There should be a map!)
 * The red triangle on the map should rotate as you point the phone in different directions.
-* Speech describing your surroundings should be heard when you click on each of the 4 buttons at 
-  the bottom of the screen.
+* Speech describing your surroundings should be heard when you click on each of the 4 buttons at the bottom of the screen.
 
-If you've got to this point and it all seems to be working, then you can move on to more 
-detailed testing.
+If you've got to this point and it all seems to be working, then you can move on to more detailed testing.
 
 ### Test 1 - Go for a walk
-As you move around, Soundscape should periodically describe your location and call out any 
-points of interest that you pass e.g. Shops, Bus Stops etc. We're interested if there's anything 
-that doesn't sound right. The app will consume a little bit of data as it downloads maps as you 
-move around, but in general those are fairly small (< 50kb for a 600m square bit of map). The 
-map tiles are cached so they will generally only be downloaded once.
+As you move around, Soundscape should periodically describe your location and call out any points of interest that you pass e.g. Shops, Bus Stops etc. We're interested if there's anything that doesn't sound right. The app will consume a little bit of data as it downloads maps as you move around, but in general those are fairly small (< 50kb for a 600m square bit of map). The map tiles are cached so they will generally only be downloaded once.
 
 ### Test 2 - Create a route and play it back
 This uses a bit more of the UI, but once set up it should be fairly straightforward.
 #### Create some Markers
 Markers are points on the map which can be added together to make a route. Markers can be saved from
 the Location Details screen, but there are many ways to get to that.
-1. A long tap on the map on the home screen, or the map on the _Current Location_ screen will bring 
-   up a Location Details page for that location.
-1. The _Current Location_ button on the main screen brings up the Location Details for the 
-   current location. The map there is scrollable and you can zoom in and out. It's possible to 
-   save markers, move to a new point, long tap and save another marker.
-1. The _Places Nearby_ button on the home screen shows nearby points that can be clicked on for 
-   Location Details.
+1. A long tap on the map on the home screen, or the map on the _Current Location_ screen will bring up a Location Details page for that location.
+1. The _Current Location_ button on the main screen brings up the Location Details for the  current location. The map there is scrollable and you can zoom in and out. It's possible to save markers, move to a new point, long tap and save another marker.
+1. The _Places Nearby_ button on the home screen shows nearby points that can be clicked on for Location Details.
 1. The search bar will bring up results which can be clicked on for Location Details.
 
-Once saved, Markers appear in the screen that can be navigated from the _Markers and Routes_ 
-button on the home screen. Once you have a number of Markers, you can create a route.
+Once saved, Markers appear in the screen that can be navigated from the _Markers and Routes_ button on the home screen. Once you have a number of Markers, you can create a route.
 
 #### Create a route
-1. With the _Routes_ tab of the _Markers and Routes_ screen selected, click on the + icon in the 
-   top right. 
+1. With the _Routes_ tab of the _Markers and Routes_ screen selected, click on the + icon in the top right. 
 1. Type in a name for your route, and an optional description.
-1. Click _Add Waypoints_ and add the Markers you've created. Select the markers in the order 
-   that you want them to appear in the route and then click _Done_.
+1. Click _Add Waypoints_ and add the Markers you've created. Select the markers in the order that you want them to appear in the route and then click _Done_.
 1. Click _Done_ again to save the route.
 
-There should now be a route listed. Click on that and you can check that it's what you think it 
-should be.
+There should now be a route listed. Click on that and you can check that it's what you think it should be.
 
 #### Play the route
-Click _Start Route_ on the _Route Details_ screen to start an audio beacon playing at the first 
-waypoint of the route. The audio beacon will sound from the direction of the waypoint from where 
-you are. When you're using the Soundscape app and your phone is unlocked, the direction used is 
-the direction that the phone is pointing in. You can lock your phone and put it in your bag and 
-then it will start using the direction in which your walking. The sound of the beacon will be
-different if you are walking towards it or away from it. If you stop moving and your phone is 
-locked then any beacon will go quieter to indicate that there's no available direction data.
+Click _Start Route_ on the _Route Details_ screen to start an audio beacon playing at the first waypoint of the route. The audio beacon will sound from the direction of the waypoint from where you are. When you're using the Soundscape app and your phone is unlocked, the direction used is the direction that the phone is pointing in. You can lock your phone and put it in your bag and then it will start using the direction in which your walking. The sound of the beacon will be different if you are walking towards it or away from it. If you stop moving and your phone is locked then any beacon will go quieter to indicate that there's no available direction data.
 
 ## Providing debug location trace
 The app can store up to an hour buffer of the user location recorded whilst the app is running. This feature is disabled by default, and even when enabled the data stays on the phone unless the user chooses to share it via interaction with the app. To use the feature:


### PR DESCRIPTION
If startForeground fails we now start the geoEngine anyway. And then in the next onResume we try startForeground again. There's also some debug code to make it 'fail' the first time to check the error paths. If there's no onResume within 10 seconds then the app will still shutdown, but not due to a crash. I think that's as good as we can do for now. The Crashlytics logging should allow us to check that any failures are a due to this behaviour.