### PR TITLE
Add settings to add direction and distance to POI callouts

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -862,6 +862,10 @@ class MainActivity : AppCompatActivity() {
         const val VOICE_COMMAND_LISTENING_PROMPT_KEY = "VoiceCommandListeningPrompt"
         const val VOICE_COMMAND_MICROPHONE_DEFAULT = "Auto"
         const val VOICE_COMMAND_MICROPHONE_KEY = "VoiceCommandMicrophone"
+        const val POSITION_INCLUDES_HEADING_AND_DISTANCE_DEFAULT = false
+        const val POSITION_INCLUDES_HEADING_AND_DISTANCE_KEY = "PositionTextDescription"
+        const val RELATIVE_DIRECTION_DEFAULT = "ClockFace"
+        const val RELATIVE_DIRECTION_KEY = "RelativeDirectionMode"
 
         const val FIRST_LAUNCH_KEY = "FirstLaunch"
         const val AUDIO_TOUR_SHOWN_KEY = "AudioTourShown"

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -46,8 +46,11 @@ import org.scottishtecharmy.soundscape.geoengine.utils.getCompassLabelFacingDire
 import org.scottishtecharmy.soundscape.geoengine.utils.getCompassLabelFacingDirectionAlong
 import org.scottishtecharmy.soundscape.geoengine.utils.getDistanceToFeature
 import org.scottishtecharmy.soundscape.geoengine.utils.getFovTriangle
+import org.scottishtecharmy.soundscape.geoengine.utils.getRelativeClockTime
 import org.scottishtecharmy.soundscape.geoengine.utils.getRelativeDirectionsPolygons
+import org.scottishtecharmy.soundscape.geoengine.utils.getRelativeLeftRightLabel
 import org.scottishtecharmy.soundscape.geoengine.utils.getTriangleForDirection
+import org.scottishtecharmy.soundscape.geoengine.utils.normalizeHeading
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
@@ -66,6 +69,7 @@ import org.scottishtecharmy.soundscape.geoengine.utils.rulers.CheapRuler
 import org.scottishtecharmy.soundscape.utils.Analytics
 import org.scottishtecharmy.soundscape.utils.NetworkUtils
 import java.lang.String.format
+import kotlin.math.roundToInt
 
 
 data class PositionedString(
@@ -73,7 +77,8 @@ data class PositionedString(
     val location : LngLatAlt? = null,
     val earcon : String? = null,
     val type: AudioType = AudioType.STANDARD,
-    val heading: Double? = null
+    val heading: Double? = null,
+    val addDistanceAndHeading: Boolean = false
 )
 
 fun getPhotonLanguage(sharedPreferences: SharedPreferences?) : String? {
@@ -367,22 +372,6 @@ class GeoEngine {
         return enabledCategories
     }
 
-    private fun updateAudioEngineGeometry(
-        soundscapeService: SoundscapeService,
-        userGeometry: UserGeometry
-    ) {
-        // Send the update to the audio engine. This affects the direction and sound
-        // of the audio beacon.
-        soundscapeService.audioEngine.updateGeometry(
-            userGeometry.location.latitude,
-            userGeometry.location.longitude,
-            userGeometry.presentationHeading(),
-            soundscapeService.audioFocusGained,
-            soundscapeService.duckingAllowed,
-            15.0
-        )
-    }
-
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun startMonitoringLocation(soundscapeService: SoundscapeService) {
         Log.e(TAG, "startTileGridService")
@@ -478,7 +467,7 @@ class GeoEngine {
 
                     }.collect { geometry ->
                         lastGeometry = geometry
-                        updateAudioEngineGeometry(soundscapeService, geometry)
+                        soundscapeService.updateAudioEngineGeometry(geometry)
                         checkStreetPreviewBestChoice(
                             soundscapeService,
                             soundscapeService.streetPreviewFlow.value.choices,
@@ -496,7 +485,7 @@ class GeoEngine {
                         else
                             last.phoneHeading = null
 
-                        updateAudioEngineGeometry(soundscapeService, last)
+                        soundscapeService.updateAudioEngineGeometry(last)
                         checkStreetPreviewBestChoice(
                             soundscapeService,
                             soundscapeService.streetPreviewFlow.value.choices,
@@ -1182,7 +1171,13 @@ fun updateMeasurementUnits(sharedPreferences: SharedPreferences) {
         metric = (unitsString == "Metric")
 }
 
-fun formatDistanceAndDirection(distance: Double, heading: Double?, localizedContext: Context?) : String {
+fun formatDistanceAndDirection(
+    distance: Double,
+    heading: Double?,
+    localizedContext: Context?,
+    userHeading: Double? = null,
+    relativeTimeMode: String = "ClockFace"
+) : String {
     var units = distance
     var bigUnitDivisor = 100
     if(!metric) {
@@ -1210,8 +1205,47 @@ fun formatDistanceAndDirection(distance: Double, heading: Double?, localizedCont
     }
 
     var headingText = ""
-    if(heading != null && localizedContext != null) {
-        headingText = ", " + localizedContext.getString(getCompassLabel(heading.toInt()))
+    if(heading != null) {
+        if(userHeading == null) {
+            if(localizedContext != null)
+                headingText = ", " + localizedContext.getString(getCompassLabel(heading.toInt()))
+        } else {
+            // We have a user heading, so we want to describe with a relative direction
+            when(relativeTimeMode) {
+                "ClockFace" -> {
+                    val timeHeading = getRelativeClockTime(heading.toInt(), userHeading.toInt())
+                    headingText =
+                        ", " + (localizedContext?.getString(R.string.relative_clock_direction) ?: "at %s o'clock")
+                        .format(timeHeading)
+                }
+                "Degrees" -> {
+                    val heading = (heading - userHeading)
+                    val degrees = normalizeHeading(((heading / 5.0).roundToInt() * 5))
+                    headingText =
+                        ", " + (localizedContext?.getString(R.string.relative_degrees_direction) ?: "at %s degrees")
+                            .format(degrees)
+                }
+                "LeftRight" -> {
+                    val labelId = getRelativeLeftRightLabel((heading - userHeading).toInt())
+                    if(localizedContext != null) {
+                        headingText = ", " + localizedContext.getString(labelId)
+                    } else {
+                        headingText = ", " +
+                            when (labelId) {
+                                R.string.relative_left_right_direction_ahead -> "Ahead"
+                                R.string.relative_left_right_direction_ahead_right -> "Ahead right"
+                                R.string.relative_left_right_direction_right -> "Right"
+                                R.string.relative_left_right_direction_behind_right -> "Behind right"
+                                R.string.relative_left_right_direction_behind -> "Behind"
+                                R.string.relative_left_right_direction_behind_left -> "Behind left"
+                                R.string.relative_left_right_direction_left -> "Left"
+                                R.string.relative_left_right_direction_ahead_left -> "Ahead left"
+                                else -> "Unknown"
+                            }
+                    }
+                }
+            }
+        }
     }
     return format("$distanceText$headingText")
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/AutoCallout.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/callouts/AutoCallout.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.scottishtecharmy.soundscape.MainActivity.Companion.ALLOW_CALLOUTS_KEY
+import org.scottishtecharmy.soundscape.MainActivity.Companion.POSITION_INCLUDES_HEADING_AND_DISTANCE_KEY
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.audio.AudioType
 import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
@@ -246,7 +247,8 @@ class AutoCallout(
                                         text = name.text,
                                         location = nearestPoint.point,
                                         earcon = earcon,
-                                        type = AudioType.LOCALIZED
+                                        type = AudioType.LOCALIZED,
+                                        addDistanceAndHeading = sharedPreferences?.getBoolean(POSITION_INCLUDES_HEADING_AND_DISTANCE_KEY, false) ?: false
                                     )
                                 }
                             }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/CompassDirections.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/CompassDirections.kt
@@ -4,7 +4,7 @@ package org.scottishtecharmy.soundscape.geoengine.utils
 import android.content.Context
 import org.scottishtecharmy.soundscape.R
 
-private fun normalize(deg: Int) : Int {
+fun normalizeHeading(deg: Int) : Int {
     var tmp = deg
     while (tmp < 0) tmp += 360
     while (tmp > 360) tmp -= 360
@@ -18,7 +18,7 @@ fun getCompassLabelFacingDirection(localizedContext: Context,
                                    inMotion: Boolean,
                                    inVehicle: Boolean
 ): String{
-    val normalizedDegrees = normalize(degrees)
+    val normalizedDegrees = normalizeHeading(degrees)
     if(!inMotion) {
         return when (normalizedDegrees) {
             in 338..360, in 0..22 -> localizedContext.getString(R.string.directions_facing_n)
@@ -64,7 +64,7 @@ fun getCompassLabelFacingDirectionAlong(localizedContext: Context,
                                         inMotion: Boolean,
                                         inVehicle: Boolean
 ):String{
-    val normalizedDegrees = normalize(degrees)
+    val normalizedDegrees = normalizeHeading(degrees)
     if(!inMotion) {
         return when (normalizedDegrees) {
             in 338..360, in 0..22 -> localizedContext.getString(
@@ -177,7 +177,7 @@ fun getCompassLabelFacingDirectionAlong(localizedContext: Context,
 }
 
 fun getCompassLabel(degrees: Int):Int {
-    val normalizedDegrees = normalize(degrees)
+    val normalizedDegrees = normalizeHeading(degrees)
     return when (normalizedDegrees) {
         in 338..360, in 0..22 -> R.string.directions_cardinal_north
         in 23..67 -> R.string.directions_cardinal_north_east
@@ -188,5 +188,26 @@ fun getCompassLabel(degrees: Int):Int {
         in 248..292 -> R.string.directions_cardinal_west
         in 293..337 -> R.string.directions_cardinal_north_west
         else -> R.string.directions_cardinal_north
+    }
+}
+
+fun getRelativeClockTime(degrees: Int, userDegrees: Int): Int {
+    val relative = normalizeHeading(degrees - userDegrees)
+    val hour = ((relative + 15) / 30) % 12
+    return if (hour == 0) 12 else hour
+}
+
+fun getRelativeLeftRightLabel(relativeAngle: Int):Int {
+    val normalizedAngle = normalizeHeading(relativeAngle)
+    return when (normalizedAngle) {
+        in 338..360, in 0..22 -> R.string.relative_left_right_direction_ahead
+        in 23..67 -> R.string.relative_left_right_direction_ahead_right
+        in 68..112 -> R.string.relative_left_right_direction_right
+        in 113..157 -> R.string.relative_left_right_direction_behind_right
+        in 158..202 -> R.string.relative_left_right_direction_behind
+        in 203..247 -> R.string.relative_left_right_direction_behind_left
+        in 248..292 -> R.string.relative_left_right_direction_left
+        in 293..337 -> R.string.relative_left_right_direction_ahead_left
+        else -> R.string.relative_left_right_direction_ahead
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/settings/Settings.kt
@@ -291,6 +291,17 @@ fun Settings(
         "AudioMenu",
     )
 
+    val relativeDirectionDescriptions = listOf(
+        stringResource(R.string.settings_relative_directions_clockface),
+        stringResource(R.string.settings_relative_directions_degrees),
+        stringResource(R.string.settings_relative_directions_left_right),
+    )
+    val relativeDirectionValues = listOf(
+        "ClockFace",
+        "Degrees",
+        "LeftRight",
+    )
+
     val microphoneDescriptions = uiState.microphoneDescriptions
     val microphoneValues = uiState.microphoneValues
 
@@ -422,6 +433,42 @@ fun Settings(
                     },
                     enabled = { allowCallouts.value },
                 )
+                switchPreference(
+                    key = MainActivity.POSITION_INCLUDES_HEADING_AND_DISTANCE_KEY,
+                    defaultValue = MainActivity.POSITION_INCLUDES_HEADING_AND_DISTANCE_DEFAULT,
+                    modifier = expandedSectionModifier,
+                    title = {
+                        SettingDetails(
+                            R.string.callout_settings_position_text,
+                            R.string.callout_settings_position_description,
+                            textColor
+                        )
+                    },
+                    enabled = { allowCallouts.value },
+                )
+                listPreference(
+                    key = MainActivity.RELATIVE_DIRECTION_KEY,
+                    defaultValue = MainActivity.RELATIVE_DIRECTION_DEFAULT,
+                    values = relativeDirectionValues,
+                    modifier = expandedSectionModifier,
+                    title = {
+                        SettingDetails(
+                            R.string.settings_relative_directions_text,
+                            R.string.settings_relative_directions_description,
+                            textColor
+                        )
+                    },
+                    item = { value, currentValue, onClick ->
+                        ListPreferenceItem(relativeDirectionDescriptions[relativeDirectionValues.indexOf(value)], value, currentValue, onClick, relativeDirectionValues.indexOf(value), relativeDirectionValues.size)
+                    },
+                    summary = {
+                        ClickableOption(
+                            relativeDirectionDescriptions[relativeDirectionValues.indexOf(it)],
+                            textColor
+                        )
+                    },
+                )
+
 //                switchPreference(
 //                    key = MainActivity.UNNAMED_ROADS_KEY,
 //                    defaultValue = MainActivity.UNNAMED_ROADS_DEFAULT,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -11,6 +11,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Intent
+import android.content.SharedPreferences
 import android.content.pm.ServiceInfo
 import android.media.AudioAttributes
 import android.media.AudioFocusRequest
@@ -46,6 +47,8 @@ import kotlinx.coroutines.withContext
 import org.scottishtecharmy.soundscape.MainActivity
 import org.scottishtecharmy.soundscape.MainActivity.Companion.MEDIA_CONTROLS_MODE_DEFAULT
 import org.scottishtecharmy.soundscape.MainActivity.Companion.MEDIA_CONTROLS_MODE_KEY
+import org.scottishtecharmy.soundscape.MainActivity.Companion.RELATIVE_DIRECTION_DEFAULT
+import org.scottishtecharmy.soundscape.MainActivity.Companion.RELATIVE_DIRECTION_KEY
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.audio.AudioType
 import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
@@ -59,8 +62,11 @@ import org.scottishtecharmy.soundscape.geoengine.GridState
 import org.scottishtecharmy.soundscape.geoengine.StreetPreviewChoice
 import org.scottishtecharmy.soundscape.geoengine.StreetPreviewEnabled
 import org.scottishtecharmy.soundscape.geoengine.StreetPreviewState
+import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.utils.getCompassLabel
 import org.scottishtecharmy.soundscape.geoengine.filters.TrackedCallout
+import org.scottishtecharmy.soundscape.geoengine.formatDistanceAndDirection
+import org.scottishtecharmy.soundscape.geoengine.utils.rulers.CheapRuler
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.hasPlayServices
 import org.scottishtecharmy.soundscape.locationprovider.AndroidDirectionProvider
@@ -273,6 +279,8 @@ class SoundscapeService : MediaSessionService() {
         return super.onStartCommand(intent, flags, startId)
     }
 
+    lateinit var sharedPreferences : SharedPreferences
+
     @OptIn(UnstableApi::class)
     override fun onCreate() {
         super.onCreate()
@@ -312,7 +320,7 @@ class SoundscapeService : MediaSessionService() {
             }
 
             // Update the media controls mode
-            val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
+            sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
             val mode = sharedPreferences.getString(MEDIA_CONTROLS_MODE_KEY, MEDIA_CONTROLS_MODE_DEFAULT)!!
             updateMediaControls(mode)
 
@@ -761,6 +769,24 @@ class SoundscapeService : MediaSessionService() {
             audioEngine.createTextToSpeech(text, AudioType.STANDARD)
     }
 
+    private var lastGeometry : UserGeometry? = null
+    private var ruler = CheapRuler(0.0)
+    fun updateAudioEngineGeometry(
+        userGeometry: UserGeometry
+    ) {
+        // Send the update to the audio engine. This affects the direction and sound
+        // of the audio beacon.
+        lastGeometry = userGeometry
+        audioEngine.updateGeometry(
+            userGeometry.location.latitude,
+            userGeometry.location.longitude,
+            userGeometry.presentationHeading(),
+            audioFocusGained,
+            duckingAllowed,
+            15.0
+        )
+    }
+
     fun speakCallout(callout: TrackedCallout?, addModeEarcon: Boolean) : Long {
 
         if(callout == null) return 0L
@@ -790,8 +816,28 @@ class SoundscapeService : MediaSessionService() {
                         result.location.longitude,
                         result.heading?:0.0)
                 }
+                val text =
+                    if(result.addDistanceAndHeading) {
+                        lastGeometry?.location?.let { location ->
+                            if (ruler.needsReplacing(location.latitude))
+                                ruler = CheapRuler(location.latitude)
+
+                            val distance =
+                                ruler.distance(location, result.location)
+                            val heading = ruler.bearing(location, result.location)
+                            result.text + ", " + formatDistanceAndDirection(
+                                distance,
+                                heading,
+                                localizedContext,
+                                lastGeometry?.heading(),
+                                sharedPreferences.getString(RELATIVE_DIRECTION_KEY, RELATIVE_DIRECTION_DEFAULT)!!
+                            )
+                        } ?: result.text
+                    }
+                    else
+                        result.text
                 lastHandle = audioEngine.createTextToSpeech(
-                    result.text,
+                    text,
                     result.type,
                     result.location.latitude,
                     result.location.longitude,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,16 @@
 <string name="settings_search_offline">"Offline"</string>
 <!-- The option for setting the search to automatically pick the best engine based on network and device capabilities -->
 <string name="settings_search_auto">"Auto"</string>
+<!-- The option for setting how relative directions are described -->
+<string name="settings_relative_directions_text">"Relative directions mode"</string>
+<!-- The longer description for setting how relative directions -->
+<string name="settings_relative_directions_description">"Change how relative directions are described."</string>
+<!-- Clock face relative direction mode e.g. at 2 o'clock -->
+<string name="settings_relative_directions_clockface">"Clock face"</string>
+<!-- Degrees relative direction mode e.g. at 45 degrees -->
+<string name="settings_relative_directions_degrees">"Degrees"</string>
+<!-- Left/Right relative direction mode e.g. Left, or Right or Behind -->
+<string name="settings_relative_directions_left_right">"Left/Right"</string>
 <!-- Text shown when no search results were found -->
 <string name="search_no_results">"No search results found"</string>
 <!-- Text shown when no search in progress -->
@@ -306,6 +316,10 @@
 <string name="callouts_nearby_markers">"Nearby Markers"</string>
 <!-- Text read out when there are no markers nearby to report -->
 <string name="callouts_no_nearby_markers">"There are no nearby markers"</string>
+<!-- Settings menu text for position  -->
+<string name="callout_settings_position_text">"Include the distance and direction when calling out points of interest"</string>
+<!-- Settings menu description text for whether to include the distand and direction in POI callouts  -->
+<string name="callout_settings_position_description">"By default when places are called out they don't include a distance or direction. This setting adds those to the callouts."</string>
 <!-- Sleep Title, Sleep. Putting the app in an idle state for a period of time. -->
 <string name="sleep_sleep">"Sleep"</string>
 <!-- App is currently Sleeping. Putting the app in an idle state for a period of time. -->
@@ -2678,4 +2692,17 @@ Please report any problems that you have, however small they may be via the *Con
 <string name="voice_cmd_speech_recognition_error_cannot_listen_to_download_events">"Speech recognition download listen error."</string>
 <string name="voice_cmd_speech_recognition_error_unknown">"Speech recognition unknown error."</string>
 <string name="voice_cmd_speech_recognition_error_unsupported">"Speech recognition is not supported on this phone."</string>
+<!-- Relative directions using clock face notation, %s is time in hours e.g. at 3 o'clock -->
+<string name="relative_clock_direction">"at %s o'clock"</string>
+<!-- Relative directions using degrees, %s is angle e.g. at 45 degrees -->
+<string name="relative_degrees_direction">"at %s degrees"</string>
+<!-- Relative directions using left/right -->
+<string name="relative_left_right_direction_ahead">"Ahead"</string>
+<string name="relative_left_right_direction_ahead_left">"Ahead left"</string>
+<string name="relative_left_right_direction_ahead_right">"Ahead right"</string>
+<string name="relative_left_right_direction_left">"Left"</string>
+<string name="relative_left_right_direction_right">"Right"</string>
+<string name="relative_left_right_direction_behind_left">"Behind left"</string>
+<string name="relative_left_right_direction_behind_right">"Behind right"</string>
+<string name="relative_left_right_direction_behind">"Behind"</string>
 </resources>

--- a/app/src/test/java/org/scottishtecharmy/soundscape/GeoUtilsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/GeoUtilsTest.kt
@@ -26,6 +26,7 @@ import org.scottishtecharmy.soundscape.geoengine.utils.pixelXYToLatLon
 import org.scottishtecharmy.soundscape.geoengine.utils.polygonContainsCoordinates
 import org.junit.Assert
 import org.junit.Test
+import org.scottishtecharmy.soundscape.geoengine.formatDistanceAndDirection
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.MvtFeature
 import org.scottishtecharmy.soundscape.geoengine.utils.rulers.CheapRuler
 import org.scottishtecharmy.soundscape.geoengine.utils.Triangle
@@ -583,6 +584,40 @@ class GeoUtilsTest {
 
         val adapter = GeoJsonObjectMoshiAdapter()
         val mapMatchingOutput = FileOutputStream("cheap-ruler.geojson")
+        mapMatchingOutput.write(adapter.toJson(fc).toByteArray())
+        mapMatchingOutput.close()
+    }
+
+    @Test
+    fun relativeLeftRightTest() {
+        // Create circle
+        val center = LngLatAlt(-2.653228, 51.431658)
+        val circle = circleToPolygon(
+            32,
+            center.latitude,
+            center.longitude,
+            200.0
+        )
+        // Turn the circle into a line
+        val line = LineString()
+        line.coordinates.addAll(circle.coordinates[0])
+
+        val fc = FeatureCollection()
+
+        val ruler = CheapRuler(center.latitude)
+        for(point in circle.coordinates[0]) {
+            val distance = ruler.distance(center, point)
+            val heading = ruler.bearing(center, point)
+            val text = formatDistanceAndDirection(distance, heading, null, 270.0, "LeftRight")
+
+            val pointFeature1 = Feature()
+            pointFeature1.geometry = Point(point)
+            pointFeature1.properties = hashMapOf("direction" to text)
+            fc.addFeature(pointFeature1)
+        }
+
+        val adapter = GeoJsonObjectMoshiAdapter()
+        val mapMatchingOutput = FileOutputStream("relative-left-right.geojson")
         mapMatchingOutput.write(adapter.toJson(fc).toByteArray())
         mapMatchingOutput.close()
     }


### PR DESCRIPTION
This defaults to off as per iOS Soundscape, however the user can enable distance and relative direction from the Settings. The relative direction mode can be selected from Clock Face, Degrees or Left/Right/Ahead modes. Currently this is only used for POI auto callouts.