### PR TITLE
Add local GraphHopper turn-by-turn prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 .gradle
+.serena/
 /local.properties
 /.idea/caches
 /.idea/libraries
@@ -15,6 +16,7 @@
 app/gpxFiles/*
 app/*.geojson
 app/src/screenshotTestDebug/*
+tools/routing/.local/
 
 # Gradle files
 .gradle/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,14 +88,16 @@ android {
         var searchProviderUrl = ""
         var searchProviderApiKey = ""
         var extractProviderUrl = ""
+        var routingProviderUrl = ""
         try {
             val localProperties = Properties()
             localProperties.load(FileInputStream(rootProject.file("local.properties")))
-            tileProviderUrl = localProperties["tileProviderUrl"].toString()
-            tileProviderApiKey = localProperties["tileProviderApiKey"].toString()
-            searchProviderUrl = localProperties["searchProviderUrl"].toString()
-            searchProviderApiKey = localProperties["searchProviderApiKey"].toString()
-            extractProviderUrl = localProperties["extractProviderUrl"].toString()
+            tileProviderUrl = localProperties.getProperty("tileProviderUrl", "")
+            tileProviderApiKey = localProperties.getProperty("tileProviderApiKey", "")
+            searchProviderUrl = localProperties.getProperty("searchProviderUrl", "")
+            searchProviderApiKey = localProperties.getProperty("searchProviderApiKey", "")
+            extractProviderUrl = localProperties.getProperty("extractProviderUrl", "")
+            routingProviderUrl = localProperties.getProperty("routingProviderUrl", "")
         } catch (e: Exception) {
             println("Failed to load local.properties for tile and search providers: $e")
         }
@@ -104,6 +106,7 @@ android {
         buildConfigField("String", "SEARCH_PROVIDER_URL", "\"${searchProviderUrl}\"")
         buildConfigField("String", "SEARCH_PROVIDER_API_KEY", "\"${searchProviderApiKey}\"")
         buildConfigField("String", "EXTRACT_PROVIDER_URL", "\"${extractProviderUrl}\"")
+        buildConfigField("String", "ROUTING_PROVIDER_URL", "\"${routingProviderUrl}\"")
 
         buildConfigField("String", "VERSION_NAME", "\"${versionName}\"")
 

--- a/app/src/androidTest/java/org/scottishtecharmy/soundscape/LocationDetailsScreenTest.kt
+++ b/app/src/androidTest/java/org/scottishtecharmy/soundscape/LocationDetailsScreenTest.kt
@@ -1,0 +1,90 @@
+package org.scottishtecharmy.soundscape
+
+import android.content.Context
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.core.content.edit
+import androidx.navigation.compose.rememberNavController
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
+import org.scottishtecharmy.soundscape.screens.home.locationDetails.LocationDetails
+import org.scottishtecharmy.soundscape.ui.theme.SoundscapeTheme
+
+class LocationDetailsScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val destination = LngLatAlt(7.4213, 43.7339)
+
+    @Before
+    fun setUp() {
+        PreferenceManager.getDefaultSharedPreferences(context).edit(commit = true) {
+            putBoolean(MainActivity.SHOW_MAP_KEY, false)
+        }
+    }
+
+    @Test
+    fun startDirectionsAction_hasTalkBackHintAndStartsTurnByTurn() {
+        var turnByTurnDestination: LngLatAlt? = null
+
+        composeTestRule.setContent {
+            SoundscapeTheme {
+                LocationDetails(
+                    locationDescription = LocationDescription(
+                        name = "Monaco destination",
+                        location = destination,
+                        description = "21 Rue Princesse Caroline"
+                    ),
+                    navController = rememberNavController(),
+                    location = LngLatAlt(7.4246, 43.7384),
+                    heading = 0.0F,
+                    createBeacon = {},
+                    startTurnByTurn = { turnByTurnDestination = it },
+                    saveMarker = { _, _, _, _ -> },
+                    deleteMarker = {},
+                    enableStreetPreview = {},
+                    shareLocation = { _, _ -> },
+                    offlineMaps = {},
+                    showDialog = {},
+                    getLocationDescription = { LocationDescription("Current location", it) },
+                )
+            }
+        }
+
+        val directionsHint = context.resources.getString(
+            R.string.location_detail_action_directions_hint
+        )
+        val directionsAction = composeTestRule.onNodeWithTag(
+            "locationDetailsStartDirections",
+            useUnmergedTree = true
+        )
+
+        directionsAction
+            .assertIsDisplayed()
+            .assert(hasClickAction())
+
+        val clickAction = directionsAction.fetchSemanticsNode()
+            .config
+            .getOrElseNullable(SemanticsActions.OnClick) { null }
+
+        assertNotNull("Start directions should expose a TalkBack click action", clickAction)
+        assertEquals(directionsHint, clickAction?.label)
+
+        directionsAction.performClick()
+
+        assertEquals(destination, turnByTurnDestination)
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
@@ -24,6 +24,7 @@ import javax.inject.Inject
 @ActivityRetainedScoped
 class SoundscapeServiceConnection @Inject constructor() {
     var soundscapeService: SoundscapeService? = null
+    private var pendingTurnByTurnNavigation: PendingTurnByTurnNavigation? = null
 
     private var _serviceBoundState = MutableStateFlow(false)
     val serviceBoundState = _serviceBoundState.asStateFlow()
@@ -70,6 +71,24 @@ class SoundscapeServiceConnection @Inject constructor() {
         soundscapeService?.startBeacon(location, name)
     }
 
+    fun startTurnByTurnNavigation(location: LngLatAlt, name: String) {
+        val boundService = soundscapeService
+        if(boundService != null) {
+            boundService.startTurnByTurnNavigation(location, name)
+        } else {
+            pendingTurnByTurnNavigation = PendingTurnByTurnNavigation(location, name)
+        }
+    }
+
+    internal fun drainPendingTurnByTurnNavigation(
+        onStart: (location: LngLatAlt, name: String) -> Unit
+    ): Boolean {
+        val pendingNavigation = pendingTurnByTurnNavigation ?: return false
+        pendingTurnByTurnNavigation = null
+        onStart(pendingNavigation.location, pendingNavigation.name)
+        return true
+    }
+
     fun routeSkipPrevious() {
         soundscapeService?.routeSkipPrevious()
     }
@@ -93,6 +112,9 @@ class SoundscapeServiceConnection @Inject constructor() {
             val binder = service as SoundscapeBinder
             soundscapeService = binder.getSoundscapeService()
             _serviceBoundState.value = true
+            drainPendingTurnByTurnNavigation { location, name ->
+                soundscapeService?.startTurnByTurnNavigation(location, name)
+            }
         }
 
         override fun onServiceDisconnected(arg0: ComponentName) {
@@ -137,4 +159,9 @@ class SoundscapeServiceConnection @Inject constructor() {
     companion object {
         private const val TAG = "SoundscapeServiceConnection"
     }
+
+    private data class PendingTurnByTurnNavigation(
+        val location: LngLatAlt,
+        val name: String
+    )
 }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/navigation/GraphHopperRouteParser.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/navigation/GraphHopperRouteParser.kt
@@ -1,0 +1,114 @@
+package org.scottishtecharmy.soundscape.navigation
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+
+data class NavigationRoute(
+    val distanceMeters: Double,
+    val durationMillis: Long,
+    val geometry: List<NavigationPoint>,
+    val instructions: List<NavigationInstruction>
+)
+
+data class NavigationPoint(
+    val latitude: Double,
+    val longitude: Double
+)
+
+data class NavigationInstruction(
+    val text: String,
+    val streetName: String,
+    val distanceMeters: Double,
+    val durationMillis: Long,
+    val sign: Int,
+    val geometryStartIndex: Int,
+    val geometryEndIndex: Int
+)
+
+object GraphHopperRouteParser {
+    fun parse(routeJson: String): NavigationRoute {
+        val root = Json.parseToJsonElement(routeJson).jsonObject
+        val path = root.requiredArray("paths").firstOrNull()?.jsonObject
+            ?: throw IllegalArgumentException("GraphHopper route response does not contain a path")
+
+        return NavigationRoute(
+            distanceMeters = path.requiredDouble("distance"),
+            durationMillis = path.requiredLong("time"),
+            geometry = parseGeometry(path.requiredObject("points")),
+            instructions = path.requiredArray("instructions").map { instruction ->
+                parseInstruction(instruction.jsonObject)
+            }
+        )
+    }
+
+    private fun parseGeometry(points: JsonObject): List<NavigationPoint> {
+        return points.requiredArray("coordinates").map { coordinate ->
+            val values = coordinate.jsonArray
+            if (values.size < 2) {
+                throw IllegalArgumentException("GraphHopper coordinate must include longitude and latitude")
+            }
+            NavigationPoint(
+                longitude = values[0].jsonPrimitive.double,
+                latitude = values[1].jsonPrimitive.double
+            )
+        }
+    }
+
+    private fun parseInstruction(instruction: JsonObject): NavigationInstruction {
+        val interval = instruction.requiredArray("interval")
+        if (interval.size < 2) {
+            throw IllegalArgumentException("GraphHopper instruction interval must include start and end indexes")
+        }
+
+        return NavigationInstruction(
+            text = instruction.requiredString("text"),
+            streetName = instruction.optionalString("street_name"),
+            distanceMeters = instruction.requiredDouble("distance"),
+            durationMillis = instruction.requiredLong("time"),
+            sign = instruction.requiredInt("sign"),
+            geometryStartIndex = interval[0].jsonPrimitive.int,
+            geometryEndIndex = interval[1].jsonPrimitive.int
+        )
+    }
+
+    private fun JsonObject.requiredArray(name: String): JsonArray {
+        return this[name]?.jsonArray
+            ?: throw IllegalArgumentException("GraphHopper route response is missing '$name'")
+    }
+
+    private fun JsonObject.requiredObject(name: String): JsonObject {
+        return this[name]?.jsonObject
+            ?: throw IllegalArgumentException("GraphHopper route response is missing '$name'")
+    }
+
+    private fun JsonObject.requiredString(name: String): String {
+        return this[name]?.jsonPrimitive?.content
+            ?: throw IllegalArgumentException("GraphHopper route response is missing '$name'")
+    }
+
+    private fun JsonObject.optionalString(name: String): String {
+        return this[name]?.jsonPrimitive?.content.orEmpty()
+    }
+
+    private fun JsonObject.requiredDouble(name: String): Double {
+        return this[name]?.jsonPrimitive?.double
+            ?: throw IllegalArgumentException("GraphHopper route response is missing '$name'")
+    }
+
+    private fun JsonObject.requiredLong(name: String): Long {
+        return this[name]?.jsonPrimitive?.long
+            ?: throw IllegalArgumentException("GraphHopper route response is missing '$name'")
+    }
+
+    private fun JsonObject.requiredInt(name: String): Int {
+        return this[name]?.jsonPrimitive?.int
+            ?: throw IllegalArgumentException("GraphHopper route response is missing '$name'")
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/navigation/GraphHopperRouteProvider.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/navigation/GraphHopperRouteProvider.kt
@@ -1,0 +1,44 @@
+package org.scottishtecharmy.soundscape.navigation
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+interface GraphHopperRouteResponseFetcher {
+    fun fetch(url: String): String
+}
+
+interface NavigationRouteProvider {
+    fun route(request: GraphHopperRouteRequest): NavigationRoute
+}
+
+class GraphHopperRouteProvider(
+    private val baseUrl: String,
+    private val responseFetcher: GraphHopperRouteResponseFetcher = OkHttpGraphHopperRouteResponseFetcher()
+) : NavigationRouteProvider {
+    override fun route(request: GraphHopperRouteRequest): NavigationRoute {
+        val url = GraphHopperRouteRequestBuilder.buildRouteUrl(baseUrl, request)
+        return GraphHopperRouteParser.parse(responseFetcher.fetch(url))
+    }
+}
+
+class OkHttpGraphHopperRouteResponseFetcher(
+    private val client: OkHttpClient = OkHttpClient.Builder()
+        .callTimeout(10, TimeUnit.SECONDS)
+        .build()
+) : GraphHopperRouteResponseFetcher {
+    override fun fetch(url: String): String {
+        val request = Request.Builder()
+            .url(url)
+            .get()
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("GraphHopper route request failed: HTTP ${response.code}")
+            }
+            return response.body.string()
+        }
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/navigation/GraphHopperRouteRequest.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/navigation/GraphHopperRouteRequest.kt
@@ -1,0 +1,21 @@
+package org.scottishtecharmy.soundscape.navigation
+
+data class GraphHopperRouteRequest(
+    val start: NavigationPoint,
+    val destination: NavigationPoint,
+    val profile: String = "foot",
+    val locale: String = "en"
+)
+
+object GraphHopperRouteRequestBuilder {
+    fun buildRouteUrl(baseUrl: String, request: GraphHopperRouteRequest): String {
+        return "${baseUrl.trimEnd('/')}/route" +
+            "?profile=${request.profile}" +
+            "&point=${request.start.latitude},${request.start.longitude}" +
+            "&point=${request.destination.latitude},${request.destination.longitude}" +
+            "&locale=${request.locale}" +
+            "&instructions=true" +
+            "&points_encoded=false" +
+            "&ch.disable=true"
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/navigation/RouteFollower.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/navigation/RouteFollower.kt
@@ -1,0 +1,144 @@
+package org.scottishtecharmy.soundscape.navigation
+
+import org.scottishtecharmy.soundscape.geoengine.utils.distance
+import kotlin.math.cos
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.roundToInt
+import kotlin.math.sqrt
+
+data class RouteFollowerConfig(
+    val offRouteThresholdMeters: Double = 30.0,
+    val arrivalThresholdMeters: Double = 12.0,
+    val rerouteDebounceMillis: Long = 5_000
+)
+
+enum class RouteProgressStatus {
+    ON_ROUTE,
+    OFF_ROUTE,
+    ARRIVED
+}
+
+data class RouteProgressUpdate(
+    val status: RouteProgressStatus,
+    val isOffRoute: Boolean,
+    val isArrived: Boolean,
+    val nextInstructionIndex: Int?,
+    val nextInstruction: NavigationInstruction?,
+    val distanceFromRouteMeters: Double,
+    val matchedGeometryIndex: Int
+)
+
+class RouteFollower(
+    private val route: NavigationRoute,
+    private val config: RouteFollowerConfig = RouteFollowerConfig()
+) {
+    private var latestGeometryIndex = 0
+
+    fun update(location: NavigationPoint): RouteProgressUpdate {
+        val destination = route.geometry.last()
+        if (distanceMeters(location, destination) <= config.arrivalThresholdMeters) {
+            latestGeometryIndex = route.geometry.lastIndex
+            return RouteProgressUpdate(
+                status = RouteProgressStatus.ARRIVED,
+                isOffRoute = false,
+                isArrived = true,
+                nextInstructionIndex = null,
+                nextInstruction = null,
+                distanceFromRouteMeters = 0.0,
+                matchedGeometryIndex = latestGeometryIndex
+            )
+        }
+
+        val match = findNearestRouteMatch(location)
+        latestGeometryIndex = max(latestGeometryIndex, match.geometryIndex)
+        val instructionIndex = nextInstructionIndex(latestGeometryIndex)
+        val isOffRoute = match.distanceMeters > config.offRouteThresholdMeters
+
+        return RouteProgressUpdate(
+            status = if (isOffRoute) RouteProgressStatus.OFF_ROUTE else RouteProgressStatus.ON_ROUTE,
+            isOffRoute = isOffRoute,
+            isArrived = false,
+            nextInstructionIndex = instructionIndex,
+            nextInstruction = instructionIndex?.let { route.instructions[it] },
+            distanceFromRouteMeters = match.distanceMeters,
+            matchedGeometryIndex = latestGeometryIndex
+        )
+    }
+
+    private fun nextInstructionIndex(geometryIndex: Int): Int? {
+        return route.instructions.indexOfFirst { instruction ->
+            geometryIndex < instruction.geometryEndIndex
+        }.takeIf { it >= 0 }
+    }
+
+    private fun findNearestRouteMatch(location: NavigationPoint): RouteMatch {
+        if (route.geometry.size == 1) {
+            return RouteMatch(
+                distanceMeters = distanceMeters(location, route.geometry.first()),
+                geometryIndex = 0
+            )
+        }
+
+        return route.geometry.zipWithNext().mapIndexed { index, segment ->
+            distanceToSegment(location, segment.first, segment.second, index)
+        }.minBy { it.distanceMeters }
+    }
+
+    private fun distanceToSegment(
+        location: NavigationPoint,
+        start: NavigationPoint,
+        end: NavigationPoint,
+        segmentStartIndex: Int
+    ): RouteMatch {
+        val locationXY = location.toLocalMeters(start)
+        val endXY = end.toLocalMeters(start)
+        val segmentLengthSquared = endXY.x.pow(2) + endXY.y.pow(2)
+        if (segmentLengthSquared == 0.0) {
+            return RouteMatch(
+                distanceMeters = distanceMeters(location, start),
+                geometryIndex = segmentStartIndex
+            )
+        }
+
+        val rawFraction = ((locationXY.x * endXY.x) + (locationXY.y * endXY.y)) / segmentLengthSquared
+        val fraction = rawFraction.coerceIn(0.0, 1.0)
+        val nearestX = endXY.x * fraction
+        val nearestY = endXY.y * fraction
+        val dx = locationXY.x - nearestX
+        val dy = locationXY.y - nearestY
+
+        return RouteMatch(
+            distanceMeters = sqrt(dx.pow(2) + dy.pow(2)),
+            geometryIndex = segmentStartIndex + fraction.roundToInt()
+        )
+    }
+
+    private fun NavigationPoint.toLocalMeters(origin: NavigationPoint): LocalPoint {
+        val latitudeScale = METERS_PER_DEGREE
+        val longitudeScale = METERS_PER_DEGREE * cos(Math.toRadians(origin.latitude))
+        return LocalPoint(
+            x = (longitude - origin.longitude) * longitudeScale,
+            y = (latitude - origin.latitude) * latitudeScale
+        )
+    }
+
+    private fun distanceMeters(start: NavigationPoint, end: NavigationPoint): Double {
+        return distance(start.latitude, start.longitude, end.latitude, end.longitude)
+    }
+
+    private data class RouteMatch(
+        val distanceMeters: Double,
+        val geometryIndex: Int
+    )
+
+    private data class LocalPoint(
+        val x: Double,
+        val y: Double
+    )
+
+    private companion object {
+        private const val METERS_PER_DEGREE = 111_320.0
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/navigation/RouteGuidance.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/navigation/RouteGuidance.kt
@@ -1,0 +1,67 @@
+package org.scottishtecharmy.soundscape.navigation
+
+sealed class RouteGuidanceEvent {
+    data class Instruction(
+        val instructionIndex: Int,
+        val instruction: NavigationInstruction,
+        val update: RouteProgressUpdate
+    ) : RouteGuidanceEvent()
+
+    data class OffRoute(
+        val update: RouteProgressUpdate
+    ) : RouteGuidanceEvent()
+
+    data class Arrived(
+        val update: RouteProgressUpdate
+    ) : RouteGuidanceEvent()
+}
+
+class RouteGuidance(
+    route: NavigationRoute,
+    config: RouteFollowerConfig = RouteFollowerConfig()
+) {
+    private val follower = RouteFollower(route, config)
+    private var lastStatus: RouteProgressStatus? = null
+    private var lastInstructionIndex: Int? = null
+
+    fun isOffRoute(): Boolean = lastStatus == RouteProgressStatus.OFF_ROUTE
+
+    fun update(location: NavigationPoint): RouteGuidanceEvent? {
+        val progress = follower.update(location)
+        val previousStatus = lastStatus
+        lastStatus = progress.status
+
+        return when (progress.status) {
+            RouteProgressStatus.ARRIVED -> {
+                if (previousStatus == RouteProgressStatus.ARRIVED) {
+                    null
+                } else {
+                    RouteGuidanceEvent.Arrived(progress)
+                }
+            }
+            RouteProgressStatus.OFF_ROUTE -> {
+                if (previousStatus == RouteProgressStatus.OFF_ROUTE) {
+                    null
+                } else {
+                    RouteGuidanceEvent.OffRoute(progress)
+                }
+            }
+            RouteProgressStatus.ON_ROUTE -> {
+                val instructionIndex = progress.nextInstructionIndex ?: return null
+                if (
+                    instructionIndex == lastInstructionIndex &&
+                    previousStatus != RouteProgressStatus.OFF_ROUTE
+                ) {
+                    null
+                } else {
+                    lastInstructionIndex = instructionIndex
+                    RouteGuidanceEvent.Instruction(
+                        instructionIndex = instructionIndex,
+                        instruction = progress.nextInstruction!!,
+                        update = progress
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/navigation/RouteGuidanceAnnouncementFormatter.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/navigation/RouteGuidanceAnnouncementFormatter.kt
@@ -1,0 +1,11 @@
+package org.scottishtecharmy.soundscape.navigation
+
+object RouteGuidanceAnnouncementFormatter {
+    fun format(event: RouteGuidanceEvent): String {
+        return when (event) {
+            is RouteGuidanceEvent.Instruction -> event.instruction.text
+            is RouteGuidanceEvent.OffRoute -> "You are off route."
+            is RouteGuidanceEvent.Arrived -> "Arrived."
+        }
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/navigation/TurnByTurnNavigationSession.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/navigation/TurnByTurnNavigationSession.kt
@@ -1,0 +1,48 @@
+package org.scottishtecharmy.soundscape.navigation
+
+class TurnByTurnNavigationSession(
+    private val routeProvider: NavigationRouteProvider,
+    private val config: RouteFollowerConfig = RouteFollowerConfig(),
+    private val currentTimeMillis: () -> Long = { System.currentTimeMillis() }
+) {
+    private var guidance: RouteGuidance? = null
+    private var activeRequest: GraphHopperRouteRequest? = null
+    private var offRouteSinceMillis: Long? = null
+
+    fun start(request: GraphHopperRouteRequest): NavigationRoute {
+        val route = routeProvider.route(request)
+        activeRequest = request
+        offRouteSinceMillis = null
+        guidance = RouteGuidance(route, config)
+        return route
+    }
+
+    fun updateLocation(location: NavigationPoint): RouteGuidanceEvent? {
+        val activeGuidance = guidance ?: return null
+        val event = activeGuidance.update(location)
+
+        if (event !is RouteGuidanceEvent.OffRoute && !activeGuidance.isOffRoute()) {
+            offRouteSinceMillis = null
+            return event
+        }
+
+        val offRouteSince = offRouteSinceMillis ?: currentTimeMillis().also {
+            offRouteSinceMillis = it
+        }
+        if (currentTimeMillis() - offRouteSince < config.rerouteDebounceMillis) {
+            return null
+        }
+
+        val previousRequest = activeRequest ?: return null
+        val rerouteRequest = previousRequest.copy(start = location)
+        start(rerouteRequest)
+        offRouteSinceMillis = null
+        return guidance?.update(location)
+    }
+
+    fun stop() {
+        guidance = null
+        activeRequest = null
+        offRouteSinceMillis = null
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/locationDetails/LocationDetailsScreen.kt
@@ -107,6 +107,10 @@ fun LocationDetailsScreen(
             viewModel.startBeacon(loc, finalLocationDescription.name)
             navController.popBackStack(HomeRoutes.Home.route, false)
         },
+        startTurnByTurn = { loc ->
+            viewModel.startTurnByTurnNavigation(loc, finalLocationDescription.name)
+            navController.popBackStack(HomeRoutes.Home.route, false)
+        },
         saveMarker = { description, successMessage, failureMessage, duplicateMessage ->
             viewModel.createMarker(
                 description,
@@ -153,6 +157,7 @@ fun LocationDetails(
     location: LngLatAlt?,
     heading: Float,
     createBeacon: (location: LngLatAlt) -> Unit,
+    startTurnByTurn: (location: LngLatAlt) -> Unit,
     saveMarker: (
         description: LocationDescription,
         successMessage: String,
@@ -238,6 +243,7 @@ fun LocationDetails(
                         HorizontalDivider()
                         LocationDescriptionButtonsSection(
                             createBeacon = createBeacon,
+                            startTurnByTurn = startTurnByTurn,
                             locationDescription = description.value,
                             enableStreetPreview = enableStreetPreview,
                             shareLocation = shareLocation,
@@ -287,6 +293,7 @@ fun LocationDetails(
 @Composable
 private fun LocationDescriptionButtonsSection(
     createBeacon: (location: LngLatAlt) -> Unit,
+    startTurnByTurn: (location: LngLatAlt) -> Unit,
     locationDescription: LocationDescription,
     enableStreetPreview: (location: LngLatAlt) -> Unit,
     shareLocation: (message: String, locationDescription : LocationDescription) -> Unit,
@@ -325,6 +332,19 @@ private fun LocationDescriptionButtonsSection(
                 .testTag("locationDetailsStartBeacon")
         ) {
             createBeacon(locationDescription.location)
+        }
+
+        IconWithTextButton(
+            icon = Icons.Filled.Navigation,
+            text = stringResource(R.string.location_detail_action_directions),
+            talkbackHint = stringResource(R.string.location_detail_action_directions_hint),
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier
+                .defaultMinSize(minHeight = spacing.targetSize)
+                .fillMaxWidth()
+                .testTag("locationDetailsStartDirections")
+        ) {
+            startTurnByTurn(locationDescription.location)
         }
 
         if(locationDescription.databaseId != 0L) {
@@ -489,6 +509,8 @@ fun LocationDetailsPreview() {
             typeDescription = TextForFeature("Blah", false,"Restaurant")
         ),
         createBeacon = { _ ->
+        },
+        startTurnByTurn = { _ ->
         },
         enableStreetPreview = { _ ->
         },

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/RoutePlayer.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/RoutePlayer.kt
@@ -46,7 +46,11 @@ class RoutePlayer(val service: SoundscapeService, context: Context) {
      * @param beaconLocation The location to place the beacon at
      * @param beaconName The name of the beacon
      */
