### PR TITLE
SA-308: add inline Search button to search bar

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/components/MainSearchBar.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/components/MainSearchBar.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
@@ -104,6 +105,15 @@ fun MainSearchBar(
             // Get keyboard controller inside Popup since it has its own window
             val keyboardController = LocalSoftwareKeyboardController.current
 
+            val triggerSearch = {
+                val trimmed = query.trim()
+                if (trimmed.isNotEmpty()) {
+                    searchLocation.value = userLocation
+                    keyboardController?.hide()
+                    searchFunctions.onTriggerSearch(trimmed)
+                }
+            }
+
             // Request focus on the text field when the search overlay opens
             LaunchedEffect(expanded) {
                 if (expanded) {
@@ -148,14 +158,7 @@ fun MainSearchBar(
                                 textStyle = textStyle,
                                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
                                 keyboardActions = KeyboardActions(
-                                    onSearch = {
-                                        val trimmed = query.trim()
-                                        if (trimmed.isNotEmpty()) {
-                                            searchLocation.value = userLocation
-                                            keyboardController?.hide()
-                                            searchFunctions.onTriggerSearch(trimmed)
-                                        }
-                                    }
+                                    onSearch = { triggerSearch() }
                                 ),
                                 modifier = Modifier
                                     .weight(1f)
@@ -174,6 +177,12 @@ fun MainSearchBar(
                             )
 
                             if (query.isNotEmpty()) {
+                                TextButton(onClick = { triggerSearch() }) {
+                                    Text(
+                                        text = stringResource(R.string.search_button_label),
+                                        color = colors.primary
+                                    )
+                                }
                                 IconButton(
                                     onClick = { query = "" }
                                 ) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,8 @@
 <string name="settings_units_metric">"Metric (Meters)"</string>
 <!-- In the Settings page the title of the section for selecting which search system to use -->
 <string name="settings_section_search">"Search"</string>
+<!-- Label for the inline Search button next to the search input field -->
+<string name="search_button_label">"Search"</string>
 <!-- A hint for the search bar explaining what it's for -->
 <string name="search_bar_hint">"Type a destination name or address"</string>
 <!-- This is the setting to control whether the Search uses offline data or can use an online server -->


### PR DESCRIPTION
## Summary
- Adds a visible "Search" `TextButton` inside the search bar, between the text input and the ✕ clear button, as an alternative way to start a search (per SA-308).
- Both the new button and the existing keyboard Enter / IME search action call the same `triggerSearch()` lambda, so behaviour is identical and the existing flow is preserved.
- Button only appears when the query is non-empty (matches the mockup; avoids triggering empty searches).

## Changes
- `components/MainSearchBar.kt` — extracted shared `triggerSearch` lambda; added `TextButton` in the search header row.
- `res/values/strings.xml` — new string `search_button_label` for the button label.

## Test plan
- [x] Debug APK installed on device, app launches.
- [x] Open the search overlay; with text typed, "Search" button appears next to ✕ and triggers search.
- [x] Keyboard Enter / magnifying glass still triggers search (unchanged code path via the same lambda).
- [ ] TalkBack reads the button label correctly.
- [ ] Verify against both light and dark themes.