### PR TITLE
Improve app behaviour when offline map is updated

### DIFF
--- a/.github/workflows/run-maestro-tests.yaml
+++ b/.github/workflows/run-maestro-tests.yaml
@@ -231,8 +231,13 @@ jobs:
             #
             # "Unable to launch app" launch timeouts are intermittent on the
             # heavier google_apis images - the app itself does not crash and the
-            # next flow launches fine. The rf() helper runs a flow and retries it
-            # ONCE, but ONLY when its JUnit report shows that exact launch failure.
+            # next flow launches fine. Also seen for the same reason: Maestro's
+            # launchApp issuing its own adb call right into the adbd-restart race
+            # described above (adb root, further up), surfacing as "Command failed
+            # (host:transport:...): device offline" instead of the launch-timeout
+            # message - same transient cause, different wording, so it needs the
+            # same retry. The rf() helper runs a flow and retries it ONCE, but ONLY
+            # when its JUnit report shows one of those exact launch failures.
             # launchApp is the first command, before a flow does any work, so a
             # retry then is safe. A blind retry-on-any-failure would NOT be: the
             # stateful flows (e.g. LocationDetails assumes an empty database and
@@ -240,7 +245,7 @@ jobs:
             # their changes if re-run after a mid-flow failure. The retry reuses the
             # same --output path so the report reflects the final attempt.
             # To add a flow, add its name (without .yaml) to the list below.
-            status=0; rf(){ $HOME/.maestro/bin/maestro test --format=junit --output="maestro_outputs/report-$1.xml" --test-output-dir=maestro_outputs --no-ansi "maestro/$1.yaml"; r=$?; if [ "$r" -ne 0 ] && grep -q "Unable to launch app" "maestro_outputs/report-$1.xml" 2>/dev/null; then echo "::warning::launch of $1 failed; retrying once"; $HOME/.maestro/bin/maestro test --format=junit --output="maestro_outputs/report-$1.xml" --test-output-dir=maestro_outputs --no-ansi "maestro/$1.yaml"; r=$?; fi; return "$r"; }; rf Onboarding || status=1; adb shell mkdir -p /storage/emulated/0/Android/data/org.scottishtecharmy.soundscape/files/Download; adb push glasgow-gb.pmtiles /storage/emulated/0/Android/data/org.scottishtecharmy.soundscape/files/Download/; adb push .github/fixtures/glasgow-gb.pmtiles.geojson /storage/emulated/0/Android/data/org.scottishtecharmy.soundscape/files/Download/; for flow in HomePage LocationDetails PlacesNearby MarkersAndRoutes RouteCreation; do rf "$flow" || status=1; done; exit $status
+            status=0; rf(){ $HOME/.maestro/bin/maestro test --format=junit --output="maestro_outputs/report-$1.xml" --test-output-dir=maestro_outputs --no-ansi "maestro/$1.yaml"; r=$?; if [ "$r" -ne 0 ] && grep -Eq "Unable to launch app|device offline" "maestro_outputs/report-$1.xml" 2>/dev/null; then echo "::warning::launch of $1 failed; retrying once"; $HOME/.maestro/bin/maestro test --format=junit --output="maestro_outputs/report-$1.xml" --test-output-dir=maestro_outputs --no-ansi "maestro/$1.yaml"; r=$?; fi; return "$r"; }; rf Onboarding || status=1; adb shell mkdir -p /storage/emulated/0/Android/data/org.scottishtecharmy.soundscape/files/Download; adb push glasgow-gb.pmtiles /storage/emulated/0/Android/data/org.scottishtecharmy.soundscape/files/Download/; adb push .github/fixtures/glasgow-gb.pmtiles.geojson /storage/emulated/0/Android/data/org.scottishtecharmy.soundscape/files/Download/; for flow in HomePage LocationDetails PlacesNearby MarkersAndRoutes RouteCreation; do rf "$flow" || status=1; done; exit $status
 
       # Artifact names must be unique across the matrix, so suffix them with the
       # combination (e.g. maestro-reports-35-large-ja-JP).

--- a/.github/workflows/run-maestro-tests.yaml
+++ b/.github/workflows/run-maestro-tests.yaml
@@ -150,7 +150,14 @@ jobs:
           script: |
             # The emulator runs a userdebug image, so "adb root" is available;
             # we need it for scoped-storage writes and to set the system locale.
