### PR TITLE
Bump Gradle heap to 8g for Kotlin/Native release link on macOS iOS jobs

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -285,6 +285,13 @@ jobs:
     environment: development
     permissions:
       contents: write
+    # Konan's devirtualization pass during linkReleaseFrameworkIosArm64 runs
+    # in-process in the Gradle daemon and OOMs at gradle.properties' 4 GB
+    # default with Realm + MapLibre + shared/. GRADLE_OPTS overrides the file
+    # setting for this job only; the Linux runners keep the 4 GB default so
+    # the Android emulator has room in its 16 GB budget.
+    env:
+      GRADLE_OPTS: -Xmx8192m
 
     steps:
       # Pull the latest commit on the branch (including the version-bump
@@ -468,6 +475,10 @@ jobs:
     needs: ios-build
     runs-on: [self-hosted, macOS, ARM64]
     environment: development
+    # Same reasoning as ios-build: the Release framework link needs more heap
+    # than the file default.
+    env:
+      GRADLE_OPTS: -Xmx8192m
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Konan's devirtualization pass during linkReleaseFrameworkIosArm64 runs in-process in the Gradle daemon and OOM'd at 4 GB on the self-hosted mac runner. Realm + MapLibre + shared/ push the release framework link past that ceiling.

Scope the bump to the ios-build and ios-firebase jobs via GRADLE_OPTS rather than raising gradle.properties globally: the Linux runners already share their 16 GB budget with an Android emulator and adb, so a bigger Gradle heap risks the OOM killer taking out the build there.