### PR TITLE
Run nightly build for both main, v1.0 and multiplatform branches

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -15,37 +15,21 @@ on:
     - cron:  '30 5 * * *'
 
 jobs:
-  check_date:
-    name: Check latest commit
-    runs-on: ubuntu-latest
-    environment: development
-    permissions:
-      contents: write
-    outputs:
-      should_run: ${{ steps.should_run.outputs.should_run }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Check latest commit is less than a day
-        id: should_run
-        continue-on-error: true
-        #if: ${{ github.event_name == 'schedule' }}
-        run: test -z $(git rev-list  --after="24 hours" HEAD) && echo "should_run=false" >> $GITHUB_OUTPUT
-
   build:
-    name: Build package
+    name: Build package (${{ matrix.ref }})
     runs-on: ubuntu-latest
     environment: development
-    needs: check_date
-    if: ${{ needs.check_date.outputs.should_run != 'false' }}
     permissions:
       contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        ref: [main, v1.0, multiplatform]
 
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ matrix.ref }}
           fetch-depth: 0
 
       - name: Setup offline maps for tests
@@ -120,7 +104,7 @@ jobs:
       - name: Upload APK Release
         uses: actions/upload-artifact@v6
         with:
-          name: release-apk
+          name: release-apk-${{ matrix.ref }}
           path: ${{ env.main_project_module }}/build/outputs/apk/releaseTest/
 
       # Generate android instrumentation tests APK
@@ -198,16 +182,20 @@ jobs:
 #            ./gradlew connectedCheck
 
   firebase:
-    name: Run UI tests with Firebase Test Lab
+    name: Run UI tests with Firebase Test Lab (${{ matrix.ref }})
     needs: build
     environment: development
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ref: [main, v1.0, multiplatform]
 
     steps:
       - name: Download app APK
         uses: actions/download-artifact@v8
         with:
-          name: release-apk
+          name: release-apk-${{ matrix.ref }}
 
 #      - name: Download Android test APK
 #        uses: actions/download-artifact@v8


### PR DESCRIPTION
Matrix the build and firebase jobs so the scheduled cron produces a nightly for each. Artifacts are scoped per ref to avoid name collisions. Drops the check_date freshness gate, which is awkward to preserve cleanly per matrix leg.