### PR TITLE
Drop emulator so as not to use SDK 36

### DIFF
--- a/.github/workflows/run-maestro-tests.yaml
+++ b/.github/workflows/run-maestro-tests.yaml
@@ -61,12 +61,12 @@ jobs:
             screen: large
             profile: pixel_6
             locale: en-US
-          - api-level: 36
+          - api-level: 35
             target: google_apis
             screen: small
             profile: small_phone
             locale: en-US
-          - api-level: 36
+          - api-level: 35
             target: google_apis
             screen: large
             profile: pixel_6

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -87,8 +87,8 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         continue-on-error: true # IMPORTANT: allow pipeline to continue to Android Test Report step
         with:
-          api-level: 36
-          target: default
+          api-level: 35
+          target: google_apis
           arch: x86_64
           script: |
             adb root


### PR DESCRIPTION
Startup emulators at SDK level 35 with google APIs for tests. This is to try and avoid some of the intermittent failures and SSL certificate issues seen with SDK level 36 and AOSP.