### PR TITLE
Fix waypoint GUI map numbering when skipping between waypoints

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/Home.kt
@@ -172,6 +172,7 @@ fun Home(
                     MapContainerLibre(
                         beaconLocation = state.beaconState?.location,
                         routeData = state.currentRouteData.routeData,
+                        currentBeaconWaypointIndex = state.currentRouteData.currentWaypoint,
                         mapCenter = location,
                         allowScrolling = false,
                         userLocation = location,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/HomeContent.kt
@@ -281,6 +281,7 @@ fun HomeContent(
                                     MapContainerLibre(
                                         beaconLocation = beaconState?.location,
                                         routeData = routePlayerState.routeData,
+                                        currentBeaconWaypointIndex = routePlayerState.currentWaypoint,
                                         mapCenter = location,
                                         allowScrolling = false,
                                         userLocation = location,

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
@@ -251,6 +251,7 @@ fun MapContainerLibre(
     userSymbolRotation: Float,
     beaconLocation: LngLatAlt?,
     routeData: RouteWithMarkers?,
+    currentBeaconWaypointIndex: Int = 0,
     modifier: Modifier = Modifier,
     editBeaconLocation: Boolean = false,
     onMapLongClick: OnMapLongClickListener,
@@ -298,6 +299,8 @@ fun MapContainerLibre(
             val currentRouteData = remember { mutableStateOf(routeData) }
             val routeMarkers = remember { mutableStateOf<List<Symbol>?>(null) }
             val beaconLocationMarker = remember { mutableStateOf<Symbol?>(null) }
+            val currentBeaconLocation = remember { mutableStateOf(beaconLocation) }
+            val currentBeaconIndex = remember { mutableStateOf(currentBeaconWaypointIndex) }
             val symbol = remember { mutableStateOf<Symbol?>(null) }
             val symbolManager = remember { mutableStateOf<SymbolManager?>(null) }
             val filesDir = remember { context.filesDir.toString() }
@@ -514,7 +517,7 @@ fun MapContainerLibre(
                         if (beaconLocation != null) {
                             val markerOptions = SymbolOptions()
                                 .withLatLng(beaconLocation.toLatLng())
-                                .withIconImage(LOCATION_MARKER_NAME.format(0))
+                                .withIconImage(LOCATION_MARKER_NAME.format(currentBeaconWaypointIndex))
                                 .withIconAnchor("bottom")
                                 .withIconSize(1.5f)
                             val beacon = sm.create(markerOptions)
@@ -650,6 +653,25 @@ fun MapContainerLibre(
                     updateRouteMarkers(sm, annotationList, routeData, routeMarkers)
                     sm.update(annotationList)
                     currentRouteData.value = routeData
+                }
+            }
+
+            // Check if the beacon location or waypoint index has changed
+            if (beaconLocation != currentBeaconLocation.value ||
+                currentBeaconWaypointIndex != currentBeaconIndex.value) {
+                symbolManager.value?.let { sm ->
+                    beaconLocationMarker.value?.let { sm.delete(it) }
+                    beaconLocationMarker.value = null
+                    if (beaconLocation != null) {
+                        val markerOptions = SymbolOptions()
+                            .withLatLng(beaconLocation.toLatLng())
+                            .withIconImage(LOCATION_MARKER_NAME.format(currentBeaconWaypointIndex))
+                            .withIconAnchor("bottom")
+                            .withIconSize(1.5f)
+                        beaconLocationMarker.value = sm.create(markerOptions)
+                    }
+                    currentBeaconLocation.value = beaconLocation
+                    currentBeaconIndex.value = currentBeaconWaypointIndex
                 }
             }
 


### PR DESCRIPTION
The current beacon was always appearing as marker 1 on the GUI map. This change fixes that.