### PR TITLE
Use confected names when constructing intersection names

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
@@ -229,11 +229,16 @@ open class GridState(
                 traverseIntersectionsConfectingNames(hashmap, intersectionAccumulator)
             }
 
+            // And now update the names for the intersection to include the confections
+            for (intersection in intersectionAccumulator) {
+                intersection.value.updateName()
+            }
+
 // The other confection is done lazily as it's relatively time consuming to do the whole tile at once
 //          //And then fill in any remaining names using rtree searches - this is slower and
 //            // adds POIs and co-linear names
 //            for (road in featureCollections[TreeId.ROADS_AND_PATHS.id]) {
-//                confectNamesForRoad(road, featureTrees)
+//                confectNamesForRoad(road, this)
 //          }
         }
     }


### PR DESCRIPTION
As a final stage after the grid has been constructed, go through all of the intersections updating their names to reflect any confections that took place.