### PR TITLE
Switch iOS CI archive to manual signing

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -338,12 +338,19 @@ jobs:
       # Reuse the version produced by the Android job. MARKETING_VERSION maps
       # to CFBundleShortVersionString and CURRENT_PROJECT_VERSION to
       # CFBundleVersion when passed as xcodebuild build settings.
+      #
+      # Manual signing: project.yml pins each Release target to the
+      # distribution cert and references PROFILE_NAME_APP /
+      # PROFILE_NAME_SHAREEXT as user-defined build settings. Passing them
+      # here lets each target pick up its own profile name (xcodebuild
+      # SETTING=VALUE overrides apply to all targets, but each target's
+      # PROVISIONING_PROFILE_SPECIFIER references a different var). No
+      # -allowProvisioningUpdates: the profiles were already imported by
+      # setup-ios-signing, so Apple doesn't need to mint fresh ones.
       - name: Archive iOS app
         env:
           VERSION_CODE: ${{ needs.prepare-version.outputs.version_code }}
           VERSION_NAME: ${{ needs.prepare-version.outputs.version_name }}
-          KEY_ID: ${{ secrets.APPSTORE_CONNECT_API_KEY_ID }}
-          ISSUER_ID: ${{ secrets.APPSTORE_CONNECT_API_ISSUER_ID }}
         run: |
           # Strip the patch component so TestFlight groups all 2.0.x builds
           # under one "2.0" train; uniqueness within the train comes from
@@ -356,13 +363,11 @@ jobs:
             -sdk iphoneos \
             -destination 'generic/platform=iOS' \
             -archivePath "$RUNNER_TEMP/Soundscape.xcarchive" \
-            -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey_$KEY_ID.p8" \
-            -authenticationKeyID "$KEY_ID" \
-            -authenticationKeyIssuerID "$ISSUER_ID" \
-            -allowProvisioningUpdates \
             MARKETING_VERSION="$SHORT_VERSION" \
             CURRENT_PROJECT_VERSION="$VERSION_CODE" \
-            APP_VERSION_NAME="$VERSION_NAME"
+            APP_VERSION_NAME="$VERSION_NAME" \
+            PROFILE_NAME_APP="$IOS_PROFILE_NAME" \
+            PROFILE_NAME_SHAREEXT="$IOS_SHAREEXT_PROFILE_NAME"
 
       # Manual signing during export so xcodebuild reuses the profile we
       # imported in setup-ios-signing instead of asking Apple to mint a fresh
@@ -493,16 +498,7 @@ jobs:
           shareext_provisioning_profile_base64: ${{ secrets.IOS_SHAREEXT_PROVISIONING_PROFILE_BASE64 }}
           keychain_password: ${{ secrets.IOS_KEYCHAIN_PASSWORD }}
 
-      - name: Decode App Store Connect API key
-        uses: ./.github/actions/decode-base64-secret
-        with:
-          encoded: ${{ secrets.APPSTORE_CONNECT_API_KEY_BASE64 }}
-          output_path: ${{ runner.temp }}/private_keys/AuthKey_${{ secrets.APPSTORE_CONNECT_API_KEY_ID }}.p8
-
       - name: Build XCTest bundle for device
-        env:
-          KEY_ID: ${{ secrets.APPSTORE_CONNECT_API_KEY_ID }}
-          ISSUER_ID: ${{ secrets.APPSTORE_CONNECT_API_ISSUER_ID }}
         run: |
           xcodebuild build-for-testing \
             -project iosApp/iosApp.xcodeproj \
@@ -511,11 +507,9 @@ jobs:
             -sdk iphoneos \
             -destination 'generic/platform=iOS' \
             -derivedDataPath build_for_testing \
-            -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey_$KEY_ID.p8" \
-            -authenticationKeyID "$KEY_ID" \
-            -authenticationKeyIssuerID "$ISSUER_ID" \
-            -allowProvisioningUpdates \
-            ENABLE_TESTABILITY=YES
+            ENABLE_TESTABILITY=YES \
+            PROFILE_NAME_APP="$IOS_PROFILE_NAME" \
+            PROFILE_NAME_SHAREEXT="$IOS_SHAREEXT_PROFILE_NAME"
 
       - name: Package test bundle for Test Lab
         run: |

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -118,17 +118,34 @@ targets:
             UTTypeTagSpecification:
               public.filename-extension:
                 - gpx
+    # xcodegen: mixing flat entries with a `configs:` key silently drops the
+    # flat entries, so wrap the shared settings in `base:` when adding per-
+    # config overrides.
     settings:
-      PRODUCT_BUNDLE_IDENTIFIER: org.scottishtecharmy.soundscape
-      PRODUCT_NAME: Soundscape
-      FRAMEWORK_SEARCH_PATHS:
-        - "$(inherited)"
-        - "$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)"
-      OTHER_LINKER_FLAGS:
-        - "$(inherited)"
-        - "-framework"
-        - "Shared"
-      CODE_SIGN_ENTITLEMENTS: iosApp/iosApp.entitlements
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: org.scottishtecharmy.soundscape
+        PRODUCT_NAME: Soundscape
+        FRAMEWORK_SEARCH_PATHS:
+          - "$(inherited)"
+          - "$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)"
+        OTHER_LINKER_FLAGS:
+          - "$(inherited)"
+          - "-framework"
+          - "Shared"
+        CODE_SIGN_ENTITLEMENTS: iosApp/iosApp.entitlements
+      configs:
+        # CI archives with manual signing so xcodebuild uses the
+        # distribution cert + profile imported by setup-ios-signing rather
+        # than asking Apple to mint a managed Apple Development profile
+        # (which fails when the App Store Connect API key can't manage
+        # the per-machine dev cert). The profile name is injected via a
+        # user-defined build setting so each target can get its own value
+        # from the xcodebuild command line. Debug is left on the default
+        # automatic signing so local runs from Xcode keep working.
+        Release:
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: "Apple Distribution"
+          PROVISIONING_PROFILE_SPECIFIER: "$(PROFILE_NAME_APP)"
     preBuildScripts:
       - name: "Build Kotlin Framework"
         script: |
@@ -172,8 +189,14 @@ targets:
           NSExtensionPointIdentifier: com.apple.share-services
           NSExtensionPrincipalClass: $(PRODUCT_MODULE_NAME).ShareViewController
     settings:
-      PRODUCT_BUNDLE_IDENTIFIER: org.scottishtecharmy.soundscape.share
-      SKIP_INSTALL: "YES"
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: org.scottishtecharmy.soundscape.share
+        SKIP_INSTALL: "YES"
+      configs:
+        Release:
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: "Apple Distribution"
+          PROVISIONING_PROFILE_SPECIFIER: "$(PROFILE_NAME_SHAREEXT)"
 
 schemes:
   iosApp:


### PR DESCRIPTION
The archive step relied on automatic signing + -allowProvisioningUpdates, which Apple would satisfy by minting an Apple Development cert bound to the runner. That path breaks on the self-hosted runner: setup-ios-signing provisions a fresh keychain with only the distribution cert, so Xcode sees the API-recorded dev cert as unrecoverable and aborts. Pin both Release targets to Manual/Apple Distribution and inject profile names as user-defined build settings so each target picks up its own.