### PR TITLE
Remove matrix of instrumentation tests from nightly build

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -127,65 +127,65 @@ jobs:
           name: debug-androidTest
           path: ${{ env.main_project_module }}/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
 
-  instrumentation-tests:
-    name: Run matrix of instrumentation tests
-    needs: build
-    environment: development
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        api-level: [30, 31, 34]
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup tile provider
-        env:
-          TILE_PROVIDER_API_KEY: ${{ secrets.TILE_PROVIDER_API_KEY }}
-          TILE_PROVIDER_URL: ${{ secrets.TILE_PROVIDER_URL }}
-        run: |
-          echo tileProviderUrl=$TILE_PROVIDER_URL > local.properties
-          echo tileProviderApiKey=$TILE_PROVIDER_API_KEY >> local.properties
-
-      - name: Decode Google services
-        env:
-          ENCODED_STRING: ${{ secrets.GOOGLE_SERVICES }}
-          GOOGLE_SERVICES_PATH: ${{ secrets.GOOGLE_SERVICES_PATH }}
-
-        run: |
-          echo $ENCODED_STRING > google-services-b64.txt
-          base64 -d google-services-b64.txt > ${{ env.main_project_module }}/$GOOGLE_SERVICES_PATH
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: Set Up JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu' # See 'Supported distributions' for available options
-          java-version: '19'
-
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - name: Instrumentation Tests
-        id: instrumentation-tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          target: default
-          arch: x86_64
-          script: |
-            adb logcat -c                             # clear logs
-            touch app/emulator.log                    # create log file
-            chmod 777 app/emulator.log                # allow writing to log file
-            adb logcat >> app/emulator.log &          # pipe all logcat messages into log file as a background process
-            ./gradlew connectedCheck
+#  instrumentation-tests:
+#    name: Run matrix of instrumentation tests
+#    needs: build
+#    environment: development
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        api-level: [30, 31, 34]
+#      fail-fast: false
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          fetch-depth: 0
+#
+#      - name: Setup tile provider
+#        env:
+#          TILE_PROVIDER_API_KEY: ${{ secrets.TILE_PROVIDER_API_KEY }}
+#          TILE_PROVIDER_URL: ${{ secrets.TILE_PROVIDER_URL }}
+#        run: |
+#          echo tileProviderUrl=$TILE_PROVIDER_URL > local.properties
+#          echo tileProviderApiKey=$TILE_PROVIDER_API_KEY >> local.properties
+#
+#      - name: Decode Google services
+#        env:
+#          ENCODED_STRING: ${{ secrets.GOOGLE_SERVICES }}
+#          GOOGLE_SERVICES_PATH: ${{ secrets.GOOGLE_SERVICES_PATH }}
+#
+#        run: |
+#          echo $ENCODED_STRING > google-services-b64.txt
+#          base64 -d google-services-b64.txt > ${{ env.main_project_module }}/$GOOGLE_SERVICES_PATH
+#
+#      - name: Setup Gradle
+#        uses: gradle/actions/setup-gradle@v4
+#
+#      - name: Set Up JDK
+#        uses: actions/setup-java@v4
+#        with:
+#          distribution: 'zulu' # See 'Supported distributions' for available options
+#          java-version: '19'
+#
+#      - name: Enable KVM
+#        run: |
+#          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+#          sudo udevadm control --reload-rules
+#          sudo udevadm trigger --name-match=kvm
+#
+#      - name: Instrumentation Tests
+#        id: instrumentation-tests
+#        uses: reactivecircus/android-emulator-runner@v2
+#        with:
+#          api-level: ${{ matrix.api-level }}
+#          target: default
+#          arch: x86_64
+#          script: |
+#            adb logcat -c                             # clear logs
+#            touch app/emulator.log                    # create log file
+#            chmod 777 app/emulator.log                # allow writing to log file
+#            adb logcat >> app/emulator.log &          # pipe all logcat messages into log file as a background process
+#            ./gradlew connectedCheck
 
   firebase:
     name: Run UI tests with Firebase Test Lab


### PR DESCRIPTION
These have never failed and they now need the offline mapping extracts so are harder to run.