### PR TITLE
Sign iosAppTests manually with Distribution identity, no profile

### DIFF
--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -173,6 +173,18 @@ targets:
         TEST_HOST: $(BUILT_PRODUCTS_DIR)/Soundscape.app/Soundscape
         BUNDLE_LOADER: $(TEST_HOST)
         GENERATE_INFOPLIST_FILE: "YES"
+      configs:
+        # The Firebase Test Lab build-for-testing step signs with the same
+        # Apple Distribution cert used by the host app. XCTest bundles ride
+        # inside Soundscape.app/PlugIns/ and inherit the host's provisioning
+        # context, so an empty PROVISIONING_PROFILE_SPECIFIER stops xcodebuild
+        # from demanding a per-target profile that our distribution cert
+        # doesn't cover. Automatic signing would need an Apple Development
+        # cert, which no self-hosted CI runner has.
+        Release:
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: "Apple Distribution"
+          PROVISIONING_PROFILE_SPECIFIER: ""
 
   ShareExtension:
     type: app-extension


### PR DESCRIPTION
Automatic signing on the iosAppTests target fails on the self-hosted runner because no Apple Development certificate is installed there — setup-ios-signing only imports the Apple Distribution cert used by the host app. With CODE_SIGN_STYLE=Manual and PROVISIONING_PROFILE_SPECIFIER left empty, xcodebuild signs the .xctest bundle with the distribution identity and skips the per-target profile lookup, which is correct for test bundles that ride inside Soundscape.app/PlugIns/ and inherit the host app's provisioning context.