-            adb root
+            # "adb root" restarts adbd and the connection briefly drops while it
+            # does; intermittently the client sees that drop as a hard failure
+            # ("adb: unable to connect for root: closed") instead of reconnecting,
+            # especially right after the adb daemon has just started. Each script
+            # line here runs in its own shell, so a non-zero exit is fatal to the
+            # whole run - retry a few times with a short backoff rather than
+            # failing the job on what is normally a transient race.
+            status=1; for i in $(seq 1 10); do if adb wait-for-device && adb root; then status=0; break; fi; echo "adb root attempt $i failed, retrying..."; sleep 3; done; if [ "$status" -ne 0 ]; then echo "::error::adb root did not succeed after retries"; exit 1; fi
             adb wait-for-device
 
             # Language dimension: set the system locale and restart the Android

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -107,6 +107,7 @@ jobs:
             adb root
             adb shell mkdir -p /storage/emulated/0/Android/data/org.scottishtecharmy.soundscape/files/Download
             adb push ${{ env.main_project_module }}/src/test/res/org/scottishtecharmy/soundscape/glasgow-gb.pmtiles /storage/emulated/0/Android/data/org.scottishtecharmy.soundscape/files/Download/
+            adb push ${{ env.main_project_module }}/src/test/res/org/scottishtecharmy/soundscape/bristol-gb.pmtiles /storage/emulated/0/Android/data/org.scottishtecharmy.soundscape/files/Download/
             adb logcat -c                             # clear logs
             touch app/emulator.log                    # create log file
             chmod 777 app/emulator.log                # allow writing to log file

