### PR TITLE
Install Python 3.12 via Homebrew on the self-hosted mac-mini

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -591,14 +591,19 @@ jobs:
           credentials_json: ${{ secrets.GCLOUD_CREDENTIALS_JSON }}
 
       # The self-hosted mac-mini's system Python is 3.9, which gcloud dropped
-      # support for. setup-python installs a supported interpreter in the tool
-      # cache; CLOUDSDK_PYTHON pins gcloud to it without touching the runner's
-      # default python3.
+      # support for. actions/setup-python doesn't work here — its darwin
+      # install script hard-codes /Users/runner/hostedtoolcache and the
+      # runner user is gh-runner, so it errors with "mkdir: /Users/runner:
+      # Permission denied". Install via Homebrew instead (already present
+      # for xcodegen) and export the path for CLOUDSDK_PYTHON.
       - name: Set up Python for gcloud
         id: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
+        shell: bash
+        run: |
+          brew list python@3.12 &>/dev/null || brew install python@3.12
+          PY="$(brew --prefix python@3.12)/bin/python3.12"
+          "$PY" --version
+          echo "python-path=$PY" >> "$GITHUB_OUTPUT"
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3


### PR DESCRIPTION
actions/setup-python's darwin install script writes to a hard-coded /Users/runner/hostedtoolcache path and fails with "mkdir: /Users/runner: Permission denied" on this runner (whose user is gh-runner). Homebrew is already on the runner for xcodegen, so shell out to brew instead and expose the resulting python3.12 path as a step output for CLOUDSDK_PYTHON.