### PR TITLE
Add all of our translations to the github pages website

### DIFF
--- a/.github/workflows/generate-help-docs.yaml
+++ b/.github/workflows/generate-help-docs.yaml
@@ -1,0 +1,106 @@
+name: Generate localized help docs
+
+# Regenerates the user help pages (docs/users/help-*.md) in every supported
+# language from the app's string resources. The pages are produced by the
+# `DocumentationScreens.getHelp` instrumentation test, which needs an emulator,
+# so this can't run inside the lightweight Jekyll Pages build. Instead this
+# workflow runs the test, pulls the generated markdown off the emulator and
+# commits it to v1.0 — which in turn triggers the Pages deploy.
+
+env:
+  main_project_module: app
+
+on:
+  # Run manually, and weekly so translations merged from Weblate get picked up.
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * 1"   # Mondays 04:00 UTC
+
+# Needed to commit the regenerated docs back to the repository.
+permissions:
+  contents: write
+
+# Don't pile up runs; a newer run supersedes an in-flight one.
+concurrency:
+  group: "generate-help-docs"
+  cancel-in-progress: true
+
+jobs:
+  generate-help:
+    runs-on: ubuntu-latest
+    environment: development
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: v1.0
+          fetch-depth: 0
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: '19'
+
+      # getHelp() itself only needs string resources, but the app/test build
+      # reads the providers from local.properties, so populate them as the
+      # other workflows do.
+      - name: Setup tile and search providers
+        env:
+          TILE_PROVIDER_API_KEY: ${{ secrets.TILE_PROVIDER_API_KEY }}
+          TILE_PROVIDER_URL: ${{ secrets.TILE_PROVIDER_URL }}
+          SEARCH_PROVIDER_API_KEY: ${{ secrets.SEARCH_PROVIDER_API_KEY }}
+          SEARCH_PROVIDER_URL: ${{ secrets.SEARCH_PROVIDER_URL }}
+          EXTRACT_PROVIDER_URL: ${{ secrets.EXTRACT_PROVIDER_URL }}
+        run: |
+          echo tileProviderUrl="$TILE_PROVIDER_URL" > local.properties
+          echo tileProviderApiKey="$TILE_PROVIDER_API_KEY" >> local.properties
+          echo searchProviderUrl="$SEARCH_PROVIDER_URL" >> local.properties
+          echo searchProviderApiKey="$SEARCH_PROVIDER_API_KEY" >> local.properties
+          echo extractProviderUrl="$EXTRACT_PROVIDER_URL" >> local.properties
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Generate help markdown on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: default
+          arch: x86_64
+          script: |
+            adb root
+            # Run only the doc-generation test (skips the heavy screenshot tests).
+            # The test creates its own output directory (via getExternalFilesDir +
+            # mkdirs) so the app owns it and can write to it — don't pre-create it
+            # here with adb, or the app process hits EACCES.
+            ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.scottishtecharmy.soundscape.DocumentationScreens#getHelp
+            mkdir -p generated-help
+            adb pull /storage/emulated/0/Android/data/org.scottishtecharmy.soundscape/files/Documents/help/. generated-help/
+
+      - name: Sync generated markdown into docs/users
+        run: |
+          # Remove stale localized files (help-<slug>.<lang>.md — two dots) so dropped
+          # locales/pages don't linger. The English base files (help-<slug>.md) and any
+          # hand-authored pages (e.g. help-beacon-styles.md) are left in place and the
+          # English ones are overwritten by the copy below.
+          find docs/users -name 'help-*.*.md' -delete
+          cp generated-help/*.md docs/users/
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name  "soundscape-bot"
+          git config user.email "soundscapeAndroid@scottishtecharmy.support"
+          git add docs/users/help-*.md
+          if git diff --cached --quiet; then
+            echo "No changes to localized help docs."
+          else
+            git commit -m "Regenerate localized help docs from string resources"
+            git push origin HEAD:v1.0
+          fi

--- a/app/src/androidTest/java/org/scottishtecharmy/soundscape/DocumentationScreens.kt
+++ b/app/src/androidTest/java/org/scottishtecharmy/soundscape/DocumentationScreens.kt
@@ -1,6 +1,9 @@
 package org.scottishtecharmy.soundscape
 
+import android.content.Context
+import android.content.res.Configuration
 import android.os.Environment
+import android.os.LocaleList
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -37,6 +40,7 @@ import org.scottishtecharmy.soundscape.utils.processMaps
 import org.scottishtecharmy.soundscape.viewmodels.home.HomeState
 import java.io.File
 import java.io.FileOutputStream
+import java.util.Locale
 
 fun String.toSafeFilename(replacement: String = "-"): String {
     val illegalCharsRegex = """[/:\\?*"<>|#%&{}^`~ ]""".toRegex()
@@ -284,63 +288,157 @@ class DocumentationScreens {
         }
     }
 
+    // Maps each Android resource qualifier to its web / BCP-47 (jekyll-polyglot)
+    // language code. The default language "en" is emitted with no filename suffix.
+    // Source of truth for the supported set: app/build.gradle.kts resourceConfigurations.
+    // Keep this in sync with the `languages` list in docs/_config.yml.
+    private val localeMap: Map<String, String> = mapOf(
+        "en" to "en",          // default -> no suffix, no `lang:` front matter
+        "arz" to "arz",
+        "zh-rCN" to "zh-CN",
+        "da" to "da",
+        "de" to "de",
+        "el" to "el",
+        "en-rGB" to "en-GB",
+        "es" to "es",
+        "fa" to "fa",
+        "fi" to "fi",
+        "fr" to "fr",
+        "fr-rCA" to "fr-CA",
+        "hi" to "hi",
+        "is" to "is",
+        "it" to "it",
+        "ja" to "ja",
+        "nb" to "nb",
+        "nl" to "nl",
+        "pl" to "pl",
+        "pt" to "pt",
+        "pt-rBR" to "pt-BR",
+        "ro" to "ro",
+        "ru" to "ru",
+        "sv" to "sv",
+        "tr" to "tr",
+        "uk" to "uk",
+    )
+
+    /** Returns a Context whose getString() resolves strings in [webLang]. */
+    private fun localizedContext(base: Context, webLang: String): Context {
+        val locale = Locale.forLanguageTag(webLang)   // "fr-CA", "pt-BR", "zh-CN" all resolve
+        val config = Configuration(base.resources.configuration).apply {
+            setLocales(LocaleList(locale))
+        }
+        return base.createConfigurationContext(config)
+    }
+
+    /**
+     * Builds the markdown for a single help page rendered in [ctx]'s locale.
+     *
+     * @param baseCtx the English context, used to detect whether anything on the page is
+     *   actually translated (a missing string silently falls back to English).
+     * @return the markdown, and whether at least one string differed from English.
+     */
+    private fun buildPageMarkdown(
+        ctx: Context,
+        baseCtx: Context,
+        page: org.scottishtecharmy.soundscape.screens.home.home.Sections,
+        webLang: String,
+        slug: String
+    ): Pair<String, Boolean> {
+        var translated = false
+        fun localized(resId: Int): String {
+            val text = ctx.getString(resId)
+            if (text != baseCtx.getString(resId)) translated = true
+            return text
+        }
+
+        val pageTitle = localized(page.titleId)
+
+        val sb = StringBuilder()
+        sb.append("---\n")
+        sb.append("title: $pageTitle\n")
+        sb.append("layout: page\n")
+        // Language-invariant parent key: the English "Using Soundscape" parent page
+        // (user.md) falls back into every language tree, so localized children attach to it.
+        sb.append("parent: Using Soundscape\n")
+        sb.append("has_toc: false\n")
+        if (webLang != "en") {
+            sb.append("lang: $webLang\n")
+            // Pin the permalink to the English page's URL so jekyll-polyglot matches this
+            // file (by page_id, which it derives from the URL) to its English sibling and
+            // serves it at /<lang>/users/help-<slug>.html instead of a separate URL.
+            sb.append("permalink: /users/help-$slug.html\n")
+        }
+        sb.append("---\n\n")
+
+        sb.append("# ")
+        sb.append(pageTitle)
+        sb.append("\n")
+        for (section in page.sections) {
+            when (section.type) {
+                SectionType.Faq -> {
+                    sb.append("\n")
+                    sb.append("### ")
+                    sb.append(localized(section.textId))
+                    sb.append("\n")
+                    sb.append(localized(section.faqAnswer))
+                }
+                SectionType.Title -> {
+                    sb.append("\n")
+                    sb.append("## ")
+                    sb.append(localized(section.textId))
+                }
+                else -> {
+                    sb.append("\n")
+                    sb.append(localized(section.textId))
+                }
+            }
+            sb.append("\n")
+        }
+        sb.append("\n")
+
+        return Pair(sb.toString(), translated)
+    }
+
     @Test
     fun getHelp() {
 
-        val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val base = InstrumentationRegistry.getInstrumentation().targetContext
 
         val helpDir = File(
-            targetContext.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS),
+            base.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS),
             "help"
         )
         if (!helpDir.exists()) {
             helpDir.mkdirs()
         }
 
