### PR TITLE
Fix beacon type settings selection

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
@@ -133,7 +133,9 @@ fun Settings(
     selectedLanguageIndex: Int,
 )
 {
-    val beaconTypes = uiState.beaconTypes.map { stringResource(it) }
+    val beaconValues = uiState.beaconValues
+    val beaconDescriptions = uiState.beaconDescriptions.map { stringResource(it) }
+
     val backgroundColor = MaterialTheme.colorScheme.background
     val textColor = MaterialTheme.colorScheme.onBackground
     val themeContrastDescriptions = listOf(
@@ -343,7 +345,7 @@ fun Settings(
             listPreference(
                 key = MainActivity.BEACON_TYPE_KEY,
                 defaultValue = MainActivity.BEACON_TYPE_DEFAULT,
-                values = beaconTypes,
+                values = beaconValues,
                 title = {
                     Text(
                         text = stringResource(R.string.beacon_settings_style),
@@ -351,7 +353,7 @@ fun Settings(
                     )
                 },
                 item = { value, currentValue, onClick ->
-                    ListPreferenceItem(value, value, currentValue, onClick, beaconTypes.indexOf(value), beaconTypes.size)
+                    ListPreferenceItem(beaconDescriptions[beaconValues.indexOf(value)], value, currentValue, onClick, beaconValues.indexOf(value), beaconValues.size)
                 },
                 summary = { Text(text = it, color = textColor) },
             )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/SettingsViewModel.kt
@@ -23,7 +23,8 @@ class SettingsViewModel @Inject constructor(
 ) : ViewModel() {
     data class SettingsUiState(
         // Data for the ViewMode that affects the UI
-        var beaconTypes : List<Int> = emptyList(),
+        var beaconDescriptions : List<Int> = emptyList(),
+        var beaconValues : List<String> = emptyList(),
         var engineTypes : List<String> = emptyList(),
         var voiceTypes : List<String> = emptyList()
     )
@@ -78,11 +79,14 @@ class SettingsViewModel @Inject constructor(
 
                                 val audioEngineBeaconTypes = audioEngine.getListOfBeaconTypes()
                                 val beaconTypes = mutableListOf<Int>()
+                                val beaconValues = mutableListOf<String>()
                                 for (type in audioEngineBeaconTypes) {
                                     beaconTypes.add(getBeaconResourceId(type))
+                                    beaconValues.add(type)
                                 }
                                 _state.value = SettingsUiState(
-                                    beaconTypes = beaconTypes,
+                                    beaconDescriptions = beaconTypes,
+                                    beaconValues = beaconValues,
                                     voiceTypes = voiceTypes,
                                     engineTypes = audioEngineTypes.map { engine -> "${engine.label}:::${engine.name}" }
                                 )


### PR DESCRIPTION
The beacon type wasn't consistent across languages and so didn't work properly. It now always stores the preference using the name from the AudioEngine and translates that to resource ids for the displayed names.