### PR TITLE
Target v1.0 branch for PR tests and Pages deploys

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -8,7 +8,7 @@ name: Deploy Jekyll site to Pages
 
 on:
   push:
-    branches: ["main"]
+    branches: ["v1.0"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -9,7 +9,7 @@ env:
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: [ "v1.0" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Switch run-tests.yaml's pull_request trigger and jekyll-gh-pages.yml's push trigger from main to v1.0, so v1.0 PRs get tested and v1.0 is the source for the published docs site during the 1.0 maintenance window.