-    fun startBeacon(beaconLocation: LngLatAlt, beaconName: String) {
+    fun startBeacon(
+        beaconLocation: LngLatAlt,
+        beaconName: String,
+        monitorArrival: Boolean = true
+    ) {
         Log.e(TAG, "startBeacon")
         currentMarker = 0
 
@@ -86,7 +90,7 @@ class RoutePlayer(val service: SoundscapeService, context: Context) {
         play()
         Log.d(TAG, toString())
 
-        if(!beaconOnly) {
+        if(monitorArrival && !beaconOnly) {
             // We want to describe how far we are and a route completion
             startMonitoringLocation()
         }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -13,6 +13,7 @@ import android.app.PendingIntent
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.ServiceInfo
+import android.location.Location
 import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioManager
@@ -34,6 +35,7 @@ import androidx.media3.session.MediaSessionService
 import androidx.preference.PreferenceManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelChildren
@@ -50,6 +52,7 @@ import org.scottishtecharmy.soundscape.MainActivity.Companion.MEDIA_CONTROLS_MOD
 import org.scottishtecharmy.soundscape.MainActivity.Companion.MEDIA_CONTROLS_MODE_KEY
 import org.scottishtecharmy.soundscape.MainActivity.Companion.RELATIVE_DIRECTION_DEFAULT
 import org.scottishtecharmy.soundscape.MainActivity.Companion.RELATIVE_DIRECTION_KEY
+import org.scottishtecharmy.soundscape.BuildConfig
 import org.scottishtecharmy.soundscape.R
 import org.scottishtecharmy.soundscape.audio.AudioType
 import org.scottishtecharmy.soundscape.audio.NativeAudioEngine
@@ -79,6 +82,12 @@ import org.scottishtecharmy.soundscape.locationprovider.DirectionProvider
 import org.scottishtecharmy.soundscape.locationprovider.GpxDrivenProvider
 import org.scottishtecharmy.soundscape.locationprovider.LocationProvider
 import org.scottishtecharmy.soundscape.locationprovider.StaticLocationProvider
+import org.scottishtecharmy.soundscape.navigation.GraphHopperRouteProvider
+import org.scottishtecharmy.soundscape.navigation.GraphHopperRouteRequest
+import org.scottishtecharmy.soundscape.navigation.NavigationPoint
+import org.scottishtecharmy.soundscape.navigation.RouteGuidanceAnnouncementFormatter
+import org.scottishtecharmy.soundscape.navigation.RouteGuidanceEvent
+import org.scottishtecharmy.soundscape.navigation.TurnByTurnNavigationSession
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
 import org.scottishtecharmy.soundscape.services.mediacontrol.AudioMenu
 import org.scottishtecharmy.soundscape.services.mediacontrol.AudioMenuMediaControls
@@ -109,6 +118,8 @@ class SoundscapeService : MediaSessionService() {
     lateinit var locationProvider: LocationProvider
     lateinit var directionProvider: DirectionProvider
     lateinit var routePlayer: RoutePlayer
+    private var turnByTurnNavigationSession: TurnByTurnNavigationSession? = null
+    private var turnByTurnNavigationJob: Job? = null
 
     // secondary service
     private var timerJob: Job? = null
@@ -258,6 +269,8 @@ class SoundscapeService : MediaSessionService() {
         mediaSession
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        setDebugStaticLocation(intent)
+
         if (!running) {
             if(startAsForegroundService()) {
                 // Reminds the user every hour that the Soundscape service is still running in the background
@@ -280,6 +293,30 @@ class SoundscapeService : MediaSessionService() {
         }
 
         return super.onStartCommand(intent, flags, startId)
+    }
+
+    private fun setDebugStaticLocation(intent: Intent?) {
+        if (!BuildConfig.DEBUG || intent?.action != DEBUG_SET_LOCATION_ACTION) {
+            return
+        }
+
+        val latitude = intent.getDoubleExtra(DEBUG_LOCATION_LATITUDE_EXTRA, Double.NaN)
+        val longitude = intent.getDoubleExtra(DEBUG_LOCATION_LONGITUDE_EXTRA, Double.NaN)
+        if (latitude.isNaN() || longitude.isNaN()) {
+            Log.e(TAG, "Debug location intent missing latitude or longitude.")
+            return
+        }
+
+        val location = LngLatAlt(longitude, latitude)
+        val currentProvider = locationProvider
+        if (currentProvider is StaticLocationProvider) {
+            currentProvider.updateLocation(location, heading = 0.0F, speed = 0.0F)
+        } else {
+            currentProvider.destroy()
+            locationProvider = StaticLocationProvider(location)
+            locationProvider.start(this)
+        }
+        Log.d(TAG, "Debug static location set: $latitude,$longitude")
     }
 
     lateinit var sharedPreferences : SharedPreferences
@@ -774,6 +811,89 @@ class SoundscapeService : MediaSessionService() {
     fun startBeacon(location: LngLatAlt, name: String) {
         routePlayer.startBeacon(location, name)
     }
+
+    fun startTurnByTurnNavigation(destination: LngLatAlt, name: String) {
+        val ctx = if (::localizedContext.isInitialized) localizedContext else this@SoundscapeService
+        val currentLocation = locationProvider.filteredLocationFlow.value
+        if (currentLocation == null) {
+            speak2dText(ctx.getString(R.string.general_error_location_services_find_location_error))
+            return
+        }
+        if (BuildConfig.ROUTING_PROVIDER_URL.isBlank()) {
+            speak2dText(ctx.getString(R.string.turn_by_turn_route_not_configured))
+            return
+        }
+
+        stopTurnByTurnNavigation(stopRoutePlayer = false)
+        routePlayer.startBeacon(destination, name, monitorArrival = false)
+        speak2dText(ctx.getString(R.string.turn_by_turn_route_calculating).format(name), clearQueue = true)
+
+        turnByTurnNavigationJob = coroutineScope.launch(Dispatchers.IO) {
+            try {
+                val session = TurnByTurnNavigationSession(
+                    GraphHopperRouteProvider(BuildConfig.ROUTING_PROVIDER_URL)
+                )
+                turnByTurnNavigationSession = session
+                val route = session.start(
+                    GraphHopperRouteRequest(
+                        start = currentLocation.toNavigationPoint(),
+                        destination = NavigationPoint(
+                            latitude = destination.latitude,
+                            longitude = destination.longitude
+                        )
+                    )
+                )
+                Log.d(
+                    TAG,
+                    "Turn-by-turn route ready: ${route.instructions.size} instructions, " +
+                        "${route.distanceMeters.toInt()} meters"
+                )
+
+                speak2dText(ctx.getString(R.string.turn_by_turn_route_started).format(name), clearQueue = true)
+                session.updateLocation(currentLocation.toNavigationPoint())?.let { event ->
+                    speakTurnByTurnEvent(event)
+                }
+
+                locationProvider.filteredLocationFlow.collectLatest { location ->
+                    location ?: return@collectLatest
+                    session.updateLocation(location.toNavigationPoint())?.let { event ->
+                        speakTurnByTurnEvent(event)
+                        if (event is RouteGuidanceEvent.Arrived) {
+                            stopTurnByTurnNavigation()
+                        }
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to start turn-by-turn navigation", e)
+                speak2dText(ctx.getString(R.string.turn_by_turn_route_failed), clearQueue = true)
+                stopTurnByTurnNavigation()
+            }
+        }
+    }
+
+    private fun speakTurnByTurnEvent(event: RouteGuidanceEvent) {
+        Log.d(TAG, "Turn-by-turn event: $event")
+        speak2dText(RouteGuidanceAnnouncementFormatter.format(event))
+    }
+
+    private fun Location.toNavigationPoint(): NavigationPoint {
+        return NavigationPoint(
+            latitude = latitude,
+            longitude = longitude
+        )
+    }
+
+    private fun stopTurnByTurnNavigation(stopRoutePlayer: Boolean = true) {
+        turnByTurnNavigationJob?.cancel()
+        turnByTurnNavigationJob = null
+        turnByTurnNavigationSession = null
+        if (stopRoutePlayer) {
+            routePlayer.stopRoute()
+        }
+    }
+
     fun routeStartById(routeId: Long) {
         routePlayer.startRoute(routeId)
     }
@@ -782,6 +902,7 @@ class SoundscapeService : MediaSessionService() {
         routePlayer.startRoute(routeId, reverse = true)
     }
     fun routeStop() {
+        stopTurnByTurnNavigation(stopRoutePlayer = false)
         routePlayer.stopRoute()
     }
     fun routeSkipPrevious(): Boolean {
@@ -1085,6 +1206,10 @@ class SoundscapeService : MediaSessionService() {
         private const val CHANNEL_ID = "SoundscapeService_channel_01"
         private const val NOTIFICATION_CHANNEL_NAME = "Soundscape_SoundscapeService"
         private const val NOTIFICATION_ID = 100000
+
+        const val DEBUG_SET_LOCATION_ACTION = "org.scottishtecharmy.soundscape.DEBUG_SET_LOCATION"
+        const val DEBUG_LOCATION_LATITUDE_EXTRA = "latitude"
+        const val DEBUG_LOCATION_LONGITUDE_EXTRA = "longitude"
 
 //      Variable used when simulating startForeground failure - only for debug usage
         private var startForegroundShouldFail = false

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/LocationDetailsViewModel.kt
@@ -38,6 +38,11 @@ class LocationDetailsViewModel @Inject constructor(
         audioTour.onBeaconStarted()
     }
 
+    fun startTurnByTurnNavigation(location: LngLatAlt, name: String) {
+        soundscapeServiceConnection.startTurnByTurnNavigation(location, name)
+        audioTour.onBeaconStarted()
+    }
+
     fun enableStreetPreview(location: LngLatAlt) {
         soundscapeServiceConnection.setStreetPreviewMode(true, location)
     }

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -33,7 +33,9 @@
     <string name="preview_include_unnamed_roads_title">Unnamed Roads</string>
     <string name="location_detail_title_default">Location Details</string>
     <string name="location_detail_action_beacon">Start Audio Beacon</string>
+    <string name="location_detail_action_directions">Start Directions</string>
     <string name="location_detail_action_beacon_hint">guide you towards this location with sound</string>
+    <string name="location_detail_action_directions_hint">start turn by turn walking directions to this location</string>
     <string name="location_detail_action_save_hint">save this location to use later</string>
     <string name="location_detail_action_edit_hint">change the marker name or add additional notes</string>
     <string name="location_detail_action_share_hint">share this location with another app</string>
@@ -46,6 +48,10 @@
     <string name="route_detail_action_start_route_hint">start playback of this route</string>
     <string name="route_detail_action_start_route_disabled_hint">add waypoints before starting the route</string>
     <string name="route_detail_action_stop_route_hint">stop playback of this route</string>
+    <string name="turn_by_turn_route_calculating">Calculating walking directions to %s.</string>
+    <string name="turn_by_turn_route_started">Starting walking directions to %s.</string>
+    <string name="turn_by_turn_route_failed">We could not calculate walking directions.</string>
+    <string name="turn_by_turn_route_not_configured">Turn by turn routing is not configured.</string>
     <string name="route_detail_action_share_hint">share this route with another app</string>
     <string name="route_detail_action_edit_hint">change or reorder the waypoints in the route</string>
     <string name="route_detail_action_create">New Route</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -135,11 +135,13 @@
 <!-- Location Details page title. This page shows information about the location including the address and a map. -->
 <string name="location_detail_title_default">"Location Details"</string>
 <!-- Title for the action to start playing an audio beacon -->
-<string name="location_detail_action_beacon">"Start Audio Beacon"</string>
-<!-- Title for the action to start playing an audio beacon from the markers list -->
-<string name="location_detail_action_beacon_from_markers">"Start audio beacon at this marker"</string>
-<!-- Talkback hint for the action to set an audio beacon at this location. This is always preceded by "Double tap to " -->
-<string name="location_detail_action_beacon_hint">"guide you towards this location with sound"</string>
+  <string name="location_detail_action_beacon">"Start Audio Beacon"</string>
+  <string name="location_detail_action_directions">"Start Directions"</string>
+  <!-- Title for the action to start playing an audio beacon from the markers list -->
+  <string name="location_detail_action_beacon_from_markers">"Start audio beacon at this marker"</string>
+  <!-- Talkback hint for the action to set an audio beacon at this location. This is always preceded by "Double tap to " -->
+  <string name="location_detail_action_beacon_hint">"guide you towards this location with sound"</string>
+  <string name="location_detail_action_directions_hint">"start turn by turn walking directions to this location"</string>
 <!-- Talkback hint for the action to save marker. This is always preceded by "Double tap to " -->
 <string name="location_detail_action_save_hint">"save this location to use later"</string>
 <!-- Talkback hint for the action to edit marker. This is always preceded by "Double tap to " -->
@@ -177,9 +179,13 @@
 <!-- Talkback hint for the action to start the route when the action is disabled. This action is only disabled when no waypoints have been added to a route yet. This is always preceded by "Double tap to " -->
 <string name="route_detail_action_start_route_disabled_hint">"add waypoints before starting the route"</string>
 <!-- Talkback hint for the action to stop the route. This is always preceded by "Double tap to " -->
-<string name="route_detail_action_stop_route_hint">"stop playback of this route"</string>
-<!-- Talkback hint for the action to share. This is always preceded by "Double tap to " -->
-<string name="route_detail_action_share_hint">"share this route with another app"</string>
+  <string name="route_detail_action_stop_route_hint">"stop playback of this route"</string>
+  <string name="turn_by_turn_route_calculating">"Calculating walking directions to %s."</string>
+  <string name="turn_by_turn_route_started">"Starting walking directions to %s."</string>
+  <string name="turn_by_turn_route_failed">"We could not calculate walking directions."</string>
+  <string name="turn_by_turn_route_not_configured">"Turn by turn routing is not configured."</string>
+  <!-- Talkback hint for the action to share. This is always preceded by "Double tap to " -->
+  <string name="route_detail_action_share_hint">"share this route with another app"</string>
 <!-- Accessibility hint for the edit button on the Route Detail screen . This is always preceded by "Double tap to " -->
 <string name="route_detail_action_edit_hint">"change or reorder the waypoints in the route"</string>
 <!-- Add button on the Route list screen -->

--- a/app/src/test/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnectionTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnectionTest.kt
@@ -1,0 +1,51 @@
+package org.scottishtecharmy.soundscape
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+
+class SoundscapeServiceConnectionTest {
+    @Test
+    fun startTurnByTurnNavigation_queuesRequestUntilServiceCanStartIt() {
+        val connection = SoundscapeServiceConnection()
+        val destination = LngLatAlt(7.4213, 43.7339)
+
+        connection.startTurnByTurnNavigation(destination, "Monaco destination")
+
+        var startedLocation: LngLatAlt? = null
+        var startedName: String? = null
+        val drained = connection.drainPendingTurnByTurnNavigation { location, name ->
+            startedLocation = location
+            startedName = name
+        }
+
+        assertTrue(drained)
+        assertEquals(destination, startedLocation)
+        assertEquals("Monaco destination", startedName)
+        assertFalse(connection.drainPendingTurnByTurnNavigation { _, _ -> })
+    }
+
+    @Test
+    fun startTurnByTurnNavigation_keepsLatestRequestWhenServiceIsNotReady() {
+        val connection = SoundscapeServiceConnection()
+        val firstDestination = LngLatAlt(7.4213, 43.7339)
+        val latestDestination = LngLatAlt(7.4200, 43.7320)
+
+        connection.startTurnByTurnNavigation(firstDestination, "First destination")
+        connection.startTurnByTurnNavigation(latestDestination, "Latest destination")
+
+        var startedLocation: LngLatAlt? = null
+        var startedName: String? = null
+        val drained = connection.drainPendingTurnByTurnNavigation { location, name ->
+            startedLocation = location
+            startedName = name
+        }
+
+        assertTrue(drained)
+        assertEquals(latestDestination, startedLocation)
+        assertEquals("Latest destination", startedName)
+        assertFalse(connection.drainPendingTurnByTurnNavigation { _, _ -> })
+    }
+}

--- a/app/src/test/java/org/scottishtecharmy/soundscape/navigation/GraphHopperRouteParserTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/navigation/GraphHopperRouteParserTest.kt
@@ -1,0 +1,60 @@
+package org.scottishtecharmy.soundscape.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GraphHopperRouteParserTest {
+    @Test
+    fun parsesUnencodedRouteGeometryAndInstructions() {
+        val route = GraphHopperRouteParser.parse(
+            """
+            {
+              "paths": [
+                {
+                  "distance": 42.5,
+                  "time": 30000,
+                  "points": {
+                    "type": "LineString",
+                    "coordinates": [
+                      [7.42461, 43.73841],
+                      [7.42480, 43.73810],
+                      [7.42500, 43.73790]
+                    ]
+                  },
+                  "instructions": [
+                    {
+                      "distance": 12.5,
+                      "heading": 180.0,
+                      "sign": 0,
+                      "interval": [0, 1],
+                      "text": "Continue",
+                      "time": 10000,
+                      "street_name": "Rue des Iris"
+                    },
+                    {
+                      "distance": 30.0,
+                      "sign": 2,
+                      "interval": [1, 2],
+                      "text": "Turn right onto Avenue Saint-Martin",
+                      "time": 20000,
+                      "street_name": "Avenue Saint-Martin"
+                    }
+                  ]
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(42.5, route.distanceMeters, 0.0)
+        assertEquals(30000, route.durationMillis)
+        assertEquals(3, route.geometry.size)
+        assertEquals(43.73841, route.geometry.first().latitude, 0.0)
+        assertEquals(7.42461, route.geometry.first().longitude, 0.0)
+        assertEquals(2, route.instructions.size)
+        assertEquals("Continue", route.instructions.first().text)
+        assertEquals("Rue des Iris", route.instructions.first().streetName)
+        assertEquals(0, route.instructions.first().geometryStartIndex)
+        assertEquals(1, route.instructions.first().geometryEndIndex)
+    }
+}

--- a/app/src/test/java/org/scottishtecharmy/soundscape/navigation/GraphHopperRouteProviderTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/navigation/GraphHopperRouteProviderTest.kt
@@ -1,0 +1,82 @@
+package org.scottishtecharmy.soundscape.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GraphHopperRouteProviderTest {
+    @Test
+    fun fetchesRouteJsonAndParsesNavigationRoute() {
+        val fetcher = CapturingRouteResponseFetcher(sampleRouteJson())
+        val provider = GraphHopperRouteProvider(
+            baseUrl = "http://127.0.0.1:8989",
+            responseFetcher = fetcher
+        )
+
+        val route = provider.route(
+            GraphHopperRouteRequest(
+                start = NavigationPoint(latitude = 43.7384, longitude = 7.4246),
+                destination = NavigationPoint(latitude = 43.7339, longitude = 7.4213)
+            )
+        )
+
+        assertEquals(
+            "http://127.0.0.1:8989/route?profile=foot&point=43.7384,7.4246" +
+                "&point=43.7339,7.4213&locale=en&instructions=true" +
+                "&points_encoded=false&ch.disable=true",
+            fetcher.requestedUrl
+        )
+        assertEquals(42.5, route.distanceMeters, 0.0)
+        assertEquals(2, route.instructions.size)
+        assertEquals("Turn right", route.instructions[1].text)
+    }
+
+    private class CapturingRouteResponseFetcher(
+        private val response: String
+    ) : GraphHopperRouteResponseFetcher {
+        var requestedUrl: String? = null
+
+        override fun fetch(url: String): String {
+            requestedUrl = url
+            return response
+        }
+    }
+
+    private fun sampleRouteJson(): String {
+        return """
+            {
+              "paths": [
+                {
+                  "distance": 42.5,
+                  "time": 30000,
+                  "points": {
+                    "type": "LineString",
+                    "coordinates": [
+                      [7.42461, 43.73841],
+                      [7.42480, 43.73810],
+                      [7.42500, 43.73790]
+                    ]
+                  },
+                  "instructions": [
+                    {
+                      "distance": 12.5,
+                      "sign": 0,
+                      "interval": [0, 1],
+                      "text": "Continue",
+                      "time": 10000,
+                      "street_name": ""
+                    },
+                    {
+                      "distance": 30.0,
+                      "sign": 2,
+                      "interval": [1, 2],
+                      "text": "Turn right",
+                      "time": 20000,
+                      "street_name": "Avenue Saint-Martin"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+    }
+}

--- a/app/src/test/java/org/scottishtecharmy/soundscape/navigation/GraphHopperRouteRequestBuilderTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/navigation/GraphHopperRouteRequestBuilderTest.kt
@@ -1,0 +1,43 @@
+package org.scottishtecharmy.soundscape.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GraphHopperRouteRequestBuilderTest {
+    @Test
+    fun buildsWalkingRouteUrlForUnencodedInstructions() {
+        val url = GraphHopperRouteRequestBuilder.buildRouteUrl(
+            baseUrl = "http://127.0.0.1:8989/",
+            request = GraphHopperRouteRequest(
+                start = NavigationPoint(latitude = 43.7384, longitude = 7.4246),
+                destination = NavigationPoint(latitude = 43.7339, longitude = 7.4213),
+                locale = "en"
+            )
+        )
+
+        assertEquals(
+            "http://127.0.0.1:8989/route?profile=foot&point=43.7384,7.4246" +
+                "&point=43.7339,7.4213&locale=en&instructions=true" +
+                "&points_encoded=false&ch.disable=true",
+            url
+        )
+    }
+
+    @Test
+    fun trimsBaseUrlBeforeAppendingRoutePath() {
+        val url = GraphHopperRouteRequestBuilder.buildRouteUrl(
+            baseUrl = "http://127.0.0.1:8989",
+            request = GraphHopperRouteRequest(
+                start = NavigationPoint(latitude = 55.0, longitude = -4.0),
+                destination = NavigationPoint(latitude = 55.1, longitude = -4.1)
+            )
+        )
+
+        assertEquals(
+            "http://127.0.0.1:8989/route?profile=foot&point=55.0,-4.0" +
+                "&point=55.1,-4.1&locale=en&instructions=true" +
+                "&points_encoded=false&ch.disable=true",
+            url
+        )
+    }
+}

--- a/app/src/test/java/org/scottishtecharmy/soundscape/navigation/RouteFollowerTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/navigation/RouteFollowerTest.kt
@@ -1,0 +1,103 @@
+package org.scottishtecharmy.soundscape.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RouteFollowerTest {
+    @Test
+    fun reportsCurrentInstructionWhenUserIsNearStartOfRoute() {
+        val follower = RouteFollower(
+            testRoute(),
+            RouteFollowerConfig(arrivalThresholdMeters = 4.0)
+        )
+
+        val update = follower.update(NavigationPoint(latitude = 55.0, longitude = -4.0))
+
+        assertEquals(RouteProgressStatus.ON_ROUTE, update.status)
+        assertFalse(update.isOffRoute)
+        assertFalse(update.isArrived)
+        assertEquals(0, update.nextInstructionIndex)
+        assertEquals("Continue", update.nextInstruction?.text)
+    }
+
+    @Test
+    fun advancesToNextInstructionWhenUserReachesInstructionEnd() {
+        val follower = RouteFollower(
+            testRoute(),
+            RouteFollowerConfig(arrivalThresholdMeters = 4.0)
+        )
+        follower.update(NavigationPoint(latitude = 55.0, longitude = -4.0))
+
+        val update = follower.update(NavigationPoint(latitude = 55.0001, longitude = -4.0))
+
+        assertEquals(RouteProgressStatus.ON_ROUTE, update.status)
+        assertEquals(1, update.nextInstructionIndex)
+        assertEquals("Turn right", update.nextInstruction?.text)
+    }
+
+    @Test
+    fun reportsOffRouteWhenUserIsTooFarFromRouteGeometry() {
+        val follower = RouteFollower(
+            testRoute(),
+            RouteFollowerConfig(offRouteThresholdMeters = 25.0)
+        )
+
+        val update = follower.update(NavigationPoint(latitude = 55.0, longitude = -4.001))
+
+        assertEquals(RouteProgressStatus.OFF_ROUTE, update.status)
+        assertTrue(update.isOffRoute)
+        assertFalse(update.isArrived)
+        assertEquals(0, update.nextInstructionIndex)
+    }
+
+    @Test
+    fun reportsArrivalWhenUserReachesFinalRoutePoint() {
+        val follower = RouteFollower(
+            testRoute(),
+            RouteFollowerConfig(arrivalThresholdMeters = 8.0)
+        )
+
+        val update = follower.update(NavigationPoint(latitude = 55.0002, longitude = -4.0))
+
+        assertEquals(RouteProgressStatus.ARRIVED, update.status)
+        assertFalse(update.isOffRoute)
+        assertTrue(update.isArrived)
+        assertNull(update.nextInstruction)
+        assertNull(update.nextInstructionIndex)
+    }
+
+    private fun testRoute(): NavigationRoute {
+        return NavigationRoute(
+            distanceMeters = 22.0,
+            durationMillis = 120000,
+            geometry = listOf(
+                NavigationPoint(latitude = 55.0, longitude = -4.0),
+                NavigationPoint(latitude = 55.0001, longitude = -4.0),
+                NavigationPoint(latitude = 55.0002, longitude = -4.0)
+            ),
+            instructions = listOf(
+                NavigationInstruction(
+                    text = "Continue",
+                    streetName = "",
+                    distanceMeters = 11.0,
+                    durationMillis = 60000,
+                    sign = 0,
+                    geometryStartIndex = 0,
+                    geometryEndIndex = 1
+                ),
+                NavigationInstruction(
+                    text = "Turn right",
+                    streetName = "Main Street",
+                    distanceMeters = 11.0,
+                    durationMillis = 60000,
+                    sign = 2,
+                    geometryStartIndex = 1,
+                    geometryEndIndex = 2
+                )
+            )
+        )
+    }
+}

--- a/app/src/test/java/org/scottishtecharmy/soundscape/navigation/RouteGuidanceAnnouncementFormatterTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/navigation/RouteGuidanceAnnouncementFormatterTest.kt
@@ -1,0 +1,61 @@
+package org.scottishtecharmy.soundscape.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RouteGuidanceAnnouncementFormatterTest {
+    @Test
+    fun formatsInstructionTextDirectlyFromRouteEngine() {
+        val text = RouteGuidanceAnnouncementFormatter.format(
+            RouteGuidanceEvent.Instruction(
+                instructionIndex = 1,
+                instruction = testInstruction("Turn right onto Main Street"),
+                update = testUpdate(RouteProgressStatus.ON_ROUTE)
+            )
+        )
+
+        assertEquals("Turn right onto Main Street", text)
+    }
+
+    @Test
+    fun formatsOffRouteWarning() {
+        val text = RouteGuidanceAnnouncementFormatter.format(
+            RouteGuidanceEvent.OffRoute(testUpdate(RouteProgressStatus.OFF_ROUTE))
+        )
+
+        assertEquals("You are off route.", text)
+    }
+
+    @Test
+    fun formatsArrival() {
+        val text = RouteGuidanceAnnouncementFormatter.format(
+            RouteGuidanceEvent.Arrived(testUpdate(RouteProgressStatus.ARRIVED))
+        )
+
+        assertEquals("Arrived.", text)
+    }
+
+    private fun testInstruction(text: String): NavigationInstruction {
+        return NavigationInstruction(
+            text = text,
+            streetName = "Main Street",
+            distanceMeters = 20.0,
+            durationMillis = 10000,
+            sign = 2,
+            geometryStartIndex = 0,
+            geometryEndIndex = 1
+        )
+    }
+
+    private fun testUpdate(status: RouteProgressStatus): RouteProgressUpdate {
+        return RouteProgressUpdate(
+            status = status,
+            isOffRoute = status == RouteProgressStatus.OFF_ROUTE,
+            isArrived = status == RouteProgressStatus.ARRIVED,
+            nextInstructionIndex = null,
+            nextInstruction = null,
+            distanceFromRouteMeters = 0.0,
+            matchedGeometryIndex = 0
+        )
+    }
+}

--- a/app/src/test/java/org/scottishtecharmy/soundscape/navigation/RouteGuidanceTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/navigation/RouteGuidanceTest.kt
@@ -1,0 +1,105 @@
+package org.scottishtecharmy.soundscape.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RouteGuidanceTest {
+    @Test
+    fun announcesInitialInstructionOnce() {
+        val guidance = RouteGuidance(testRoute(), testConfig())
+
+        val firstEvent = guidance.update(NavigationPoint(latitude = 55.0, longitude = -4.0))
+        val secondEvent = guidance.update(NavigationPoint(latitude = 55.00001, longitude = -4.0))
+
+        assertInstructionEvent(firstEvent, 0, "Continue")
+        assertNull(secondEvent)
+    }
+
+    @Test
+    fun announcesNextInstructionWhenProgressAdvances() {
+        val guidance = RouteGuidance(testRoute(), testConfig())
+        guidance.update(NavigationPoint(latitude = 55.0, longitude = -4.0))
+
+        val event = guidance.update(NavigationPoint(latitude = 55.0001, longitude = -4.0))
+
+        assertInstructionEvent(event, 1, "Turn right")
+    }
+
+    @Test
+    fun announcesOffRouteOnlyOnceUntilUserReturnsToRoute() {
+        val guidance = RouteGuidance(testRoute(), testConfig())
+
+        val firstOffRoute = guidance.update(NavigationPoint(latitude = 55.0, longitude = -4.001))
+        val repeatedOffRoute = guidance.update(NavigationPoint(latitude = 55.00002, longitude = -4.001))
+        val backOnRoute = guidance.update(NavigationPoint(latitude = 55.0, longitude = -4.0))
+        val secondOffRoute = guidance.update(NavigationPoint(latitude = 55.0, longitude = -4.001))
+
+        assertTrue(firstOffRoute is RouteGuidanceEvent.OffRoute)
+        assertNull(repeatedOffRoute)
+        assertInstructionEvent(backOnRoute, 0, "Continue")
+        assertTrue(secondOffRoute is RouteGuidanceEvent.OffRoute)
+    }
+
+    @Test
+    fun announcesArrivalOnce() {
+        val guidance = RouteGuidance(testRoute(), testConfig())
+
+        val firstArrival = guidance.update(NavigationPoint(latitude = 55.0002, longitude = -4.0))
+        val repeatedArrival = guidance.update(NavigationPoint(latitude = 55.0002, longitude = -4.0))
+
+        assertTrue(firstArrival is RouteGuidanceEvent.Arrived)
+        assertNull(repeatedArrival)
+    }
+
+    private fun assertInstructionEvent(
+        event: RouteGuidanceEvent?,
+        expectedIndex: Int,
+        expectedText: String
+    ) {
+        assertTrue(event is RouteGuidanceEvent.Instruction)
+        val instructionEvent = event as RouteGuidanceEvent.Instruction
+        assertEquals(expectedIndex, instructionEvent.instructionIndex)
+        assertEquals(expectedText, instructionEvent.instruction.text)
+    }
+
+    private fun testConfig(): RouteFollowerConfig {
+        return RouteFollowerConfig(
+            offRouteThresholdMeters = 25.0,
+            arrivalThresholdMeters = 4.0
+        )
+    }
+
+    private fun testRoute(): NavigationRoute {
+        return NavigationRoute(
+            distanceMeters = 22.0,
+            durationMillis = 120000,
+            geometry = listOf(
+                NavigationPoint(latitude = 55.0, longitude = -4.0),
+                NavigationPoint(latitude = 55.0001, longitude = -4.0),
+                NavigationPoint(latitude = 55.0002, longitude = -4.0)
+            ),
+            instructions = listOf(
+                NavigationInstruction(
+                    text = "Continue",
+                    streetName = "",
+                    distanceMeters = 11.0,
+                    durationMillis = 60000,
+                    sign = 0,
+                    geometryStartIndex = 0,
+                    geometryEndIndex = 1
+                ),
+                NavigationInstruction(
+                    text = "Turn right",
+                    streetName = "Main Street",
+                    distanceMeters = 11.0,
+                    durationMillis = 60000,
+                    sign = 2,
+                    geometryStartIndex = 1,
+                    geometryEndIndex = 2
+                )
+            )
+        )
+    }
+}

--- a/app/src/test/java/org/scottishtecharmy/soundscape/navigation/TurnByTurnNavigationSessionTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/navigation/TurnByTurnNavigationSessionTest.kt
@@ -1,0 +1,186 @@
+package org.scottishtecharmy.soundscape.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TurnByTurnNavigationSessionTest {
+    @Test
+    fun returnsNoEventBeforeRouteStarts() {
+        val session = TurnByTurnNavigationSession(FakeRouteProvider(testRoute()))
+
+        val event = session.updateLocation(NavigationPoint(latitude = 55.0, longitude = -4.0))
+
+        assertNull(event)
+    }
+
+    @Test
+    fun startsRouteAndEmitsGuidanceEventsFromLocationUpdates() {
+        val provider = FakeRouteProvider(testRoute())
+        val session = TurnByTurnNavigationSession(provider, testConfig())
+        val request = GraphHopperRouteRequest(
+            start = NavigationPoint(latitude = 55.0, longitude = -4.0),
+            destination = NavigationPoint(latitude = 55.0002, longitude = -4.0)
+        )
+
+        val route = session.start(request)
+        val firstEvent = session.updateLocation(NavigationPoint(latitude = 55.0, longitude = -4.0))
+        val nextEvent = session.updateLocation(NavigationPoint(latitude = 55.0001, longitude = -4.0))
+
+        assertEquals(request, provider.lastRequest)
+        assertEquals(testRoute(), route)
+        assertInstructionEvent(firstEvent, 0, "Continue")
+        assertInstructionEvent(nextEvent, 1, "Turn right")
+    }
+
+    @Test
+    fun stopClearsActiveRoute() {
+        val session = TurnByTurnNavigationSession(FakeRouteProvider(testRoute()), testConfig())
+        session.start(
+            GraphHopperRouteRequest(
+                start = NavigationPoint(latitude = 55.0, longitude = -4.0),
+                destination = NavigationPoint(latitude = 55.0002, longitude = -4.0)
+            )
+        )
+
+        session.stop()
+        val event = session.updateLocation(NavigationPoint(latitude = 55.0, longitude = -4.0))
+
+        assertNull(event)
+    }
+
+    @Test
+    fun reroutesFromCurrentLocationAfterOffRoutePersistsForFiveSeconds() {
+        val firstRoute = testRoute()
+        val reroutedRoute = reroutedRoute()
+        val provider = FakeRouteProvider(firstRoute, reroutedRoute)
+        val clock = FakeClock()
+        val session = TurnByTurnNavigationSession(provider, testConfig(), clock::now)
+        val request = GraphHopperRouteRequest(
+            start = NavigationPoint(latitude = 55.0, longitude = -4.0),
+            destination = NavigationPoint(latitude = 55.0002, longitude = -4.0)
+        )
+        val offRouteLocation = NavigationPoint(latitude = 55.001, longitude = -4.002)
+
+        session.start(request)
+        val firstOffRouteUpdate = session.updateLocation(offRouteLocation)
+        clock.advanceBy(4_999)
+        val beforeDebounce = session.updateLocation(offRouteLocation)
+        clock.advanceBy(1)
+        val afterDebounce = session.updateLocation(offRouteLocation)
+
+        assertNull(firstOffRouteUpdate)
+        assertNull(beforeDebounce)
+        assertInstructionEvent(afterDebounce, 0, "Continue on rerouted path")
+        assertEquals(2, provider.requests.size)
+        assertEquals(offRouteLocation, provider.requests.last().start)
+        assertEquals(request.destination, provider.requests.last().destination)
+    }
+
+    private class FakeRouteProvider(
+        private vararg val routes: NavigationRoute
+    ) : NavigationRouteProvider {
+        var lastRequest: GraphHopperRouteRequest? = null
+        val requests = mutableListOf<GraphHopperRouteRequest>()
+
+        override fun route(request: GraphHopperRouteRequest): NavigationRoute {
+            lastRequest = request
+            requests.add(request)
+            return routes[(requests.size - 1).coerceAtMost(routes.lastIndex)]
+        }
+    }
+
+    private class FakeClock {
+        private var timeMillis = 0L
+
+        fun now(): Long = timeMillis
+
+        fun advanceBy(millis: Long) {
+            timeMillis += millis
+        }
+    }
+
+    private fun assertInstructionEvent(
+        event: RouteGuidanceEvent?,
+        expectedIndex: Int,
+        expectedText: String
+    ) {
+        assertTrue(event is RouteGuidanceEvent.Instruction)
+        val instructionEvent = event as RouteGuidanceEvent.Instruction
+        assertEquals(expectedIndex, instructionEvent.instructionIndex)
+        assertEquals(expectedText, instructionEvent.instruction.text)
+    }
+
+    private fun testConfig(): RouteFollowerConfig {
+        return RouteFollowerConfig(
+            offRouteThresholdMeters = 25.0,
+            arrivalThresholdMeters = 4.0,
+            rerouteDebounceMillis = 5_000
+        )
+    }
+
+    private fun testRoute(): NavigationRoute {
+        return NavigationRoute(
+            distanceMeters = 22.0,
+            durationMillis = 120000,
+            geometry = listOf(
+                NavigationPoint(latitude = 55.0, longitude = -4.0),
+                NavigationPoint(latitude = 55.0001, longitude = -4.0),
+                NavigationPoint(latitude = 55.0002, longitude = -4.0)
+            ),
+            instructions = listOf(
+                NavigationInstruction(
+                    text = "Continue",
+                    streetName = "",
+                    distanceMeters = 11.0,
+                    durationMillis = 60000,
+                    sign = 0,
+                    geometryStartIndex = 0,
+                    geometryEndIndex = 1
+                ),
+                NavigationInstruction(
+                    text = "Turn right",
+                    streetName = "Main Street",
+                    distanceMeters = 11.0,
+                    durationMillis = 60000,
+                    sign = 2,
+                    geometryStartIndex = 1,
+                    geometryEndIndex = 2
+                )
+            )
+        )
+    }
+
+    private fun reroutedRoute(): NavigationRoute {
+        return NavigationRoute(
+            distanceMeters = 22.0,
+            durationMillis = 120000,
+            geometry = listOf(
+                NavigationPoint(latitude = 55.001, longitude = -4.002),
+                NavigationPoint(latitude = 55.0011, longitude = -4.002),
+                NavigationPoint(latitude = 55.0002, longitude = -4.0)
+            ),
+            instructions = listOf(
+                NavigationInstruction(
+                    text = "Continue on rerouted path",
+                    streetName = "",
+                    distanceMeters = 11.0,
+                    durationMillis = 60000,
+                    sign = 0,
+                    geometryStartIndex = 0,
+                    geometryEndIndex = 1
+                ),
+                NavigationInstruction(
+                    text = "Turn right after reroute",
+                    streetName = "Main Street",
+                    distanceMeters = 11.0,
+                    durationMillis = 60000,
+                    sign = 2,
+                    geometryStartIndex = 1,
+                    geometryEndIndex = 2
+                )
+            )
+        )
+    }
+}

--- a/docs/developers/offline-turn-by-turn-routing.md
+++ b/docs/developers/offline-turn-by-turn-routing.md
@@ -1,0 +1,153 @@
+---
+title: Offline turn-by-turn routing
+layout: page
+parent: Information for developers
+has_toc: false
+---
+
+# Offline turn-by-turn routing
+
+Soundscape Android currently provides environmental awareness, audio beacons, and waypoint route playback. It does not provide arbitrary destination turn-by-turn navigation. The planned work adds in-app walking guidance while preserving Soundscape's existing audio model.
+
+## Routing engine choice
+
+GraphHopper is the first implementation target.
+
+Reasons:
+
+- JVM-based, so it fits Kotlin/Android proof work better than a C++ engine.
+- OSM-based and Apache 2.0 licensed.
+- Supports foot routing and maneuver instructions.
+- Can run locally as a web server for development.
+- Can later be evaluated as an embedded/offline engine.
+
+Valhalla remains a strong later option. It has good pedestrian routing and clear route APIs, but first Android integration would require C++/NDK/JNI work or a hosted service. That raises risk before we have Soundscape's own navigation session model working.
+
+## Data distinction
+
+Soundscape PMTiles and GraphHopper graphs are different artifacts.
+
+- PMTiles power MapLibre rendering and Soundscape's GeoEngine audio awareness.
+- GraphHopper graph data powers route calculation.
+
+Both can be built from the same OSM snapshot and same extract boundaries, but one cannot replace the other directly.
+
+## Local proof setup
+
+The scripts in `tools/routing` build a local GraphHopper proof using Monaco OSM data. Monaco is intentionally small so the first import runs quickly.
+
+Run:
+
+```powershell
+.\tools\routing\setup-graphhopper-local.ps1
+.\tools\routing\start-graphhopper-local.ps1
+```
+
+In another shell:
+
+```powershell
+.\tools\routing\query-graphhopper-local.ps1
+```
+
+The route response is saved to:
+
+```text
+tools/routing/.local/graphhopper/sample-foot-route.json
+```
+
+That sample is the seed for parser tests in Android.
+
+## Expected GraphHopper endpoint
+
+Android emulators reach the host machine at `10.0.2.2`, so local debug builds can set:
+
+```properties
+routingProviderUrl=http\://10.0.2.2\:8989/
+```
+
+The app's debug manifest allows cleartext HTTP for this local proof. Release builds should use HTTPS or an embedded/offline routing provider instead.
+
+The local route endpoint uses foot routing:
+
+```text
+http://127.0.0.1:8989/route?profile=foot&point=43.7384,7.4246&point=43.7339,7.4213&locale=en&instructions=true&points_encoded=false&ch.disable=true
+```
+
+Expected response fields:
+
+- `paths[0].distance`
+- `paths[0].time`
+- `paths[0].points.coordinates`
+- `paths[0].instructions`
+
+## Android integration direction
+
+Create app-owned normalized models rather than exposing GraphHopper JSON everywhere:
+
+- `NavigationRoute`
+- `NavigationStep`
+- `NavigationPoint`
+- `ManeuverType`
+
+Then implement:
+
+- `GraphHopperRouteParser`
+- `RoutingProvider`
+- `NavigationSession`
+
+`NavigationSession` should live near `SoundscapeService` and use existing systems:
+
+- `LocationProvider.filteredLocationFlow`
+- `MapMatchFilter`
+- `AudioEngine` / `speakText`
+- destination beacon
+- MapLibre route drawing
+
+## Device and accessibility testing
+
+Use the Pixel 6 emulator as an older supported baseline. It can catch problems on smaller, older Pixel hardware. Do not treat it as the only target.
+
+Before release, test at least:
+
+- Pixel 6-class emulator or device, on a supported Android version
+- current Pixel flagship-class emulator or device
+- one lower-spec Android device if available
+- TalkBack enabled
+- Soundscape audio guidance enabled
+- real GPS movement on hardware or Firebase Test Lab for sensor and location behavior
+
+TalkBack testing checks UI labels, focus, actions, and permission flows. It does not replace Soundscape audio testing. Turn-by-turn guidance must also be checked through Soundscape's own speech output because that is the navigation channel users depend on while walking.
+
+For local emulator testing:
+
+```powershell
+adb shell settings put secure enabled_accessibility_services com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService
+adb shell settings put secure accessibility_enabled 1
+```
+
+Then open a destination and confirm that `Start Directions` is reachable and starts guidance. With TalkBack enabled, a normal coordinate tap may only move accessibility focus. Use a double tap or keyboard activation when manually testing.
+
+To run the repeatable local emulator smoke check:
+
+```powershell
+.\tools\routing\run-turn-by-turn-local-smoke.ps1 -EnableTalkBack
+```
+
+The smoke check uses the local GraphHopper server, installs the debug APK, opens a Monaco destination, activates `Start Directions`, verifies that the route starts, moves the app off route, then verifies silent reroute behavior after the 5 second debounce.
+
+The smoke check does not rely on emulator FusedLocation for route-test coordinates. It sends test coordinates to `SoundscapeService` through a debug-only intent guarded by `BuildConfig.DEBUG`. Release builds ignore that action.
+
+This check is local only. Firebase Test Lab devices cannot reach the emulator host alias `10.0.2.2`, so cloud testing needs one of these later options:
+
+- public HTTPS routing endpoint
+- embedded/offline routing provider
+- test build with a fake routing provider
+
+## Offline app direction
+
+The first app phase can call local GraphHopper JSON parsing from tests only. After that:
+
+1. Decide whether to embed GraphHopper or run it as a local service abstraction during development.
+2. Measure graph size for Monaco, then Scotland.
+3. Decide download packaging alongside existing offline maps.
+4. Align GraphHopper graph extracts with Soundscape PMTiles extract metadata.

--- a/tools/routing/query-graphhopper-local.ps1
+++ b/tools/routing/query-graphhopper-local.ps1
@@ -1,0 +1,25 @@
+param(
+    [string]$WorkDir = (Join-Path $PSScriptRoot ".local\graphhopper"),
+    [string]$BaseUrl = "http://127.0.0.1:8989",
+    [string]$OutputFile = "sample-foot-route.json"
+)
+
+$ErrorActionPreference = "Stop"
+
+New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+
+$query = "/route?profile=foot&point=43.7384,7.4246&point=43.7339,7.4213&locale=en&instructions=true&points_encoded=false&ch.disable=true"
+$uri = "$BaseUrl$query"
+$outputPath = Join-Path $WorkDir $OutputFile
+
+Write-Host "Querying: $uri"
+$response = Invoke-WebRequest -UseBasicParsing -Uri $uri
+$response.Content | Set-Content -LiteralPath $outputPath -NoNewline
+
+$json = $response.Content | ConvertFrom-Json
+$path = $json.paths[0]
+
+Write-Host "Saved: $outputPath"
+Write-Host "Distance meters: $($path.distance)"
+Write-Host "Duration ms: $($path.time)"
+Write-Host "Instruction count: $($path.instructions.Count)"

--- a/tools/routing/run-turn-by-turn-local-smoke.ps1
+++ b/tools/routing/run-turn-by-turn-local-smoke.ps1
@@ -1,0 +1,348 @@
+param(
+    [string]$AndroidSdk = (Join-Path $env:LOCALAPPDATA "Android\Sdk"),
+    [string]$Serial = "",
+    [string]$PackageName = "org.scottishtecharmy.soundscape",
+    [string]$GraphHopperBaseUrl = "http://127.0.0.1:8989",
+    [double]$StartLatitude = 43.7384,
+    [double]$StartLongitude = 7.4246,
+    [double]$DestinationLatitude = 43.7339,
+    [double]$DestinationLongitude = 7.4213,
+    [double]$OffRouteLatitude = 43.7440,
+    [double]$OffRouteLongitude = 7.4260,
+    [double]$SecondOffRouteLatitude = 43.7441,
+    [double]$SecondOffRouteLongitude = 7.4261,
+    [int]$UiTimeoutSeconds = 30,
+    [int]$RouteReadyTimeoutSeconds = 30,
+    [switch]$SkipBuild,
+    [switch]$EnableTalkBack
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$adb = Join-Path $AndroidSdk "platform-tools\adb.exe"
+$gradle = Join-Path $repoRoot "gradlew.bat"
+$appApk = Join-Path $repoRoot "app\build\outputs\apk\debug\app-debug.apk"
+$debugSetLocationAction = "$PackageName.DEBUG_SET_LOCATION"
+$adbTarget = @()
+if ($Serial -ne "") {
+    $adbTarget = @("-s", $Serial)
+}
+
+function Invoke-Adb {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    & $adb @adbTarget @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "adb failed: $($Arguments -join ' ')"
+    }
+}
+
+function Invoke-AdbAllowFailure {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    & $adb @adbTarget @Arguments | Out-Null
+}
+
+function Invoke-AdbQuiet {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    & $adb @adbTarget @Arguments *> $null
+    if ($LASTEXITCODE -ne 0) {
+        throw "adb failed: $($Arguments -join ' ')"
+    }
+}
+
+function Set-EmulatorLocation {
+    param(
+        [Parameter(Mandatory = $true)][double]$Latitude,
+        [Parameter(Mandatory = $true)][double]$Longitude,
+        [int]$Repeat = 1,
+        [int]$DelayMilliseconds = 1200
+    )
+
+    for ($i = 0; $i -lt $Repeat; $i++) {
+        Invoke-Adb @("emu", "geo", "fix", "$Longitude", "$Latitude")
+        if ($i -lt ($Repeat - 1)) {
+            Start-Sleep -Milliseconds $DelayMilliseconds
+        }
+    }
+}
+
+function Set-AppDebugLocation {
+    param(
+        [Parameter(Mandatory = $true)][double]$Latitude,
+        [Parameter(Mandatory = $true)][double]$Longitude
+    )
+
+    Invoke-Adb @(
+        "shell",
+        "am",
+        "startservice",
+        "-a",
+        $debugSetLocationAction,
+        "-n",
+        "$PackageName/.services.SoundscapeService",
+        "--ed",
+        "latitude",
+        "$Latitude",
+        "--ed",
+        "longitude",
+        "$Longitude"
+    )
+}
+
+function Test-GraphHopperRoute {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][double]$Latitude,
+        [Parameter(Mandatory = $true)][double]$Longitude
+    )
+
+    $query = "/route?profile=foot&point=$Latitude,$Longitude&point=$DestinationLatitude,$DestinationLongitude&locale=en&instructions=true&points_encoded=false&ch.disable=true"
+    $uri = "$GraphHopperBaseUrl$query"
+
+    Write-Host "Checking GraphHopper $Name route: $uri"
+    $response = Invoke-WebRequest -UseBasicParsing -Uri $uri -TimeoutSec 10
+    $json = $response.Content | ConvertFrom-Json
+    if ($null -eq $json.paths -or $json.paths.Count -eq 0) {
+        throw "GraphHopper returned no route paths for $Name."
+    }
+    if ($null -eq $json.paths[0].instructions -or $json.paths[0].instructions.Count -eq 0) {
+        throw "GraphHopper returned no route instructions for $Name."
+    }
+    Write-Host "GraphHopper $Name route OK: $([math]::Round($json.paths[0].distance)) meters, $($json.paths[0].instructions.Count) instructions"
+}
+
+function Test-GraphHopper {
+    Test-GraphHopperRoute -Name "start" -Latitude $StartLatitude -Longitude $StartLongitude
+    Test-GraphHopperRoute -Name "off-route" -Latitude $OffRouteLatitude -Longitude $OffRouteLongitude
+    Test-GraphHopperRoute -Name "second off-route" -Latitude $SecondOffRouteLatitude -Longitude $SecondOffRouteLongitude
+}
+
+function Get-Logcat {
+    return [string]::Join("`n", (& $adb @adbTarget @("logcat", "-d", "-v", "brief")))
+}
+
+function Get-SmokeLogcat {
+    $patterns = @(
+        "Turn-by-turn",
+        "GraphHopper",
+        "LocationDetailsViewModel",
+        "SoundscapeService",
+        "SoundscapeServiceConnection",
+        "SoundscapeIntents",
+        "MainActivity"
+    )
+    $pattern = $patterns -join "|"
+    return [string]::Join("`n", (
+        & $adb @adbTarget @("logcat", "-d", "-v", "brief") |
+            Select-String -Pattern $pattern |
+            ForEach-Object { $_.Line }
+    ))
+}
+
+function Get-LogTail {
+    param([Parameter(Mandatory = $true)][string]$Log)
+
+    return ($Log -split "`n" | Select-Object -Last 80) -join "`n"
+}
+
+function Wait-ForLog {
+    param(
+        [Parameter(Mandatory = $true)][string]$Pattern,
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        $log = Get-Logcat
+        if ($log -match $Pattern) {
+            return $true
+        }
+        Start-Sleep -Seconds 1
+    }
+    return $false
+}
+
+function Get-UiXml {
+    Invoke-AdbQuiet @("shell", "uiautomator", "dump", "/sdcard/window.xml")
+    return [string]::Join("`n", (& $adb @adbTarget @("exec-out", "cat", "/sdcard/window.xml")))
+}
+
+function Wait-ForResourceBounds {
+    param(
+        [Parameter(Mandatory = $true)][string[]]$ResourceIds,
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        try {
+            [xml]$xml = Get-UiXml
+            foreach ($resourceId in $ResourceIds) {
+                $node = $xml.SelectSingleNode("//*[@resource-id='$resourceId']")
+                if ($null -ne $node) {
+                    $bounds = $node.bounds
+                    if ($bounds -match "\[(\d+),(\d+)\]\[(\d+),(\d+)\]") {
+                        $left = [int]$Matches[1]
+                        $top = [int]$Matches[2]
+                        $right = [int]$Matches[3]
+                        $bottom = [int]$Matches[4]
+                        return @{
+                            X = [int](($left + $right) / 2)
+                            Y = [int](($top + $bottom) / 2)
+                        }
+                    }
+                }
+            }
+        } catch {
+            Start-Sleep -Seconds 1
+        }
+        Start-Sleep -Seconds 1
+    }
+
+    throw "Resource id not found: $($ResourceIds -join ', ')"
+}
+
+function Set-TestPreferences {
+    $prefsFile = "$PackageName`_preferences.xml"
+    $tmpPrefs = Join-Path ([System.IO.Path]::GetTempPath()) "soundscape-local-smoke-preferences.xml"
+    $prefsXml = @"
+<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
+<map>
+    <boolean name="FirstLaunch" value="false" />
+    <boolean name="ShowMap" value="false" />
+    <string name="LastNewRelease">local-smoke</string>
+</map>
+"@
+
+    Set-Content -LiteralPath $tmpPrefs -Value $prefsXml -Encoding UTF8
+    Invoke-AdbQuiet @("push", $tmpPrefs, "/data/local/tmp/soundscape-local-smoke-preferences.xml")
+    Invoke-AdbQuiet @("shell", "chmod", "644", "/data/local/tmp/soundscape-local-smoke-preferences.xml")
+    Invoke-AdbQuiet @("shell", "run-as", $PackageName, "mkdir", "-p", "shared_prefs")
+    Invoke-AdbQuiet @("shell", "run-as", $PackageName, "cp", "/data/local/tmp/soundscape-local-smoke-preferences.xml", "shared_prefs/$prefsFile")
+}
+
+function Grant-TestPermissions {
+    $permissions = @(
+        "android.permission.ACCESS_COARSE_LOCATION",
+        "android.permission.ACCESS_FINE_LOCATION",
+        "android.permission.POST_NOTIFICATIONS",
+        "android.permission.RECORD_AUDIO"
+    )
+
+    foreach ($permission in $permissions) {
+        Invoke-AdbAllowFailure @("shell", "pm", "grant", $PackageName, $permission)
+    }
+    Invoke-AdbAllowFailure @("shell", "dumpsys", "deviceidle", "whitelist", "+$PackageName")
+}
+
+function Enable-TalkBackIfRequested {
+    if (!$EnableTalkBack) {
+        return $false
+    }
+
+    $packages = [string]::Join("`n", (& $adb @adbTarget @("shell", "pm", "list", "packages", "com.google.android.marvin.talkback")))
+    if ($packages -notmatch "com.google.android.marvin.talkback") {
+        throw "TalkBack package missing on emulator."
+    }
+
+    Invoke-Adb @("shell", "settings", "put", "secure", "enabled_accessibility_services", "com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService")
+    Invoke-Adb @("shell", "settings", "put", "secure", "accessibility_enabled", "1")
+    Invoke-AdbAllowFailure @("shell", "pm", "grant", "com.google.android.marvin.talkback", "android.permission.POST_NOTIFICATIONS")
+    return $true
+}
+
+if (!(Test-Path -LiteralPath $adb)) {
+    throw "adb.exe not found at '$adb'."
+}
+
+Test-GraphHopper
+
+if (!$SkipBuild) {
+    Write-Host "Building debug APK"
+    & $gradle ":app:assembleDebug" "--console=plain"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Gradle assembleDebug failed."
+    }
+}
+
+if (!(Test-Path -LiteralPath $appApk)) {
+    throw "Debug APK missing: $appApk"
+}
+
+Write-Host "Installing app"
+Invoke-Adb @("install", "-r", $appApk)
+Set-TestPreferences
+Grant-TestPermissions
+$talkBackEnabledForSmoke = Enable-TalkBackIfRequested
+
+Write-Host "Starting route smoke scenario"
+Invoke-AdbAllowFailure @("shell", "am", "force-stop", $PackageName)
+Set-EmulatorLocation -Latitude $StartLatitude -Longitude $StartLongitude -Repeat 2
+Invoke-Adb @("logcat", "-c")
+Invoke-Adb @(
+    "shell",
+    "am",
+    "start",
+    "-a",
+    "android.intent.action.VIEW",
+    "-d",
+    "soundscape:$DestinationLatitude,$DestinationLongitude",
+    "-p",
+    $PackageName
+)
+
+$directionsResourceIds = @(
+    "locationDetailsStartDirections",
+    "$PackageName`:id/locationDetailsStartDirections"
+)
+$tapPoint = Wait-ForResourceBounds -ResourceIds $directionsResourceIds -TimeoutSeconds $UiTimeoutSeconds
+if (!(Wait-ForLog -Pattern "LocationDetailsViewModel.*serviceBoundState true|SoundscapeServiceConnection.*onServiceConnected" -TimeoutSeconds $UiTimeoutSeconds)) {
+    $tail = Get-LogTail -Log (Get-SmokeLogcat)
+    throw "Service did not bind before directions activation. Log tail:`n$tail"
+}
+Set-EmulatorLocation -Latitude $StartLatitude -Longitude $StartLongitude -Repeat 2
+Set-AppDebugLocation -Latitude $StartLatitude -Longitude $StartLongitude
+if (!(Wait-ForLog -Pattern "Debug static location set: $StartLatitude,$StartLongitude" -TimeoutSeconds 10)) {
+    $tail = Get-LogTail -Log (Get-SmokeLogcat)
+    throw "Debug start location was not applied. Log tail:`n$tail"
+}
+Start-Sleep -Seconds 2
+
+Write-Host "Activating Start Directions at $($tapPoint.X),$($tapPoint.Y)"
+if ($talkBackEnabledForSmoke) {
+    Invoke-Adb @("shell", "input", "tap", "$($tapPoint.X)", "$($tapPoint.Y)")
+    Start-Sleep -Milliseconds 500
+    Invoke-Adb @("shell", "input", "tap", "$($tapPoint.X)", "$($tapPoint.Y)")
+    Start-Sleep -Milliseconds 80
+    Invoke-Adb @("shell", "input", "tap", "$($tapPoint.X)", "$($tapPoint.Y)")
+} else {
+    Invoke-Adb @("shell", "input", "tap", "$($tapPoint.X)", "$($tapPoint.Y)")
+}
+
+if (!(Wait-ForLog -Pattern "Turn-by-turn route ready" -TimeoutSeconds $RouteReadyTimeoutSeconds)) {
+    $tail = Get-LogTail -Log (Get-SmokeLogcat)
+    throw "Route did not become ready. Log tail:`n$tail"
+}
+Write-Host "Route start OK"
+
+Write-Host "Testing silent reroute after off-route location persists"
+Invoke-Adb @("logcat", "-c")
+Set-AppDebugLocation -Latitude $OffRouteLatitude -Longitude $OffRouteLongitude
+Start-Sleep -Seconds 6
+Set-AppDebugLocation -Latitude $SecondOffRouteLatitude -Longitude $SecondOffRouteLongitude
+Start-Sleep -Seconds 2
+
+$rerouteLog = Get-Logcat
+if ($rerouteLog -match "Turn-by-turn event: OffRoute") {
+    throw "Off-route event was spoken/logged. Silent reroute expected."
+}
+if (!(Wait-ForLog -Pattern "Turn-by-turn event: Instruction" -TimeoutSeconds 20)) {
+    $tail = Get-LogTail -Log (Get-SmokeLogcat)
+    throw "No reroute instruction observed after off-route movement. Log tail:`n$tail"
+}
+
+Write-Host "Silent reroute OK"
+Write-Host "Local turn-by-turn smoke passed"

--- a/tools/routing/setup-graphhopper-local.ps1
+++ b/tools/routing/setup-graphhopper-local.ps1
@@ -1,0 +1,88 @@
+param(
+    [string]$WorkDir = (Join-Path $PSScriptRoot ".local\graphhopper"),
+    [string]$JavaExe = "C:\Program Files\Eclipse Adoptium\jdk-21.0.9.10-hotspot\bin\java.exe",
+    [string]$GraphHopperVersion = "11.0",
+    [string]$OsmPbfUrl = "https://download.geofabrik.de/europe/monaco-latest.osm.pbf"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Save-UrlIfMissing {
+    param(
+        [Parameter(Mandatory = $true)][string]$Url,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    if (Test-Path -LiteralPath $Path) {
+        Write-Host "Exists: $Path"
+        return
+    }
+
+    Write-Host "Downloading: $Url"
+    Invoke-WebRequest -UseBasicParsing -Uri $Url -OutFile $Path
+}
+
+if (!(Test-Path -LiteralPath $JavaExe)) {
+    throw "JDK 21 java.exe not found at '$JavaExe'. Install Eclipse Temurin 21 or pass -JavaExe."
+}
+
+New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+
+$jarName = "graphhopper-web-$GraphHopperVersion.jar"
+$jarPath = Join-Path $WorkDir $jarName
+$jarUrl = "https://repo1.maven.org/maven2/com/graphhopper/graphhopper-web/$GraphHopperVersion/$jarName"
+Save-UrlIfMissing -Url $jarUrl -Path $jarPath
+
+$pbfName = Split-Path -Leaf $OsmPbfUrl
+$pbfPath = Join-Path $WorkDir $pbfName
+Save-UrlIfMissing -Url $OsmPbfUrl -Path $pbfPath
+
+$configUrl = "https://raw.githubusercontent.com/graphhopper/graphhopper/$GraphHopperVersion/config-example.yml"
+$configPath = Join-Path $WorkDir "config.yml"
+Save-UrlIfMissing -Url $configUrl -Path $configPath
+
+$builtInModelNames = @(
+    "car.json",
+    "foot.json",
+    "foot_elevation.json",
+    "bike.json",
+    "bike_elevation.json"
+)
+
+foreach ($model in $builtInModelNames) {
+    $localModel = Join-Path $WorkDir $model
+    if (Test-Path -LiteralPath $localModel) {
+        Remove-Item -LiteralPath $localModel -Force
+        Write-Host "Removed local built-in model shadow: $localModel"
+    }
+}
+
+$config = Get-Content -Raw -LiteralPath $configPath
+$config = $config -replace '(?m)^  datareader\.file:.*$', "  datareader.file: `"$pbfName`""
+$config = $config -replace '(?m)^  graph\.location:.*$', '  graph.location: graph-cache'
+$config = $config -replace '(?m)^  graph\.elevation\.provider:.*$', '  graph.elevation.provider: ""'
+$config = $config -replace '(?m)^  import\.osm\.ignored_highways:.*$', "  import.osm.ignored_highways: ''"
+$config = $config -replace '(?ms)^  profiles:.*?^  profiles_ch:', @"
+  profiles:
+   - name: car
+     custom_model_files: [car.json]
+   - name: foot
+     custom_model_files: [foot.json]
+
+  profiles_ch:
+"@
+$config = $config -replace '(?m)^  graph\.encoded_values:.*$', '  graph.encoded_values: car_access, car_average_speed, road_access, road_class, road_environment, roundabout, foot_access, foot_priority, foot_average_speed, foot_road_access, hike_rating, mtb_rating, country, ferry_speed'
+Set-Content -LiteralPath $configPath -Value $config -NoNewline
+
+$graphCache = Join-Path $WorkDir "graph-cache"
+if (Test-Path -LiteralPath $graphCache) {
+    Remove-Item -LiteralPath $graphCache -Recurse -Force
+    Write-Host "Removed graph cache so profile/config changes are re-imported: $graphCache"
+}
+
+& $JavaExe -version
+
+Write-Host ""
+Write-Host "GraphHopper local setup written to: $WorkDir"
+Write-Host "Start server:"
+Write-Host ".\tools\routing\start-graphhopper-local.ps1"

--- a/tools/routing/start-graphhopper-local.ps1
+++ b/tools/routing/start-graphhopper-local.ps1
@@ -1,0 +1,32 @@
+param(
+    [string]$WorkDir = (Join-Path $PSScriptRoot ".local\graphhopper"),
+    [string]$JavaExe = "C:\Program Files\Eclipse Adoptium\jdk-21.0.9.10-hotspot\bin\java.exe",
+    [string]$GraphHopperVersion = "11.0",
+    [int]$Port = 8989
+)
+
+$ErrorActionPreference = "Stop"
+
+$jarPath = Join-Path $WorkDir "graphhopper-web-$GraphHopperVersion.jar"
+$configPath = Join-Path $WorkDir "config.yml"
+
+if (!(Test-Path -LiteralPath $JavaExe)) {
+    throw "JDK 21 java.exe not found at '$JavaExe'."
+}
+
+if (!(Test-Path -LiteralPath $jarPath)) {
+    throw "GraphHopper jar missing. Run tools\routing\setup-graphhopper-local.ps1 first."
+}
+
+if (!(Test-Path -LiteralPath $configPath)) {
+    throw "GraphHopper config missing. Run tools\routing\setup-graphhopper-local.ps1 first."
+}
+
+Push-Location $WorkDir
+try {
+    Write-Host "Starting GraphHopper on http://127.0.0.1:$Port"
+    & $JavaExe -Xmx2g -jar $jarPath server $configPath
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary

This draft PR adds a first in-app turn-by-turn routing path for Android. It uses a local GraphHopper routing service through `routingProviderUrl`, so guidance stays inside Soundscape instead of handing the user to another map app.

Changes included:

- route request, parsing, route following, off-route rerouting, and spoken guidance formatting
- `Start Directions` on Location Details, wired through `SoundscapeServiceConnection` into `SoundscapeService`
- debug-only location injection and PowerShell scripts for local GraphHopper setup and smoke testing
- unit tests, one Compose accessibility test for the Start Directions action, and developer setup docs

## Why this is draft

This is not meant as a final product decision. It gives maintainers a working branch to review before we widen scope. I would like feedback on:

- whether GraphHopper is acceptable as the first self-hosted, offline-capable provider
- whether routing should stay behind build-time `routingProviderUrl` config or move to user or developer settings later
- route announcement wording, reroute behavior, and stop controls
- whether debug-only location injection is acceptable for local smoke tests

## Authors

- `blindndangerous <20344049+blindndangerous@users.noreply.github.com>`: feature direction, implementation review, commits, and testing
- `OpenAI Codex <codex@openai.com>`: implementation assistance. Each commit includes `Co-authored-by: OpenAI Codex <codex@openai.com>`.

## Validation

- `./gradlew.bat :app:testDebugUnitTest --tests "org.scottishtecharmy.soundscape.navigation.*" --tests "org.scottishtecharmy.soundscape.SoundscapeServiceConnectionTest" --console=plain`
- `./gradlew.bat :app:assembleDebug :app:assembleDebugAndroidTest --console=plain`
- Installed debug and androidTest APKs on emulator
- `adb shell am instrument -w -e class org.scottishtecharmy.soundscape.LocationDetailsScreenTest org.scottishtecharmy.soundscape.test/androidx.test.runner.AndroidJUnitRunner`
- `./tools/routing/run-turn-by-turn-local-smoke.ps1 -SkipBuild -EnableTalkBack`

The smoke run covered GraphHopper route checks from the start point and two off-route points, route start, silent reroute, and a TalkBack-enabled emulator run.

## Notes for reviewers

Local setup is documented in `docs/developers/offline-turn-by-turn-routing.md`. The smoke script expects GraphHopper on `127.0.0.1:8989`; the app reaches the same service from the emulator with `10.0.2.2:8989` through `routingProviderUrl`.