### PR TITLE
Bump Gradle daemon heap to 8g on macOS iOS jobs

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -302,6 +302,17 @@ jobs:
           ref: ${{ github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
 
+      # Konan's devirtualization pass during linkReleaseFrameworkIosArm64
+      # runs in-process in the Gradle daemon and OOMs at gradle.properties'
+      # 4 GB default with Realm + MapLibre + shared/. GRADLE_OPTS only sets
+      # the client JVM, so patch the file for this checkout instead. Linux
+      # runners never run this step and keep the 4 GB default so the Android
+      # emulator has room in its 16 GB budget.
+      - name: Bump Gradle daemon heap for Kotlin/Native release link
+        run: |
+          sed -i.bak 's/^org\.gradle\.jvmargs=.*/org.gradle.jvmargs=-Xmx8192m -Dfile.encoding=UTF-8/' gradle.properties
+          grep '^org\.gradle\.jvmargs' gradle.properties
+
       - name: Setup iOS toolchain
         uses: ./.github/actions/setup-ios-toolchain
 
@@ -484,6 +495,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      # See ios-build: linkReleaseFrameworkIosArm64 needs more heap than
+      # gradle.properties' 4 GB default, and GRADLE_OPTS only sets the client
+      # JVM. Patch the file for this checkout so the daemon picks it up.
+      - name: Bump Gradle daemon heap for Kotlin/Native release link
+        run: |
+          sed -i.bak 's/^org\.gradle\.jvmargs=.*/org.gradle.jvmargs=-Xmx8192m -Dfile.encoding=UTF-8/' gradle.properties
+          grep '^org\.gradle\.jvmargs' gradle.properties
 
       - name: Setup iOS toolchain
         uses: ./.github/actions/setup-ios-toolchain


### PR DESCRIPTION
Konan's devirtualization pass during linkReleaseFrameworkIosArm64 runs in-process in the Gradle daemon and OOM'd at 4 GB on the self-hosted mac runner. Realm + MapLibre + shared/ push the release framework link past that ceiling.

Scope the bump to the ios-build and ios-firebase jobs by patching the working-copy gradle.properties after checkout. GRADLE_OPTS only sets the client JVM's args - the daemon reads org.gradle.jvmargs from the file at start and ignores GRADLE_OPTS - so the previous env-based attempt was silently a no-op. Linux runners never run this step, so their Android emulator keeps its 4 GB budget.