### PR TITLE
Fix crash during switching language

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -776,6 +776,12 @@ class MainActivity : AppCompatActivity() {
     var serviceSleeping = false
     fun setServiceState(newServiceState: Boolean, sleeping: Boolean? = null) {
         Log.d(TAG, "setServiceState $newServiceState, sleeping = $sleeping, serviceSleeping = $serviceSleeping")
+        // Bail out if we're a destroyed activity instance still being held by some caller —
+        // ActivityResultLaunchers are unregistered on destroy and launch() would throw.
+        if (isFinishing || isDestroyed) {
+            Log.w(TAG, "setServiceState called on finishing/destroyed activity; ignoring")
+            return
+        }
         if(!serviceSleeping || (sleeping == false)) {
             if (!newServiceState) {
                 soundscapeServiceConnection.stopService()

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
@@ -199,7 +199,7 @@ fun HomeScreen(
                 supportedLanguages = languageUiState.value.supportedLanguages,
                 onLanguageSelected = { selectedLanguage ->
                     languageViewModel.updateLanguage(selectedLanguage)
-                    settingsViewModel.updateLanguage(localActivity)
+                    settingsViewModel.updateLanguage()
                  },
                 selectedLanguageIndex = languageUiState.value.selectedLanguageIndex,
                 storages = uiState.value.storages,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/SettingsViewModel.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.viewModelScope
 import androidx.preference.PreferenceManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -50,7 +49,6 @@ class SettingsViewModel @Inject constructor(
 
     private val _state: MutableStateFlow<SettingsUiState> = MutableStateFlow(SettingsUiState())
     val state: StateFlow<SettingsUiState> = _state.asStateFlow()
-    private val coroutineScope = CoroutineScope(Job())
     private var serviceBoundJob: Job? = null
 
     init {
@@ -182,12 +180,13 @@ class SettingsViewModel @Inject constructor(
         else -> "Type $type"
     }
 
-    fun updateLanguage(localContext: MainActivity) {
-        coroutineScope.launch {
-            localContext.setServiceState(false)
-            Thread.sleep(1000)
-            localContext.setServiceState(true)
-        }
+    fun updateLanguage() {
+        // Stop the service so it picks up the new locale on next start. The activity will be
+        // recreated by AppCompatDelegate.setApplicationLocales(...); its onResume() detects the
+        // stopped service and calls setServiceState(true) from a freshly-registered
+        // ActivityResultLauncher. Holding a MainActivity reference across recreate would crash
+        // when launch() is invoked on the destroyed activity's launcher.
+        soundscapeServiceConnection.stopService()
     }
 
     fun selectStorage(path: String) {


### PR DESCRIPTION
- SettingsViewModel.kt — updateLanguage() no longer takes a MainActivity. It just calls soundscapeServiceConnection.stopService() and lets the recreated activity's onResume handle restart from a fresh launcher. Removed the now-unused coroutineScope field and CoroutineScope import. The 1-second Thread.sleep (which was the bug's window) is gone.
- HomeScreen.kt:202 — updated call site to settingsViewModel.updateLanguage().
- MainActivity.kt:setServiceState — added isFinishing || isDestroyed guard so any future stale-activity caller bails out instead of crashing on launch().