-        for (page in helpPages) {
+        for ((_, webLang) in localeMap) {
+            val ctx = if (webLang == "en") base else localizedContext(base, webLang)
 
-            if(page.titleId == R.string.menu_help)
-                continue
-            val pageTitle = targetContext.getString(page.titleId)
+            for (page in helpPages) {
 
-            val markdownOutput = StringBuilder()
-            markdownOutput.append("---\n")
-            markdownOutput.append("title: $pageTitle\n")
-            markdownOutput.append("layout: page\n")
-            markdownOutput.append("parent: Using Soundscape\n")
-            markdownOutput.append("has_toc: false\n")
-            markdownOutput.append("---\n\n")
+                if (page.titleId == R.string.menu_help)
+                    continue
 
-            markdownOutput.append("# ")
-            markdownOutput.append(pageTitle)
-            markdownOutput.append("\n")
-            for(section in page.sections) {
-                when (section.type) {
-                    SectionType.Faq -> {
-                        markdownOutput.append("\n")
-                        markdownOutput.append("### ")
-                        markdownOutput.append(targetContext.getString(section.textId))
-                        markdownOutput.append("\n")
-                        markdownOutput.append(targetContext.getString(section.faqAnswer))
-                    }
-                    SectionType.Title -> {
-                        markdownOutput.append("\n")
-                        markdownOutput.append("## ")
-                        markdownOutput.append(targetContext.getString(section.textId))
-                    }
-                    else -> {
-                        markdownOutput.append("\n")
-                        markdownOutput.append(targetContext.getString(section.textId))
-                    }
-                }
-                markdownOutput.append("\n")
+                // Slug always comes from the English title so all languages of one page
+                // share a base name (help-routes.md / help-routes.de.md) and the same
+                // permalink, which is how polyglot pairs them.
+                val slug = base.getString(page.titleId).toSafeFilename()
+
+                val (markdown, translated) = buildPageMarkdown(ctx, base, page, webLang, slug)
+
+                // Skip non-default locales with nothing translated on this page: polyglot
+                // will serve the English fallback rather than a page mislabelled as `lang:`.
+                if (webLang != "en" && !translated)
+                    continue
+
+                val suffix = if (webLang == "en") "" else ".$webLang"
+
+                val file = File(helpDir, "help-$slug$suffix.md")
+                val outputFile = FileOutputStream(file)
+                outputFile.write(markdown.toByteArray())
+                outputFile.close()
             }
-            markdownOutput.append("\n")
-
-            val file = File(helpDir, "help-${pageTitle.toSafeFilename()}.md")
-            val outputFile = FileOutputStream(file)
-            outputFile.write(markdownOutput.toString().toByteArray())
-            outputFile.close()
         }
     }
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/utils/Locale.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/utils/Locale.kt
@@ -22,7 +22,7 @@ fun getCurrentLocale() : Locale {
  */
 val supportedLanguages = listOf(
     Language("العربية المصرية", "arz", "EG"),
-    Language("中国人", "zh", "CN"),
+    Language("中文 (简体)", "zh", "CN"),
     Language("Dansk", "da", "DK"),
     Language("Deutsch", "de", "DE"),
     Language("Ελληνικά", "el", "GR"),

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,11 @@
+# Local Jekyll build artifacts (the site is built in CI by jekyll-gh-pages.yml)
+_site/
+.jekyll-cache/
+.jekyll-metadata
+# Local bundler install (CI uses bundler-cache instead)
+.bundle/
+vendor/
+Gemfile.lock
+# Generated locally before the Jekyll build (committed copies live elsewhere / are CI-generated)
+_includes/beacon-styles.md
+dokka/

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gem "jekyll"
 gem "webrick"
 gem "just-the-docs"
+gem "jekyll-polyglot"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,3 +10,22 @@ aux_links:
 
 mermaid:
   version: "11.8.1"
+
+# --- Multilingual support (jekyll-polyglot) ---
+# Allowed because the site is built with `bundle exec jekyll build` in a custom
+# GitHub Actions workflow (not the plugin-restricted native GitHub Pages build).
+plugins:
+  - jekyll-polyglot
+
+# Web/BCP-47 language codes. The help-page generator maps Android resource
+# qualifiers (zh-rCN, fr-rCA, pt-rBR, en-rGB) to these. Source of truth for the
+# supported set: app/build.gradle.kts resourceConfigurations.
+languages: ["en", "arz", "da", "de", "el", "en-GB", "es", "fa", "fi", "fr", "fr-CA",
+            "hi", "is", "it", "ja", "nb", "nl", "pl", "pt", "pt-BR", "ro", "ru", "sv",
+            "tr", "uk", "zh-CN"]
+default_lang: "en"
+# Untranslated pages fall back to the default_lang version under every /<lang>/ URL.
+exclude_from_localization: ["assets", "dokka", "documentationScreens", "javascript", "*.svg", "*.png", "generate-beacons.py"]
+# Keep serial for now: just-the-docs nav generation can race under polyglot's
+# parallel mode. Revisit only if build time becomes a problem.
+parallel_localization: false

--- a/docs/_data/languages.yml
+++ b/docs/_data/languages.yml
@@ -1,0 +1,30 @@
+# Display names for the header language switcher, keyed by the web/BCP-47 code
+# used in _config.yml `languages`. Native names (autonyms) match the app's
+# language picker — see supportedLanguages in
+# app/src/main/java/org/scottishtecharmy/soundscape/utils/Locale.kt.
+en: English
+arz: العربية المصرية
+zh-CN: 中文 (简体)
+da: Dansk
+de: Deutsch
+el: Ελληνικά
+en-GB: English (UK)
+es: Español
+fa: فارسی
+fi: Suomi
+fr: Français (France)
+fr-CA: Français (Canada)
+hi: हिंदी
+is: Íslenska
+it: Italiano
+ja: 日本語
+nb: Norsk
+nl: Nederlands
+pl: Polski
+pt: Português (Portugal)
+pt-BR: Português (Brasil)
+ro: Română
+ru: Русский
+sv: Svenska
+tr: Türkçe
+uk: Українська

--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -1,0 +1,25 @@
+{%- comment -%}
+  Language switcher, rendered by just-the-docs in components/header.html.
+  Uses jekyll-polyglot variables (site.languages, site.default_lang,
+  site.active_lang). During a language render pass page.url is the unprefixed
+  page path, so we build the target URL by prefixing the language code (except
+  for the default language, which lives at the site root). Untranslated pages
+  fall back to the default-language content at the same URL, so every option
+  resolves to a valid page.
+{%- endcomment -%}
+{%- if site.languages.size > 1 -%}
+<div class="lang-switcher" style="display:flex;align-items:center;padding:0 0.75rem;">
+  <select aria-label="Language"
+          onchange="if(this.value){window.location.href=this.value;}"
+          style="max-width:14rem;">
+    {%- for lang in site.languages -%}
+      {%- if lang == site.default_lang -%}
+        {%- assign lang_path = page.url -%}
+      {%- else -%}
+        {%- capture lang_path -%}/{{ lang }}{{ page.url }}{%- endcapture -%}
+      {%- endif -%}
+      <option value="{{ lang_path | relative_url }}"{% if lang == site.active_lang %} selected{% endif %}>{{ site.data.languages[lang] | default: lang }}</option>
+    {%- endfor -%}
+  </select>
+</div>
+{%- endif -%}

--- a/docs/developers/developers.md
+++ b/docs/developers/developers.md
@@ -66,4 +66,4 @@ If you would like access to the main Soundscape tile provider for development, g
 * [Unit test example]({% link developers/unit-test-example.md %}) — using host-side unit tests with real map data to prototype and debug geo features.
 
 ## Reference
-* [Dokka generated docs]({% link dokka/index.html %}) — API docs auto-generated from KDoc comments.
+* [Dokka generated docs]({{ "/dokka/index.html" | relative_url }}) — API docs auto-generated from KDoc comments.

--- a/docs/developers/dokka.md
+++ b/docs/developers/dokka.md
@@ -4,4 +4,4 @@ layout: page
 parent: Information for developers
 has_toc: false
 ---
-We use Dokka to generate documentation for the code which can be found [here]({% link dokka/index.html %}).
+We use Dokka to generate documentation for the code which can be found [here]({{ "/dokka/index.html" | relative_url }}).

--- a/docs/developers/translations.md
+++ b/docs/developers/translations.md
@@ -34,6 +34,7 @@ Whole new languages can be added via the Weblate UI and generally the translatio
 * Add the language to `getAllLanguages` in `LanguageScreen.kt`. This also requires the name of the language in that language e.g. Español for Spanish.
 * Also add the language to `MockLanguagePreviewData` in `LanguageScreen.kt` so that the `@Preview` of the `LanguageScreen` remains accurate.
 * Edit `res/xml/locales_config.xml` to include the new language code. This is the list of languages that the app advertises to Android. The list is used within Android to show the user what languages are supported by an app and allow per-app language configuration.
+* Add the language to the documentation website so the localized help pages are generated and served (see [The documentation website](#the-documentation-website) below): add an entry to `localeMap` in `DocumentationScreens.kt` (mapping the Android resource qualifier to its web/BCP-47 code) and add the same web code to the `languages` list in `docs/_config.yml`.
 
 ## AI translations
 Unfortunately, we don't currently have native speakers helping with translation in the majority of languages that we support and so we needed an additional approach. We want to try and ensure that the translations don't get left behind as we add new features which require new text. It's also quite a big task to add a new translation and so we looked at ways of accelerating that.
@@ -50,6 +51,55 @@ One of the issues with translating Soundscape is that it has some rather unique 
 2. The glossary is passed into OpenAI as context along with all of the terms to be translated by a [Python Script](https://github.com/davecraig/weblate-translate/blob/main/weblate-translation.py). The aim is to maintain a consistency of terms across the translation.
 
 The resulting translation can then be uploaded into Weblate either as Suggestions for the translator or as approved translations.
+
+## The documentation website
+
+This website is built with [Jekyll](https://jekyllrb.com/) and the [just-the-docs](https://just-the-docs.com/) theme, and is published to GitHub Pages by the `jekyll-gh-pages.yml` workflow. It is multilingual via the [`jekyll-polyglot`](https://github.com/untra/polyglot) plugin: every supported language gets its own URL subtree (e.g. `/de/`, `/fr-CA/`) and a language switcher appears in the header. Pages that have no translation in a given language fall back to the English version automatically, so the developer documentation (which is English-only) still appears under every language.
+
+### Localized help pages come from the app's strings
+
+The user help pages (`docs/users/help-*.md`) are **generated**, not hand-written. They are produced by the `getHelp` test in `app/src/androidTest/.../DocumentationScreens.kt`, which walks the `helpPages` structure in `HelpScreen.kt` and emits markdown using `context.getString(...)`. Because `getString` is locale-aware, the test loops over every supported locale (using a context built with `createConfigurationContext`) and emits one markdown file per page per language:
+
+* English is written with no suffix, e.g. `help-routes.md`.
+* Each other language is written with its web/BCP-47 code as a suffix, e.g. `help-routes.de.md`, and carries a `lang:` entry plus a `permalink:` pinned to the English page's URL (e.g. `permalink: /users/help-routes.html`). polyglot matches translations by URL, so the shared permalink is what makes it serve the German file at `/de/users/help-routes.html` rather than a separate URL.
+* A locale that has nothing translated on a page is skipped, so polyglot serves the English fallback rather than a page mislabelled as translated.
+
+The set of locales lives in `localeMap` in `DocumentationScreens.kt`, which mirrors `resourceConfigurations` in `app/build.gradle.kts` and must stay in sync with the `languages` list in `docs/_config.yml`.
+
+### Regenerating the help pages
+
+The `generate-help-docs.yaml` workflow runs `getHelp` on an emulator, pulls the generated markdown off the device, and commits any changes to `v1.0` (which triggers the Pages deploy). It runs weekly and can be triggered manually from the Actions tab — run it after a batch of Weblate translations has landed.
+
+To regenerate locally instead:
+
+1. Run only the doc-generation test on a connected device/emulator:
+   ```
+   ./gradlew connectedDebugAndroidTest \
+     -Pandroid.testInstrumentationRunnerArguments.class=org.scottishtecharmy.soundscape.DocumentationScreens#getHelp
+   ```
+2. Pull the generated files into the repo:
+   ```
+   adb pull /storage/emulated/0/Android/data/org.scottishtecharmy.soundscape/files/Documents/help/. docs/users/
+   ```
+3. Review the diff and commit. (`help-beacon-styles.md` is hand-authored — it is not produced by the test, so leave it in place.)
+
+### Pages not driven by strings
+
+`how-it-works.md`, `index.md` and the legal pages are hand-authored and not part of `strings.xml`, so they are currently English only and rely on polyglot's English fallback under each `/<lang>/` URL. A translation can be added later by committing a per-language variant (e.g. `index.de.md` with `lang: de`). The legal pages (privacy policy, terms and conditions) should only ever be translated by a human reviewer — do not machine-translate them.
+
+### Linking to localized pages
+
+Do **not** use Jekyll's {% raw %}`{% link users/help-….md %}`{% endraw %} tag to link to a help page (or any other page that has translations). The {% raw %}`{% link %}`{% endraw %} tag resolves by *source filename*, but in each non-default language pass polyglot replaces the English page with its localized variant in the document set — so the English source filename is not found and the build fails with `Could not find document … in tag 'link'`.
+
+Instead, link to such pages by URL so polyglot can rewrite it to the active language:
+
+{% raw %}
+```
+[Help using Media Controls]({{ "/users/help-using-media-controls.html" | relative_url }})
+```
+{% endraw %}
+
+{% raw %}`{% link %}`{% endraw %} is still fine for English-only pages (developer docs, `user.md`, `how-it-works.md`), because their English source stays in every language pass.
 
 ## Weblate usage tips
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,10 +20,8 @@ The app carries on working in the background when the phone in a pocket or bag -
 
 Soundscape was originally developed on iOS by [Microsoft Research](https://www.microsoft.com/en-us/research/product/soundscape/) and was widely used before being open sourced in 2022. The [Scottish Tech Army](https://www.scottishtecharmy.org) has kept it available on iOS and also rewritten it as an open-source Android app.
 
-<a href="https://play.google.com/store/apps/details?id=org.scottishtecharmy.soundscape"> <img src="GetItOnGooglePlay_Badge_Web_color_English.svg" alt="Get Soundscape on Google Play Store" height=80></a>
-<a href="https://apps.apple.com/gb/app/soundscape/id6459021379"> <img 
-src="Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.svg" alt="Get Soundscape on Apple App 
-Store" height=80></a>
+<a href="https://play.google.com/store/apps/details?id=org.scottishtecharmy.soundscape"> <img src="{{ "/GetItOnGooglePlay_Badge_Web_color_English.svg" | relative_url }}" alt="Get Soundscape on Google Play Store" height=80></a>
+<a href="https://apps.apple.com/gb/app/soundscape/id6459021379"> <img src="{{ "/Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.svg" | relative_url }}" alt="Get Soundscape on Apple App Store" height=80></a>
 
 # Soundscape support
 The email address <soundscapeAndroid@scottishtecharmy.support> links straight into our help desk system. Please send in any feedback you have, whether it's a feature request or a bug report. You'll receive an automated email in response and we'll get pinged that there's a new ticket to look at and we'll try and answer it as quickly as possible.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,7 +8,7 @@ has_toc: false
 # Release notes
 
 # 0.4.x
-0.4 releases add some new means of controlling the app remotely through using headphone media controls and speech recognition. For more information see [Help using Media Controls]({% link users/help-using-media-controls.md %}).
+0.4 releases add some new means of controlling the app remotely through using headphone media controls and speech recognition. For more information see [Help using Media Controls]({{ "/users/help-using-media-controls.html" | relative_url }}).
 Smaller fixes include:
 * Add an onboarding screen to give the user the ability to allow the app to run unhindered when the phone is locked. This is important for phone manufacturers which run more aggressive battery optimization which can stop Soundscape running.
 * Tapping any of the Hear My Surroundings buttons will cancel any which were already in progress. For example, tapping My Location and then tapping it again will stop the speech.

--- a/docs/testing/test-instructions.md
+++ b/docs/testing/test-instructions.md
@@ -36,7 +36,7 @@ Please report any of these issues via the Help Desk.
 Now that you're past the onboarding screens, you shouldn't see them again and you should be on 
 the main screen:
 
-<img src="../documentationScreens/homeScreen.png" width="200" alt="Screenshot of the Soundscape home screen">
+<img src="{{ "/documentationScreens/homeScreen.png" | relative_url }}" width="200" alt="Screenshot of the Soundscape home screen">
 
 Soundscape will now continue to run in the background. To exit it, click on the top right corner 
 to put the app to sleep, and then close the app (swipe up etc.).


### PR DESCRIPTION
We already have translations for all of the docs as they come from the app strings. Extend the website to support all of these languages. Fixed the translation of Chinese to be the language and not the people.