--- a/app/src/androidTest/java/org/scottishtecharmy/soundscape/PmtilesSwapCrashTest.kt
+++ b/app/src/androidTest/java/org/scottishtecharmy/soundscape/PmtilesSwapCrashTest.kt
@@ -1,0 +1,171 @@
+package org.scottishtecharmy.soundscape
+
+import android.os.Environment
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.After
+import org.junit.Assume.assumeTrue
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.maplibre.android.MapLibre
+import org.maplibre.android.camera.CameraPosition
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.style.sources.VectorSource
+import org.scottishtecharmy.soundscape.screens.home.home.rememberMapViewWithLifecycle
+import java.io.File
+
+/**
+ * Manual reproduction of the native SIGABRT this fix addresses - NOT part of the automated test
+ * suite (see the [Ignore] on [swappingPmtilesFileInPlaceCrashesMapLibre]).
+ *
+ * MapLibre's native PMTilesFileSource caches parsed header/directory data per
+ * pmtiles://file://<path> URL for the life of the process, with no way to invalidate it (see
+ * platform/default/src/mbgl/storage/pmtiles_file_source.cpp in maplibre-native - header_cache,
+ * metadata_cache and directory_cache are all keyed by URL and never evicted on file change). If a
+ * .pmtiles file already opened by a live map is overwritten in place - same path, different
+ * content - the next tile MapLibre requests is looked up using offsets cached from the *old*
+ * file's directory, then read from the *new* file's bytes at those offsets. Those bytes are
+ * essentially random relative to the new file's actual layout, mbgl::util::decompress fails to
+ * gunzip them, and the exception escapes MapLibre's file-source worker thread with no try/catch,
+ * hitting std::terminate - a full process abort, not a normal Response::Error.
+ *
+ * This test reproduces exactly that: load a real map view against glasgow-gb.pmtiles, let MapLibre
+ * cache its header/root directory by rendering a tile, overwrite the same file path with a
+ * completely different city's pmtiles extract (bristol-gb.pmtiles), then force fresh tile
+ * requests in the area MapLibre already has cached header info for. The instrumentation process
+ * is expected to die with a native SIGABRT - that IS the test passing. A JUnit assertion can't
+ * express "the process should crash", so there is deliberately no pass/fail signal beyond that;
+ * confirm reproduction via logcat/tombstone, matching the backtrace through
+ * PMTilesFileSource::Impl / mbgl::util::decompress documented in the memory notes for this fix.
+ *
+ * ## How to run
+ * 1. Push two distinct real-world .pmtiles fixtures to the app's external "Download" folder (the
+ *    same fixtures/location CI already uses for other tests - see run-tests.yaml):
+ *    ```
+ *    adb root
+ *    adb shell mkdir -p /storage/emulated/0/Android/data/org.scottishtecharmy.soundscape/files/Download
+ *    adb push glasgow-gb.pmtiles /storage/emulated/0/Android/data/org.scottishtecharmy.soundscape/files/Download/
+ *    adb push bristol-gb.pmtiles /storage/emulated/0/Android/data/org.scottishtecharmy.soundscape/files/Download/
+ *    ```
+ *    (Both are fetched by CI from the R2 bucket - see the `wget` steps in run-tests.yaml if you
+ *    need URLs to download them yourself.)
+ * 2. Comment out the `@Ignore` on [swappingPmtilesFileInPlaceCrashesMapLibre].
+ * 3. `adb logcat -c && ./gradlew connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.scottishtecharmy.soundscape.PmtilesSwapCrashTest`
+ * 4. Watch for the instrumentation process dying mid-test, then `adb logcat` for a `libmaplibre.so`
+ *    abort whose backtrace includes `PMTilesFileSource` / `mbgl::util::decompress`.
+ */
+class PmtilesSwapCrashTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+    private val downloadsDir =
+        targetContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)!!
+    private val fixtureA = File(downloadsDir, "glasgow-gb.pmtiles")
+    private val fixtureB = File(downloadsDir, "bristol-gb.pmtiles")
+
+    // A scratch path independent of the real app's offline-extract scanning - this test drives
+    // its own minimal MapView rather than the app's real map screen, so nothing else needs to
+    // treat this as a "real" downloaded extract.
+    private val scratchDir = File(downloadsDir, "pmtiles-swap-test")
+    private val scratchFile = File(scratchDir, "swap.pmtiles")
+
+    private lateinit var mapView: MapView
+
+    @After
+    fun cleanup() {
+        scratchDir.deleteRecursively()
+    }
+
+    @Ignore(
+        "Deliberately reproduces a native SIGABRT in libmaplibre.so - run manually only, see " +
+            "class KDoc for setup and how to interpret the result."
+    )
+    @Test
+    fun swappingPmtilesFileInPlaceCrashesMapLibre() {
+        assumeTrue("fixture not present: ${fixtureA.path}", fixtureA.exists())
+        assumeTrue("fixture not present: ${fixtureB.path}", fixtureB.exists())
+
+        scratchDir.mkdirs()
+        fixtureA.copyTo(scratchFile, overwrite = true)
+
+        // A location well within glasgow-gb.pmtiles's coverage.
+        val glasgowCenter = LatLng(55.8642, -4.2518)
+
+        composeTestRule.setContent {
+            mapView = rememberMapViewWithLifecycle(disposeCode = {})
+            AndroidView(factory = { mapView }, modifier = Modifier.fillMaxSize())
+        }
+        composeTestRule.waitForIdle()
+
+        loadPmtilesSource(scratchFile, glasgowCenter, zoom = 15.0)
+
+        // Let the first load complete: MapLibre fetches glasgow-gb.pmtiles's header and root
+        // directory, caches them natively for this URL, and renders at least one tile.
+        Thread.sleep(8_000)
+
+        // Overwrite the exact same path with a different city's pmtiles extract - this is the
+        // old OfflineDownloader's in-place-overwrite behavior this fix removed. bristol-gb.pmtiles
+        // has a completely different internal directory/offset layout, so any subsequent read
+        // through Glasgow's cached offsets lands on unrelated bytes.
+        fixtureB.copyTo(scratchFile, overwrite = true)
+
+        // Force fresh tile requests in the area MapLibre already cached header/directory info
+        // for: a different location and a higher zoom means entirely new tile IDs, so this can't
+        // be served from any already-rendered-tile cache - it must go back through
+        // PMTilesFileSource::Impl's cached (now-stale) offsets and read the swapped file.
+        moveCamera(
+            LatLng(glasgowCenter.latitude + 0.01, glasgowCenter.longitude + 0.01),
+            zoom = 17.0,
+        )
+
+        // Give the native worker thread time to request, mis-decompress, and abort.
+        Thread.sleep(10_000)
+    }
+
+    private fun loadPmtilesSource(file: File, target: LatLng, zoom: Double) {
+        val latch = java.util.concurrent.CountDownLatch(1)
+        composeTestRule.activity.runOnUiThread {
+            MapLibre.getInstance(targetContext)
+            mapView.getMapAsync { mapLibreMap ->
+                mapLibreMap.cameraPosition = CameraPosition.Builder()
+                    .target(target)
+                    .zoom(zoom)
+                    .build()
+
+                // Same style asset and "openmaptiles" source name the app's real map uses - its
+                // layers are all keyed to a source named "openmaptiles", so adding a VectorSource
+                // under that name is what actually makes MapLibre start requesting tiles from our
+                // pmtiles file.
+                mapLibreMap.setStyle("asset://osm-liberty-accessible/originalStyle.json") { style ->
+                    val vectorSource = VectorSource("openmaptiles", "pmtiles://file://${file.path}")
+                    vectorSource.isVolatile = true
+                    style.addSource(vectorSource)
+                    latch.countDown()
+                }
+            }
+        }
+        latch.await(10, java.util.concurrent.TimeUnit.SECONDS)
+    }
+
+    private fun moveCamera(target: LatLng, zoom: Double) {
+        val latch = java.util.concurrent.CountDownLatch(1)
+        composeTestRule.activity.runOnUiThread {
+            mapView.getMapAsync { mapLibreMap ->
+                mapLibreMap.cameraPosition = CameraPosition.Builder()
+                    .target(target)
+                    .zoom(zoom)
+                    .build()
+                latch.countDown()
+            }
+        }
+        latch.await(5, java.util.concurrent.TimeUnit.SECONDS)
+    }
+}

