### PR TITLE
Handle missing clear text button in Maestro test

### DIFF
--- a/maestro/MarkersAndRoutes.yaml
+++ b/maestro/MarkersAndRoutes.yaml
@@ -42,7 +42,8 @@ appId: org.scottishtecharmy.soundscape
 - tapOn:
     id: locationDetailsEditMarker
 - tapOn:
-        id: notes-clearTextField
+    id: notes-clearTextField
+    optional: true      # If the notes are empty, then there's no clear text button
 - tapOn:
     id: markerAnnotation
 - inputText: "Updated by Maestro"


### PR DESCRIPTION
If a text input box is empty, then there's no clear button to tap on.