### PR TITLE
Fix APPSTORE_CONNECT_API_KEY_ID typo in XCTest build step

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -549,7 +549,7 @@ jobs:
         uses: ./.github/actions/decode-base64-secret
         with:
           encoded: ${{ secrets.APPSTORE_CONNECT_API_KEY_BASE64 }}
-          output_path: ${{ runner.temp }}/private_keys/AuthKey_${{ secrets.APPSTORE_CONNECT_API_ID }}.p8
+          output_path: ${{ runner.temp }}/private_keys/AuthKey_${{ secrets.APPSTORE_CONNECT_API_KEY_ID }}.p8
 
       - name: Build XCTest bundle for device
         env:


### PR DESCRIPTION
The Decode App Store Connect API key step in the ios-firebase job was writing the .p8 to AuthKey_.p8 (empty middle) because it referenced a nonexistent APPSTORE_CONNECT_API_ID secret, so xcodebuild failed with "The -authenticationKeyPath flag must be an absolute path to an existing file." Match the correct secret name used everywhere else in the file.