### PR TITLE
Disable Pages auto-deploy from main

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -7,10 +7,9 @@
 name: Deploy Jekyll site to Pages
 
 on:
-  push:
-    branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
+  # Auto-deploy from this branch is disabled while v1.0 is the docs source.
+  # The v1.0 branch's copy of this workflow handles scheduled deploys.
+  # This workflow can still be run manually from the Actions tab.
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION
v1.0 is the docs source for the 1.0 maintenance window. Pushes to main no longer republish the Pages site and clobber v1.0's content. Manual workflow_dispatch is still available if a one-off deploy from main is needed.