--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
@@ -134,6 +134,10 @@ class SoundscapeServiceConnection @Inject constructor() {
         soundscapeService?.stopBeaconPreview(commit, chosenBeaconType)
     }
 
+    fun refreshOfflineMaps() {
+        soundscapeService?.refreshOfflineMaps()
+    }
+
     companion object {
         private const val TAG = "SoundscapeServiceConnection"
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -356,6 +356,17 @@ class GeoEngine {
         directionProvider.destroy()
         sharedPreferences.unregisterOnSharedPreferenceChangeListener(sharedPreferencesListener)
    }
+
+    /**
+     * Called when the on-disk offline map extracts have changed (a download completed, or an
+     * extract was deleted) so that both grids pick up the change on their next location update
+     * instead of only opportunistically the next time the user crosses a grid boundary.
+     */
+    fun refreshOfflineMaps() {
+        gridState.refreshOfflineMaps()
+        settlementGrid.refreshOfflineMaps()
+    }
+
     private var recordTravel = false
     private var gpxRecorder: GpxRecorder? = null
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -365,6 +365,7 @@ class GeoEngine {
     fun refreshOfflineMaps() {
         gridState.refreshOfflineMaps()
         settlementGrid.refreshOfflineMaps()
+        tileSearch.refreshOfflineMaps()
     }
 
     private var recordTravel = false

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/GridState.kt
@@ -86,6 +86,7 @@ open class GridState(
     // HTTP connection to tile server
     internal var tileClient: TileClient? = null
 
+    @Volatile
     private var centralBoundingBox = BoundingBox()
     private var totalBoundingBox = BoundingBox()
     internal var ruler = CheapRuler(0.0)
@@ -113,6 +114,16 @@ open class GridState(
     open fun fixupCollections(featureCollections: Array<FeatureCollection>) {}
 
     open fun checkOfflineMaps() {}
+
+    /**
+     * Forces the next locationUpdate() to recompute the grid from scratch, even if the location
+     * hasn't left the current central area. Used when the on-disk offline map extracts have
+     * changed (new download published, or an extract deleted) so the change is picked up on the
+     * very next location fix instead of waiting for the user to walk outside the current grid.
+     */
+    fun refreshOfflineMaps() {
+        centralBoundingBox = BoundingBox()
+    }
 
     fun isLocationWithinGrid(location: LngLatAlt): Boolean {
         return pointIsWithinBoundingBox(location, totalBoundingBox)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/geocoders/TileSearch.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/geoengine/utils/geocoders/TileSearch.kt
@@ -32,6 +32,7 @@ import vector_tile.VectorTile
 import java.io.File
 import java.text.Normalizer
 import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.isNotEmpty
 import kotlin.text.iterator
 
@@ -39,7 +40,21 @@ class TileSearch(val offlineExtractPath: String,
                  val gridState: GridState,
                  val settlementGrid: GridState) {
 
-    val stringCache = mutableMapOf<Long, List<String>>()
+    // Keyed only by tile (x, y), not by which extract the data came from, so this must be
+    // cleared whenever the on-disk offline extracts change - otherwise a search can keep
+    // returning strings from an extract that's since been replaced or deleted. Concurrent
+    // because refreshOfflineMaps() can be called from a different thread (e.g. a download
+    // completing) while a search() is in progress.
+    val stringCache = ConcurrentHashMap<Long, List<String>>()
+
+    /**
+     * Called when the on-disk offline map extracts have changed (a download completed, or an
+     * extract was deleted) so that the next search re-reads tile content from the current
+     * extracts instead of returning cached strings from a superseded one.
+     */
+    fun refreshOfflineMaps() {
+        stringCache.clear()
+    }
 
     private fun cacheIndex(x: Int, y: Int) : Long{
         return x.toLong() + (y.toLong().shl(32))

--- a/app/src/main/java/org/scottishtecharmy/soundscape/network/SearchProvider.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/network/SearchProvider.kt
@@ -64,7 +64,7 @@ interface PhotonSearchProvider {
         private val logging = OkHttpClient.Builder()
             .addInterceptor(UserAgentInterceptor())
             .addInterceptor(loggingInterceptor)
-            .callTimeout(5, TimeUnit.SECONDS)
+            .callTimeout(10, TimeUnit.SECONDS)
             .build()
 
         fun getInstance(): PhotonSearchProvider {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -1029,6 +1029,10 @@ class SoundscapeService : MediaSessionService() {
         geoEngine.toggleAutoCallouts()
     }
 
+    fun refreshOfflineMaps() {
+        geoEngine.refreshOfflineMaps()
+    }
+
     /**
      * streetPreviewGo is called when the 'GO' button is pressed when in StreetPreview mode.
      * It indicates that the user has selected the direction of travel in which they which to move.

--- a/app/src/main/java/org/scottishtecharmy/soundscape/utils/OfflineDownloader.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/utils/OfflineDownloader.kt
@@ -104,10 +104,22 @@ class OfflineDownloader(injectedDownloadService: IDownloadService? = null) {
         return retrofit.create(IDownloadService::class.java)
     }
 
+    /**
+     * @param outputFilePath Where to publish the download. For a .pmtiles extract this should be
+     * a path unique to this download attempt (e.g. with a version/timestamp baked into the
+     * filename) - see [logicalBaseName].
+     * @param logicalBaseName If set, [outputFilePath]'s filename is expected to be of the form
+     * "<logicalBaseName>.<version-and-extension>", e.g. "glasgow-gb.v1699999999999.pmtiles" for a
+     * logicalBaseName of "glasgow-gb". Once the download is published, any other file in the same
+     * directory whose name starts with "<logicalBaseName>." is deleted - this is what actually
+     * retires a previous version of the same extract (see the comment above the rename below for
+     * why in-place replacement isn't safe for pmtiles extracts that MapLibre may have opened).
+     */
     fun startDownload(
         fileUrl: String,
         outputFilePath: String,
-        extractSize: Double?
+        extractSize: Double?,
+        logicalBaseName: String? = null,
     ) {
         if (downloadJob?.isActive == true) {
             Log.w(TAG, "Download is already in progress.")
@@ -159,12 +171,28 @@ class OfflineDownloader(injectedDownloadService: IDownloadService? = null) {
                             throw Exception("Downloaded extract failed validation (corrupt or truncated)")
                         }
                         retries = 0
-                        // Delete any file that already exists
-                        finalFile.delete()
-                        // Rename the file on successful completion
+                        // Rename straight to the destination - do NOT delete it first, and never
+                        // reuse an existing path for an "Update" re-download (see logicalBaseName
+                        // below). MapLibre's native PMTilesFileSource caches parsed header/
+                        // directory data per URL *forever*, with no invalidation hook - so once a
+                        // pmtiles://file://<path> URL has been opened once, silently swapping the
+                        // bytes at that same path (even atomically) leaves MapLibre reading brand
+                        // new file content through stale cached offsets, which can misread garbage
+                        // and crash with no try/catch on its worker thread. Publishing each
+                        // download under a unique path sidesteps that entirely: MapLibre never
+                        // sees a URL it has cached anything for. File.renameTo (no pre-delete)
+                        // still atomically replaces a destination that does exist - e.g. a retry
+                        // of this same attempt - via the rename(2) syscall, since tempFile and
+                        // finalFile are always in the same directory.
                         if (tempFile.renameTo(finalFile)) {
-                            _downloadState.value = DownloadState.Success
                             Log.i(TAG, "Download successful. File saved to: ${finalFile.path}")
+                            // Clean up old versions before publishing Success - an observer
+                            // reacting to Success (e.g. refreshing the extract list) should never
+                            // see a superseded version still on disk.
+                            if (logicalBaseName != null) {
+                                deleteSupersededVersions(finalFile, logicalBaseName)
+                            }
+                            _downloadState.value = DownloadState.Success
                         } else {
                             throw Exception("Failed to rename file from ${tempFile.name} to ${finalFile.name}")
                         }
@@ -198,6 +226,38 @@ class OfflineDownloader(injectedDownloadService: IDownloadService? = null) {
                     DownloadState.Error(e.message ?: "An unknown error occurred")
                 tempFile.delete() // Clean up partial file
                 Log.e(TAG, "Download failed", e)
+            }
+        }
+    }
+
+    /**
+     * Delete every other file in [finalFile]'s directory whose name starts with
+     * "$logicalBaseName." - i.e. every previous version of this extract (its old .pmtiles file(s)
+     * and their .geojson sidecars), now superseded by [finalFile]. The leading-dot anchor means
+     * "glasgow-gb." matches "glasgow-gb.pmtiles" and "glasgow-gb.v123.pmtiles" but not an unrelated
+     * "glasgow-gbz.pmtiles".
+     *
+     * This is safe to do immediately, unlike the old in-place overwrite: any reader still holding
+     * the old file open keeps reading it consistently (POSIX keeps a deleted-but-open file's data
+     * intact), and any reader that tries to open the old path fresh afterward gets a clean "not
+     * found" - which MapLibre's file source already treats as a normal, handled error - rather than
+     * reading wrong-but-present bytes that fail to decompress and crash.
+     */
+    private fun deleteSupersededVersions(finalFile: File, logicalBaseName: String) {
+        val prefix = "$logicalBaseName."
+        val siblings = finalFile.parentFile?.listFiles { file ->
+            // Exclude finalFile itself AND its own "<finalFile.name>.geojson" sidecar - a plain
+            // "!= finalFile.name" check only protects the .pmtiles file, not the sidecar, so this
+            // was deleting every download's own just-written metadata immediately after
+            // publishing it, silently hiding every new extract from the offline-maps UI (which
+            // requires that sidecar to list an extract at all).
+            file.name.startsWith(prefix) && !file.name.startsWith(finalFile.name)
+        } ?: return
+        for (sibling in siblings) {
+            if (sibling.delete()) {
+                Log.i(TAG, "Deleted superseded extract version: ${sibling.path}")
+            } else {
+                Log.w(TAG, "Failed to delete superseded extract version: ${sibling.path}")
             }
         }
     }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/OfflineMapsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/OfflineMapsViewModel.kt
@@ -158,14 +158,27 @@ class OfflineMapsViewModel @AssistedInject constructor(
         return filename.substringAfter("-").substringAfter("-")
     }
 
+    /**
+     * The stable identity for an extract's on-disk files, e.g. "glasgow-gb" - everything before
+     * the ".pmtiles" extension. Every physical file for this extract (the base .pmtiles name from
+     * before versioned downloads existed, any "<logicalBase>.v<version>.pmtiles" from [download],
+     * and their .geojson sidecars) starts with "$logicalBase.".
+     */
+    private fun logicalBaseNameFor(filename: String): String {
+        return translateToLocalFilenameFrom(filename).removeSuffix(".pmtiles")
+    }
+
     fun delete(feature: Feature) {
         val filename = feature.properties?.get("filename")
         if (filename != null) {
-            val localFilename = translateToLocalFilenameFrom(filename as String)
+            val logicalBase = logicalBaseNameFor(filename as String)
             val extractsDir = File(_uiState.value.currentPath, Environment.DIRECTORY_DOWNLOADS)
             if (extractsDir.exists() && extractsDir.isDirectory) {
+                // "$logicalBase." matches every version of this extract - the pre-versioning
+                // "glasgow-gb.pmtiles" as well as any "glasgow-gb.v<version>.pmtiles" - plus their
+                // .geojson sidecars, without matching an unrelated "glasgow-gbz.pmtiles".
                 val files = extractsDir.listFiles { file ->
-                    file.name.startsWith(localFilename)
+                    file.name.startsWith("$logicalBase.")
                 }?.toList() ?: emptyList()
 
                 // Delete whatever we find
@@ -180,9 +193,17 @@ class OfflineMapsViewModel @AssistedInject constructor(
     fun download(name: String, feature: Feature) {
         val filename = feature.properties?.get("filename")
         if (filename != null) {
-            val localFilename = translateToLocalFilenameFrom(filename as String)
+            val logicalBase = logicalBaseNameFor(filename as String)
+            // Never reuse a previous download's filename for a re-download/"Update": MapLibre's
+            // native PMTilesFileSource caches parsed header/directory data per pmtiles://file://
+            // URL forever, with no way for us to invalidate it, so overwriting an already-opened
+            // path leaves it reading new bytes through stale cached offsets - which can crash.
+            // Giving each download a unique, never-before-seen filename means MapLibre never
+            // revisits a URL it has cached anything for. OfflineDownloader deletes the previous
+            // version's files once this one is published (see logicalBaseName below).
+            val versionedFilename = "$logicalBase.v${System.currentTimeMillis()}.pmtiles"
             val path =
-                _uiState.value.currentPath + "/" + Environment.DIRECTORY_DOWNLOADS + "/" + localFilename
+                _uiState.value.currentPath + "/" + Environment.DIRECTORY_DOWNLOADS + "/" + versionedFilename
 
             // Write out the feature metadata to a file
             val adapter = GeoJsonObjectMoshiAdapter()
@@ -195,7 +216,8 @@ class OfflineMapsViewModel @AssistedInject constructor(
             offlineDownloader.startDownload(
                 fileUrl,
                 path,
-                extractSize
+                extractSize,
+                logicalBaseName = logicalBase,
             )
             _uiState.value = _uiState.value.copy(
                 downloadingExtractName = name

--- a/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/OfflineMapsViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/viewmodels/OfflineMapsViewModel.kt
@@ -88,6 +88,17 @@ class OfflineMapsViewModel @AssistedInject constructor(
             offlineDownloader = OfflineDownloader()
             downloadState = offlineDownloader.downloadState
 
+            viewModelScope.launch {
+                downloadState.collect { state ->
+                    if (state is DownloadState.Success) {
+                        // Make sure the geoengine starts using the newly published extract (and
+                        // stops using whatever it superseded) immediately, rather than waiting
+                        // for the user to happen to walk outside the current tile grid.
+                        soundscapeServiceConnection.refreshOfflineMaps()
+                    }
+                }
+            }
+
             val storages = getOfflineMapStorage(appContext)
 
             val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(appContext)
@@ -184,6 +195,10 @@ class OfflineMapsViewModel @AssistedInject constructor(
                 // Delete whatever we find
                 for (file in files)
                     file.delete()
+
+                // Stop the geoengine using the now-deleted extract immediately, rather than
+                // waiting for the user to happen to walk outside the current tile grid.
+                soundscapeServiceConnection.refreshOfflineMaps()
 
                 refreshExtracts()
             }

--- a/app/src/test/java/org/scottishtecharmy/soundscape/OfflineDownloaderTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/OfflineDownloaderTest.kt
@@ -87,6 +87,99 @@ class OfflineDownloaderTest {
     }
 
     @Test
+    fun supersededVersionsAreDeletedAfterPublish() {
+        val tempDir = File(System.getProperty("java.io.tmpdir"), "offline-dl-${System.nanoTime()}")
+        tempDir.mkdirs()
+        try {
+            // Deliberately not .pmtiles, same as runDownload's outputFile: this test is about the
+            // cleanup logic, not pmtiles validation, so it avoids needing a valid pmtiles body.
+            // An old version of this extract, plus its metadata sidecar - both should be deleted
+            // once the new version publishes successfully.
+            val oldExtract = File(tempDir, "glasgow-gb.v1000.bin").apply { writeText("old") }
+            val oldSidecar = File(tempDir, "glasgow-gb.v1000.bin.geojson").apply { writeText("{}") }
+            // An unrelated extract sharing a name prefix - must survive the cleanup.
+            val unrelatedExtract = File(tempDir, "glasgow-gbx.bin").apply { writeText("unrelated") }
+
+            val newOutputFile = File(tempDir, "glasgow-gb.v2000.bin")
+            // OfflineMapsViewModel.download() writes this sidecar *before* calling startDownload -
+            // it must survive the post-publish cleanup, which previously deleted it (it starts
+            // with the logical prefix and its name isn't *exactly* newOutputFile.name), silently
+            // hiding every freshly downloaded extract from the offline-maps UI.
+            val newSidecar = File(tempDir, "glasgow-gb.v2000.bin.geojson").apply { writeText("{}") }
+
+            val service = FakeDownloadService(listOf(Response.success(body(1000))))
+            val downloader = OfflineDownloader(service)
+            downloader.startDownload(
+                "https://example.test/extract",
+                newOutputFile.path,
+                extractSize = 1000.0,
+                logicalBaseName = "glasgow-gb",
+            )
+
+            val state = runBlocking {
+                withTimeout(10_000) {
+                    downloader.downloadState.first {
+                        it is DownloadState.Success || it is DownloadState.Error
+                    }
+                }
+            }
+
+            assertTrue("expected Success but was $state", state is DownloadState.Success)
+            assertTrue("new version should exist", newOutputFile.exists())
+            assertTrue("new version's own sidecar must survive", newSidecar.exists())
+            assertTrue("old version should be deleted", !oldExtract.exists())
+            assertTrue("old sidecar should be deleted", !oldSidecar.exists())
+            assertTrue("unrelated extract must survive", unrelatedExtract.exists())
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    /**
+     * The first "Update" of an extract downloaded by the previous, pre-versioning code must also
+     * retire it: its on-disk name has no ".vNNN" segment at all (just "<logicalBase>.<ext>"), not
+     * "<logicalBase>.v1000.<ext>" like a version this code produced itself.
+     */
+    @Test
+    fun legacyUnversionedExtractIsDeletedOnFirstUpdate() {
+        val tempDir = File(System.getProperty("java.io.tmpdir"), "offline-dl-${System.nanoTime()}")
+        tempDir.mkdirs()
+        try {
+            val legacyExtract = File(tempDir, "glasgow-gb.bin").apply { writeText("legacy") }
+            val legacySidecar = File(tempDir, "glasgow-gb.bin.geojson").apply { writeText("{}") }
+            val unrelatedExtract = File(tempDir, "glasgow-gbx.bin").apply { writeText("unrelated") }
+
+            val newOutputFile = File(tempDir, "glasgow-gb.v2000.bin")
+            val newSidecar = File(tempDir, "glasgow-gb.v2000.bin.geojson").apply { writeText("{}") }
+            val service = FakeDownloadService(listOf(Response.success(body(1000))))
+            val downloader = OfflineDownloader(service)
+            downloader.startDownload(
+                "https://example.test/extract",
+                newOutputFile.path,
+                extractSize = 1000.0,
+                logicalBaseName = "glasgow-gb",
+            )
+
+            val state = runBlocking {
+                withTimeout(10_000) {
+                    downloader.downloadState.first {
+                        it is DownloadState.Success || it is DownloadState.Error
+                    }
+                }
+            }
+
+            assertTrue("expected Success but was $state", state is DownloadState.Success)
+            assertTrue("new version should exist", newOutputFile.exists())
+            assertTrue("new version's own sidecar must survive", newSidecar.exists())
+            assertTrue("legacy unversioned extract should be deleted", !legacyExtract.exists())
+            assertTrue("legacy sidecar should be deleted", !legacySidecar.exists())
+            assertTrue("unrelated extract must survive", unrelatedExtract.exists())
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    @Test
     fun partialContentIsRetriedUntilFullFileArrives() {
         val service = FakeDownloadService(
             listOf(

--- a/app/src/test/java/org/scottishtecharmy/soundscape/RefreshOfflineMapsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/RefreshOfflineMapsTest.kt
@@ -1,0 +1,44 @@
+package org.scottishtecharmy.soundscape
+
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.scottishtecharmy.soundscape.MainActivity.Companion.MOBILITY_KEY
+import org.scottishtecharmy.soundscape.MainActivity.Companion.PLACES_AND_LANDMARKS_KEY
+import org.scottishtecharmy.soundscape.geoengine.GRID_SIZE
+import org.scottishtecharmy.soundscape.geoengine.MAX_ZOOM_LEVEL
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+
+/**
+ * GridState.locationUpdate() only recomputes the tile grid (and, via updateTileGrid(), rescans
+ * the offline map extracts) when the location has moved outside the grid's current central area.
+ * refreshOfflineMaps() exists to force that recompute on the very next location update even when
+ * the location hasn't moved, so that a newly downloaded (or deleted) offline extract is picked up
+ * immediately rather than only the next time the user happens to cross a grid boundary.
+ */
+class RefreshOfflineMapsTest {
+
+    @Test
+    fun refreshOfflineMapsForcesRecomputeWithoutMoving() {
+        val location = LngLatAlt(-4.317357, 55.942527)
+        val enabledCategories = mutableSetOf(PLACES_AND_LANDMARKS_KEY, MOBILITY_KEY)
+
+        val gridState = FileGridState(MAX_ZOOM_LEVEL, GRID_SIZE)
+        gridState.start(null, offlineExtractPath)
+
+        runBlocking {
+            // The first update always recomputes, starting from an empty central bounding box.
+            assertTrue(gridState.locationUpdate(location, enabledCategories))
+
+            // A second update at the same, unmoved location is a no-op - it's still within the
+            // grid's existing central area.
+            assertFalse(gridState.locationUpdate(location, enabledCategories))
+
+            // refreshOfflineMaps() (called when an offline map extract is downloaded or deleted)
+            // must force the very next update to recompute, even without the location moving.
+            gridState.refreshOfflineMaps()
+            assertTrue(gridState.locationUpdate(location, enabledCategories))
+        }
+    }
+}

--- a/app/src/test/java/org/scottishtecharmy/soundscape/TileSearchRefreshOfflineMapsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/TileSearchRefreshOfflineMapsTest.kt
@@ -1,0 +1,39 @@
+package org.scottishtecharmy.soundscape
+
+import junit.framework.TestCase.assertTrue
+import org.junit.Test
+import org.scottishtecharmy.soundscape.geoengine.GRID_SIZE
+import org.scottishtecharmy.soundscape.geoengine.MAX_ZOOM_LEVEL
+import org.scottishtecharmy.soundscape.geoengine.utils.geocoders.TileSearch
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+
+/**
+ * TileSearch.stringCache is keyed only by tile (x, y), not by which extract the data came from,
+ * so it has to be discarded whenever the on-disk offline extracts change - otherwise a search
+ * could keep returning strings read from an extract that's since been replaced or deleted.
+ */
+class TileSearchRefreshOfflineMapsTest {
+
+    @Test
+    fun refreshOfflineMapsClearsStringCache() {
+        val location = LngLatAlt(-4.3108846, 55.9495440)
+        val gridState = getGridStateForLocation(location, MAX_ZOOM_LEVEL, GRID_SIZE)
+        val settlementState = getGridStateForLocation(location, 12, 3)
+        val tileSearch = TileSearch(offlineExtractPath, gridState, settlementState)
+
+        tileSearch.search(location, "Craigmillar", null, emptySet())
+
+        assertTrue(
+            "search() should have populated the tile string cache",
+            tileSearch.stringCache.isNotEmpty()
+        )
+
+        tileSearch.refreshOfflineMaps()
+
+        assertTrue(
+            "refreshOfflineMaps() must discard cached tile strings so a superseded extract's " +
+                "data isn't returned after the offline map changes",
+            tileSearch.stringCache.isEmpty()
+        )
+    }
+}


### PR DESCRIPTION
There was a possible maplibre crash, geoengine didn't update immediately, and search still cached strings from the previous offline extract.