### PR TITLE
Improve maestro github actions

### DIFF
--- a/.github/workflows/maestro-only-pr.yaml
+++ b/.github/workflows/maestro-only-pr.yaml
@@ -1,0 +1,56 @@
+name: Maestro-only PR tests
+
+# When a PR changes only files under maestro/, there is no app code to rebuild,
+# so skip the full build/test pipeline and instead run the Maestro UI flows
+# against the latest GitHub release. This lets Maestro flows be iterated on
+# without waiting for an app build.
+
+on:
+  pull_request:
+    branches: [ "v1.0" ]
+    paths:
+      - 'maestro/**'
+
+jobs:
+  # The paths filter above triggers the workflow if ANY changed file is under
+  # maestro/, but the PR could also touch files elsewhere. This job confirms the
+  # PR touches ONLY maestro/ files before the Maestro run is gated on it.
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      only_maestro: ${{ steps.check.outputs.only_maestro }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check only maestro files changed
+        id: check
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Three-dot diff compares HEAD against the merge-base, i.e. exactly the
+          # files this PR changes relative to where it branched.
+          changed=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")
+          echo "Changed files:"
+          echo "$changed"
+          only=true
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              maestro/*) ;;
+              *) only=false ;;
+            esac
+          done <<< "$changed"
+          echo "Only maestro files changed: $only"
+          echo "only_maestro=$only" >> "$GITHUB_OUTPUT"
+
+  # Run the Maestro UI tests against the latest GitHub release. Calling the
+  # reusable workflow with no apk_artifact makes it download and install the
+  # latest release APK (see run-maestro-tests.yaml).
+  maestro:
+    needs: check-paths
+    if: needs.check-paths.outputs.only_maestro == 'true'
+    uses: ./.github/workflows/run-maestro-tests.yaml
+    secrets: inherit

--- a/.github/workflows/run-maestro-tests.yaml
+++ b/.github/workflows/run-maestro-tests.yaml
@@ -40,6 +40,38 @@ jobs:
     permissions:
       contents: read
 
+    # Run the suite across a matrix of API levels, screen sizes and languages so
+    # the flows are exercised on small and large screens, on API 31 and 35, and
+    # in both English and Japanese. Four combinations: small and large each run
+    # on API 31 and 35, and the API 35 large run is done in Japanese. fail-fast
+    # is off so one failing combination doesn't cancel the others.
+    strategy:
+      fail-fast: false
+      matrix:
+        # target is per-leg: API 31 has a "default" x86_64 system image, but API
+        # 35 doesn't reliably, so it uses "google_apis" instead.
+        include:
+          - api-level: 31
+            target: default
+            screen: small
+            profile: small_phone
+            locale: en-US
+          - api-level: 31
+            target: default
+            screen: large
+            profile: pixel_6
+            locale: en-US
+          - api-level: 35
+            target: google_apis
+            screen: small
+            profile: small_phone
+            locale: en-US
+          - api-level: 35
+            target: google_apis
+            screen: large
+            profile: pixel_6
+            locale: ja-JP
+
     steps:
       - uses: actions/checkout@v6
         with:
@@ -106,12 +138,36 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         continue-on-error: true # IMPORTANT: allow pipeline to continue to Android Test Report step
         with:
-          api-level: 34
+          api-level: ${{ matrix.api-level }}
           arch: x86_64
           ram-size: 2048M
           enable-hw-keyboard: false
-          target: default
+          target: ${{ matrix.target }}
+          # Screen-size dimension: the AVD is created as this hardware device
+          # (small_phone for "small", pixel_6 for "large"), so the resolution and
+          # density are baked in rather than resized at runtime.
+          profile: ${{ matrix.profile }}
           script: |
+            # The emulator runs a userdebug image, so "adb root" is available;
+            # we need it for scoped-storage writes and to set the system locale.
+            adb root
+            adb wait-for-device
+
+            # Language dimension: set the system locale and restart the Android
+            # framework so the entire UI (including onboarding) comes up in the
+            # matrix language. matrix.locale is a BCP-47 tag, e.g. en-US / ja-JP.
+            # The flows select controls by testTag, so they are language-agnostic;
+            # this exercises layout/wrapping under a different language.
+            #
+            # Only restart when the locale actually differs from the current one
+            # (the emulator already boots en-US, so the English legs skip this).
+            # sys.boot_completed is NOT reset by a framework restart, so we clear
+            # it before "stop; start" and then wait for the framework to set it
+            # back to "1" - otherwise the next steps race a half-restarted system.
+            adb shell 'want='"${{ matrix.locale }}"'; have=$(getprop persist.sys.locale); [ -z "$have" ] && have=$(getprop ro.product.locale); if [ "$have" != "$want" ]; then setprop persist.sys.locale "$want"; setprop sys.boot_completed 0; stop; start; fi'
+            adb wait-for-device
+            adb shell 'while [ "$(getprop sys.boot_completed)" != "1" ]; do sleep 2; done'
+
             adb logcat -c                             # clear logs
             touch app/emulator.log                    # create log file
             chmod 777 app/emulator.log                # allow writing to log file
@@ -123,16 +179,14 @@ jobs:
             # location-dependent flows run against known map data and a fixed
             # location. The extracts directory is the app-specific external files
             # dir + "/Download" (see GeoEngine.offlineExtractPath); scoped storage
-            # blocks writes there even for the shell user, so we use root - the
-            # emulator runs a userdebug image, so "adb root" is available.
+            # blocks writes there even for the shell user, which is why we took
+            # root above.
             #
             # The android-emulator-runner runs each script line in its own
             # "sh -c", so a shell variable assigned on one line is empty by the
             # next; the extract directory path is therefore inlined rather than
             # held in a variable. It is the app-specific external files dir +
             # "/Download" (see GeoEngine.offlineExtractPath).
-            adb root
-            adb wait-for-device
             adb shell mkdir -p /storage/emulated/0/Android/data/org.scottishtecharmy.soundscape/files/Download
             adb push glasgow-gb.pmtiles /storage/emulated/0/Android/data/org.scottishtecharmy.soundscape/files/Download/
             # The .geojson metadata sidecar (findExtracts reads "<pmtiles>.geojson")
@@ -154,17 +208,19 @@ jobs:
             $HOME/.maestro/bin/maestro test --format=junit --output=report6.xml --test-output-dir=maestro_outputs --no-ansi maestro/RouteCreation.yaml || status=1
             exit $status
 
+      # Artifact names must be unique across the matrix, so suffix them with the
+      # combination (e.g. maestro-reports-35-large-ja-JP).
       - name: Upload maestro reports
         uses: actions/upload-artifact@v6
         with:
-          name: maestro-reports
+          name: maestro-reports-${{ matrix.api-level }}-${{ matrix.screen }}-${{ matrix.locale }}
           path: maestro_outputs
 
       - name: Upload Failing Test Report Log
         if: steps.maestro-tests.outcome != 'success'        # upload the generated log on failure of the tests job
         uses: actions/upload-artifact@v6
         with:
-          name: logs
+          name: logs-${{ matrix.api-level }}-${{ matrix.screen }}-${{ matrix.locale }}
           path: app/emulator.log # path to where the log is
 
       - name: Raise error on test fail # set a red tick on the workflow run if the tests failed

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -129,9 +129,7 @@ jobs:
   maestro:
     needs: test
     uses: ./.github/workflows/run-maestro-tests.yaml
-    # fail_on_error: false keeps a Maestro failure from failing the run-tests run
-    # (continue-on-error isn't allowed on a job that calls a reusable workflow).
+    # fail_on_error defaults to true, so a Maestro flow failure fails this run.
     with:
       apk_artifact: debug-apk
-      fail_on_error: false
     secrets: inherit

--- a/docs/developers/maestro-tests.md
+++ b/docs/developers/maestro-tests.md
@@ -11,9 +11,10 @@ has_toc: true
 to drive the app through real user flows on an emulator or device — onboarding,
 creating markers and routes, browsing places nearby, and so on. The flows live
 in the [`maestro/`](https://github.com/Scottish-Tech-Army/Soundscape-Android/tree/main/maestro)
-directory at the root of the repository and run in CI both as a follow-on to
+directory at the root of the repository and run in CI as a follow-on to
 the [`Run tests`](https://github.com/Scottish-Tech-Army/Soundscape-Android/blob/main/.github/workflows/run-tests.yaml)
-workflow and standalone against a published release (see
+workflow, standalone against a published release, and automatically against the
+latest release on PRs that change only flows (see
 [Running in CI](#running-in-ci)).
 
 These are end-to-end tests that exercise the real UI. For host-side logic tests
@@ -41,8 +42,9 @@ version locally avoids surprises.)
 Studio is for authoring; once a flow is saved you run it from the Maestro CLI,
 which is also what CI uses.
 
-1. Start an emulator (or plug in a device). The CI uses API level 34, x86_64,
-   so an emulator of that level is the closest match to what CI runs.
+1. Start an emulator (or plug in a device). CI runs the suite across a matrix of
+   API 31 and 35, x86_64 (see [Running in CI](#running-in-ci)), so an emulator at
+   one of those levels is the closest match to what CI runs.
 2. Build and install the debug APK:
 
    ```bash
@@ -323,21 +325,57 @@ get that APK in two ways:
 - **As a follow-on to `Run tests`** (`workflow_call`). `run-tests.yaml` builds
   the debug APK, uploads it as the `debug-apk` artifact, and then calls this
   workflow as a `maestro` job (`needs: test`) passing `apk_artifact: debug-apk`.
-  This job is marked `continue-on-error: true` in `run-tests.yaml`, so for now a
-  Maestro failure does **not** fail the `Run tests` run.
+  A Maestro flow failure fails the `Run tests` run (`fail_on_error` defaults to
+  `true`).
 - **Standalone** from the **Actions** tab (`workflow_dispatch`). With no inputs
   it downloads the **latest GitHub release**'s `release-apk-*.zip` and tests
   that; an optional `release_tag` input (e.g. `soundscape-1.0.12`) tests an older
   release instead. Note this exercises the minified, signed `release` build
   rather than a debug build — `testTag`s survive R8 because they are string
   literals, and the app id is the same, so the flows are unchanged.
+- **Automatically on a maestro-only PR.** The
+  [`Maestro-only PR tests`](https://github.com/Scottish-Tech-Army/Soundscape-Android/blob/main/.github/workflows/maestro-only-pr.yaml)
+  workflow triggers on a pull request that changes **only** files under
+  `maestro/`. There is no app code to rebuild in that case, so rather than run
+  the full `Run tests` pipeline it calls `run-maestro-tests.yaml` with no APK
+  input — which, as in the standalone case, tests the **latest GitHub release**.
+  This gives fast feedback when iterating on flows. A `paths:` filter limits the
+  trigger to PRs that touch `maestro/`, and a `check-paths` guard job confirms
+  the PR touches *only* `maestro/` files (via a `base...head` diff) before the
+  Maestro job runs — a PR that also changes app code falls through to the normal
+  `Run tests` pipeline instead.
 
-In both cases it then:
+In every case the whole suite runs across a **matrix** of four emulator
+configurations, so the flows are exercised on different API levels, screen sizes
+and languages. `fail-fast: false`, so one failing combination does not cancel the
+others:
+
+| API level | Screen | Device profile | Language |
+|-----------|--------|----------------|----------|
+| 31 | small | `small_phone` | English (`en-US`) |
+| 31 | large | `pixel_6` | English (`en-US`) |
+| 35 | small | `small_phone` | English (`en-US`) |
+| 35 | large | `pixel_6` | Japanese (`ja-JP`) |
+
+Screen size comes from the runner's `profile` input, which creates the AVD as
+that hardware device (`small_phone` for "small", `pixel_6` for "large"), so the
+resolution and density are baked in rather than resized at runtime. Language is
+set by writing `persist.sys.locale` and restarting the framework (`adb root` is
+available because the emulator is a userdebug image) so the whole UI — including
+onboarding — comes up in that language; the restart is skipped on the English
+legs because the emulator already boots `en-US`. Because the flows select
+controls by `testTag` rather than visible text, they are language-agnostic; the
+Japanese run exercises layout and text-wrapping rather than asserting on
+translated strings. Each matrix leg uploads its own
+`maestro-reports-<api>-<screen>-<locale>` artifact (and `logs-…` on failure).
+
+For each matrix combination it then:
 
 1. Locates the downloaded APK (the debug artifact and the release zip put it at
    different paths, so it is found by glob rather than a fixed name).
-2. Boots an API 34 x86_64 emulator via
-   `reactivecircus/android-emulator-runner`.
+2. Boots the matrix API level (31 or 35), x86_64, emulator created with the
+   matrix device `profile` via `reactivecircus/android-emulator-runner`, and
+   applies the matrix locale before installing the app.
 3. Installs the APK, seeds the
    [offline map extract and a fixed GPS location](#offline-map-data-and-a-fixed-gps-location)
    (it downloads the Glasgow `.pmtiles`, pushes it plus its committed `.geojson`


### PR DESCRIPTION
run-maestro-tests now runs on a matrix of emulators with different API levels and screen sizes, and one run in Japanese.
Any PR which contains only files within the maestro directory will run the tests with the last release version.