### PR TITLE
Fix native crash from corrupt offline pmtiles extracts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,6 +142,14 @@ android {
         release {
             isMinifyEnabled = true
             isShrinkResources = true
+            // Embed native debug symbols in the App Bundle so native (NDK) crashes
+            // symbolicate in Play Console / Crashlytics. Note: this can only extract
+            // symbols from libraries that still contain them - prebuilt third party
+            // libs that ship stripped (e.g. libmaplibre.so) must be symbolicated
+            // manually using their BuildId and the matching debug-symbols package.
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
             signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -158,6 +158,10 @@
         <intent>
             <action android:name="android.speech.RecognitionService" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.SENDTO" />
+            <data android:scheme="mailto" />
+        </intent>
     </queries>
 
 </manifest>

--- a/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/MainActivity.kt
@@ -2,6 +2,8 @@ package org.scottishtecharmy.soundscape
 
 import android.Manifest
 import android.accessibilityservice.AccessibilityServiceInfo
+import android.content.ActivityNotFoundException
+import android.content.ComponentName
 import android.content.Context
 import android.media.AudioDeviceInfo
 import android.media.AudioManager
@@ -652,9 +654,10 @@ class MainActivity : AppCompatActivity() {
         unknownOsmKeys.forEach { bodyText.append("\t$it<br/>") }
         bodyText.append("-----------------------------<br/><br/>")
 
+        val supportEmail = "soundscapeAndroid@scottishtecharmy.support"
         val intent = Intent(Intent.ACTION_SEND).apply {
             type = "message/rfc822"
-            putExtra(Intent.EXTRA_EMAIL, arrayOf("soundscapeAndroid@scottishtecharmy.support"))
+            putExtra(Intent.EXTRA_EMAIL, arrayOf(supportEmail))
             putExtra(Intent.EXTRA_SUBJECT, subjectText)
             putExtra(Intent.EXTRA_TEXT, Html.fromHtml(bodyText.toString(), 0))
         }
@@ -679,11 +682,39 @@ class MainActivity : AppCompatActivity() {
         }
 
         Log.e(TAG, Html.fromHtml(bodyText.toString(), 0).toString())
-        if (intent.resolveActivity(packageManager) != null) {
-            startActivity(intent)
+
+        // Send straight to the user's email app (no chooser) with the recipient,
+        // subject, body and log attachment all pre-filled. A selector or a plain
+        // ACTION_SEND chooser proved unreliable here: ACTION_SEND/message-rfc822
+        // also matches non-email share targets, and an ACTION_SENDTO selector
+        // fails to resolve under package-visibility filtering. We instead resolve
+        // the activity that handles mailto: (declared in <queries> in the manifest)
+        // and target the ACTION_SEND intent at that exact component. Targeting the
+        // package alone is not enough: the Gmail package also contains a Google
+        // Chat (Dynamite) ACTION_SEND handler, so setPackage() still shows a chooser.
+        val mailtoProbe = Intent(Intent.ACTION_SENDTO, "mailto:".toUri())
+        val emailActivity = packageManager.resolveActivity(mailtoProbe, 0)?.activityInfo
+        // resolveActivity returns the system "resolver/chooser" component when there
+        // are multiple email apps with no default - in that case leave it unset so the
+        // user picks among email apps rather than targeting the resolver itself.
+        val emailPackage = emailActivity?.packageName
+        val isSystemResolver = emailPackage == "android" || emailPackage == "com.android.intentresolver"
+        if (emailActivity != null && emailPackage != null && !isSystemResolver) {
+            Log.d(TAG, "Sending support email via $emailPackage/${emailActivity.name}")
+            intent.component = ComponentName(emailPackage, emailActivity.name)
         } else {
-            val alternativeIntent = Intent.createChooser(intent, "")
-            startActivity(alternativeIntent)
+            Log.d(TAG, "No single email app resolved (got $emailPackage), using chooser")
+        }
+        try {
+            startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            Log.w(TAG, "Targeted email launch failed, falling back to chooser", e)
+            intent.component = null
+            try {
+                startActivity(Intent.createChooser(intent, null))
+            } catch (e: ActivityNotFoundException) {
+                Log.e(TAG, "No app available to contact support", e)
+            }
         }
     }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
@@ -200,8 +200,9 @@ private fun getSourceUri(appContext: Context, location: LngLatAlt?, forceNetwork
 
         // Get locally downloaded files, excluding any that are corrupt or truncated.
         // Handing a bad .pmtiles file to MapLibre triggers an uncaught native exception
-        // (gzip metadata decompress failure) that aborts the whole app, so we validate
-        // up front and silently fall back to the network tile source instead.
+        // (gzip metadata decompress failure) that aborts the whole app, so we never
+        // select those - we fall back to the network tile source instead. Damaged
+        // extracts are surfaced to the user separately on the Offline Maps screen.
         val offlineExtractPaths =
             findExtractPaths(extractsPath + "/" + Environment.DIRECTORY_DOWNLOADS)
                 .filter { isPmtilesUsable(it) }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
@@ -70,6 +70,7 @@ import org.scottishtecharmy.soundscape.geoengine.MAX_ZOOM_LEVEL
 import org.scottishtecharmy.soundscape.geoengine.PROTOMAPS_SERVER_PATH
 import org.scottishtecharmy.soundscape.geoengine.utils.getXYTile
 import org.scottishtecharmy.soundscape.utils.findExtractPaths
+import org.scottishtecharmy.soundscape.utils.isPmtilesUsable
 import kotlin.io.path.Path
 import kotlin.io.path.fileSize
 
@@ -197,8 +198,13 @@ private fun getSourceUri(appContext: Context, location: LngLatAlt?, forceNetwork
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(appContext)
         val extractsPath = sharedPreferences.getString(MainActivity.SELECTED_STORAGE_KEY, MainActivity.SELECTED_STORAGE_DEFAULT)!!
 
-        // Get locally downloaded files
-        val offlineExtractPaths =  findExtractPaths(extractsPath + "/" + Environment.DIRECTORY_DOWNLOADS)
+        // Get locally downloaded files, excluding any that are corrupt or truncated.
+        // Handing a bad .pmtiles file to MapLibre triggers an uncaught native exception
+        // (gzip metadata decompress failure) that aborts the whole app, so we validate
+        // up front and silently fall back to the network tile source instead.
+        val offlineExtractPaths =
+            findExtractPaths(extractsPath + "/" + Environment.DIRECTORY_DOWNLOADS)
+                .filter { isPmtilesUsable(it) }
         if(offlineExtractPaths.isNotEmpty()) {
             if(location == null){
                 urlReplacement = "pmtiles://file://${offlineExtractPaths[0]}"

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/OfflineMapsScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/home/OfflineMapsScreen.kt
@@ -12,9 +12,13 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Warning
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -262,6 +266,27 @@ fun OfflineExtract(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurface,
                     )
+                }
+                // Flag damaged downloaded extracts. The "usable" property is only set for
+                // downloaded extracts (by findExtracts), so nearby/available extracts are
+                // never flagged. A damaged extract can't be used by the map (it would crash
+                // MapLibre) and needs re-downloading.
+                val usable = extract.properties?.get("usable") as? Boolean
+                if (usable == false) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Rounded.Warning,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(spacing.medium)
+                        )
+                        Text(
+                            text = stringResource(R.string.offline_maps_extract_damaged),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.padding(start = spacing.tiny)
+                        )
+                    }
                 }
             }
             Text(

--- a/app/src/main/java/org/scottishtecharmy/soundscape/utils/OfflineDownloader.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/utils/OfflineDownloader.kt
@@ -127,6 +127,14 @@ class OfflineDownloader {
                             saveFile(this, body, tempFile.path) { progress ->
                                 _downloadState.value = DownloadState.Downloading(progress)
                             }
+                            // Verify the download is intact before publishing it. A
+                            // truncated or corrupt .pmtiles extract crashes MapLibre
+                            // natively when opened, so reject it here and let the user
+                            // retry rather than persisting a file that will abort the app.
+                            if (finalFile.name.endsWith(".pmtiles") &&
+                                !isPmtilesUsable(tempFile.path)) {
+                                throw Exception("Downloaded extract failed validation (corrupt or truncated)")
+                            }
                             retries = 0
                             // Delete any file that already exists
                             finalFile.delete()

--- a/app/src/main/java/org/scottishtecharmy/soundscape/utils/StorageUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/utils/StorageUtils.kt
@@ -159,9 +159,17 @@ fun findExtracts(path: String) : FeatureCollection? {
         val extractCollection = FeatureCollection()
         for(file in files) {
             val feature = getMetadata(file.path)
-            if(feature != null)
+            if(feature != null) {
+                // Validate the extract so callers can show whether it is working or
+                // damaged. A damaged extract (its metadata won't decompress) would crash
+                // MapLibre if used, so it is excluded from the live map; here we flag it
+                // via the "usable" property instead. This does file I/O, so callers
+                // should run findExtracts off the main thread.
+                val properties = feature.properties ?: HashMap()
+                properties["usable"] = isPmtilesUsable(file.path)
+                feature.properties = properties
                 extractCollection.addFeature(feature)
-            else
+            } else
                 println("No metadata")
         }
         return extractCollection

--- a/app/src/main/java/org/scottishtecharmy/soundscape/utils/StorageUtils.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/utils/StorageUtils.kt
@@ -169,6 +169,35 @@ fun findExtracts(path: String) : FeatureCollection? {
     return null
 }
 
+/**
+ * Check that a .pmtiles extract is safe to hand to MapLibre as a tile source.
+ *
+ * MapLibre's native PMTilesFileSource decompresses the gzip-compressed JSON metadata
+ * section as soon as it opens the source. That decompress call
+ * (mbgl::util::decompress, compression.cpp:98) is NOT wrapped in a try/catch in
+ * PMTilesFileSource::Impl::getMetadata (pmtiles_file_source.cpp:389), so a corrupt or
+ * truncated extract makes it throw std::runtime_error. The exception escapes MapLibre's
+ * file-source worker thread, reaches std::terminate and aborts the whole process - a
+ * native crash we cannot catch from Kotlin.
+ *
+ * To avoid that we open the file with the same Reader we already depend on and force the
+ * identical metadata decompression here, where the exception IS catchable. If it throws,
+ * the extract is corrupt and must not be used.
+ */
+fun isPmtilesUsable(path: String): Boolean {
+    return try {
+        ch.poole.geo.pmtiles.Reader(File(path)).use { reader ->
+            // Forces decompression of the gzip metadata - the exact operation that
+            // crashes MapLibre natively when the file is corrupt or truncated.
+            reader.metadata
+        }
+        true
+    } catch (e: Exception) {
+        Log.e(StorageUtils.TAG, "Rejecting unusable pmtiles extract $path: ${e.message}")
+        false
+    }
+}
+
 fun findExtractPaths(path: String) : List<String> {
     // Find any extracts that we have downloaded
     val extractsDir = File(path)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/OfflineMapsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/OfflineMapsViewModel.kt
@@ -12,9 +12,11 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.scottishtecharmy.soundscape.BuildConfig
 import org.scottishtecharmy.soundscape.MainActivity
 import org.scottishtecharmy.soundscape.SoundscapeServiceConnection
@@ -93,7 +95,9 @@ class OfflineMapsViewModel @AssistedInject constructor(
                 MainActivity.SELECTED_STORAGE_KEY,
                 MainActivity.SELECTED_STORAGE_DEFAULT
             )!!
-            val extractCollection = findExtracts(File(path, Environment.DIRECTORY_DOWNLOADS).path)
+            val extractCollection = withContext(Dispatchers.IO) {
+                findExtracts(File(path, Environment.DIRECTORY_DOWNLOADS).path)
+            }
             _uiState.value = _uiState.value.copy(
                 downloadedExtracts = extractCollection,
                 storages = storages,
@@ -204,12 +208,17 @@ class OfflineMapsViewModel @AssistedInject constructor(
     }
 
     fun refreshExtracts() {
-        // Update the UI to reflect the deletions
-        val extractsDir = File(_uiState.value.currentPath, Environment.DIRECTORY_DOWNLOADS)
-        val extractCollection = findExtracts(extractsDir.path)
-        _uiState.value = _uiState.value.copy(
-            downloadedExtracts = extractCollection
-        )
+        // Update the UI to reflect the deletions. findExtracts validates each extract
+        // (file I/O), so run it off the main thread.
+        viewModelScope.launch {
+            val extractsDir = File(_uiState.value.currentPath, Environment.DIRECTORY_DOWNLOADS)
+            val extractCollection = withContext(Dispatchers.IO) {
+                findExtracts(extractsDir.path)
+            }
+            _uiState.value = _uiState.value.copy(
+                downloadedExtracts = extractCollection
+            )
+        }
     }
 
     companion object {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -978,6 +978,8 @@
 <string name="offline_maps_storage">"Maps are saved to %1$s which has %2$s free"</string>
 <!-- Offscreen maps title of list of downloaded maps-->
 <string name="offline_maps_already_downloaded">"Maps already downloaded"</string>
+<!-- Status shown on a downloaded offline map that is damaged and must be re-downloaded-->
+<string name="offline_maps_extract_damaged">"Damaged - delete and download again"</string>
 <!-- Offscreen maps title of list of nearby maps-->
 <string name="offline_maps_nearby">"Nearby offline maps"</string>
 <!-- Offscreen maps text shown whilst downloading offline map manifest -->


### PR DESCRIPTION
MapLibre's PMTilesFileSource decompresses the gzip JSON metadata when it opens a source (pmtiles_file_source.cpp:389 -> mbgl::util::decompress, compression.cpp:98). That decompress throws on a corrupt/truncated file and is not wrapped in a try/catch, so the exception escapes MapLibre's file-source worker thread, hits std::terminate and aborts the process - a native crash we cannot catch from Kotlin.

Guard against it app-side:
- Add isPmtilesUsable() which opens the extract with the existing pmtiles Reader and forces the same metadata decompression, where the exception is catchable.
- Filter offline extracts through it in getSourceUri() before handing them to MapLibre, falling back to the network tile source. Also fixes the location==null branch which previously used extract[0] unvalidated.
- Validate freshly downloaded extracts before publishing them so a corrupt download surfaces a retriable error instead of a file that aborts the app.

Also enable ndk debugSymbolLevel=FULL for release so native crashes in our own C++ symbolicate in Play Console / Crashlytics.