### PR TITLE
Fix ClassCastException when interpolating polygon-geometry house numbers

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/geocoders/StreetDescription.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/geocoders/StreetDescription.kt
@@ -20,7 +20,6 @@ import org.scottishtecharmy.soundscape.geoengine.utils.getSideOfLine
 import org.scottishtecharmy.soundscape.geoengine.utils.rulers.Ruler
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LineString
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
-import org.scottishtecharmy.soundscape.geojsonparser.geojson.Point
 import java.util.SortedMap
 import kotlin.collections.iterator
 import kotlin.collections.set
@@ -534,10 +533,15 @@ class StreetDescription(val name: String, val gridState: GridState) {
             if(parsedHaystack == null)
                 continue
 
+            // The feature's geometry isn't always a Point - house numbers can also come from
+            // building or POI polygons that carry a housenumber tag, so use the same helper that
+            // addHouse uses to get a representative location for the feature.
+            val centralPoint = getCentralPointForFeature(number.value) ?: continue
+
             if (parsedHaystack == needle) {
                 // We've found an exact match
                 return Pair(
-                    (number.value.geometry as Point).coordinates,
+                    centralPoint,
                     number.value.housenumber ?: ""
                 )
             }
@@ -557,7 +561,7 @@ class StreetDescription(val name: String, val gridState: GridState) {
 
             lastParsed = parsedHaystack
             lastKey = number.key
-            lastPoint = (number.value.geometry as Point).coordinates
+            lastPoint = centralPoint
         }
         return  null
     }

--- a/app/src/test/java/org/scottishtecharmy/soundscape/SearchTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/SearchTest.kt
@@ -496,4 +496,27 @@ class SearchTest {
             assertEquals("Эдинбург қамалы", results[0].name)
         }
     }
+
+    @Test
+    fun interpolatedAddressSearchWithPolygonHouseNumber() {
+        // Regression test for a real crash: "Carnoustie Library" (osm id 6068429362) is real
+        // data within glasgow-gb.pmtiles, tagged housenumber=21, street=High Street, but with
+        // Polygon (building outline) geometry rather than the Point geometry that
+        // StreetDescription.getInterpolateLocation used to assume every house number had.
+        // Resolving any house number on this street used to throw
+        // "ClassCastException: Polygon cannot be cast to Point".
+        runBlocking {
+            val currentLocation = LngLatAlt(-2.7080655097961426, 56.50118028013476)
+            val gridState = getGridStateForLocation(currentLocation, MAX_ZOOM_LEVEL, GRID_SIZE)
+
+            val tileSearch = TileSearch(offlineExtractPath, gridState, gridState)
+            val nearestWay = tileSearch.findNearestNamedWay(currentLocation, "High Street")!!
+
+            val streetDescription = StreetDescription("High Street", gridState)
+            streetDescription.createDescription(nearestWay, null)
+
+            val result = streetDescription.getLocationFromStreetNumber("21")
+            assertEquals("21", result?.second)
+        }
+    }
 }


### PR DESCRIPTION
StreetDescription.getInterpolateLocation() assumed every house number feature had Point geometry, but building/POI polygons tagged with a housenumber also get added to the street's house number map. Use getCentralPointForFeature() (already used elsewhere for this) instead of casting directly to Point.