### PR TITLE
Fix localization GeoEngine issues for KMP and route recording issue

### DIFF
--- a/app/src/androidTest/java/org/scottishtecharmy/soundscape/GeocoderTest.kt
+++ b/app/src/androidTest/java/org/scottishtecharmy/soundscape/GeocoderTest.kt
@@ -22,7 +22,6 @@ import org.scottishtecharmy.soundscape.geoengine.GridState
 import org.scottishtecharmy.soundscape.geoengine.ProtomapsGridState
 import org.scottishtecharmy.soundscape.geoengine.TreeId
 import org.scottishtecharmy.soundscape.geoengine.UserGeometry
-import org.scottishtecharmy.soundscape.geoengine.getTextForFeature
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.MvtFeature
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.Way
 import org.scottishtecharmy.soundscape.geoengine.utils.address.AddressFormatter
@@ -69,8 +68,8 @@ class GeocoderTest {
         val cheapRuler = CheapRuler(location.latitude)
         return runBlocking {
             // Update the grid states for this location
-            gridState.locationUpdate(location, emptySet())
-            settlementState.locationUpdate(location, emptySet())
+            gridState.locationUpdate(location, emptySet(), ComposeLocalizedStrings())
+            settlementState.locationUpdate(location, emptySet(), ComposeLocalizedStrings())
 
             // Find the nearby road so as we can pretend that we are map matched
             val roadTree = gridState.getFeatureTree(TreeId.WAYS_SELECTION)
@@ -309,8 +308,8 @@ class GeocoderTest {
 
         runBlocking {
             // Update the grid states for this location
-            gridState.locationUpdate(nearbyLocation, emptySet())
-            settlementState.locationUpdate(nearbyLocation, emptySet())
+            gridState.locationUpdate(nearbyLocation, emptySet(), ComposeLocalizedStrings())
+            settlementState.locationUpdate(nearbyLocation, emptySet(), ComposeLocalizedStrings())
 
             // Run the geocoders in parallel and wait for them all to either fail or complete
             val timeoutMillis = 10000L
@@ -572,7 +571,7 @@ class GeocoderTest {
 
         val milngavie = LngLatAlt(-4.317166334292434, 55.941822016283)
         runBlocking {
-            gridState.locationUpdate(milngavie, emptySet())
+            gridState.locationUpdate(milngavie, emptySet(), ComposeLocalizedStrings())
 
             val features = gridState.getFeatureCollection(TreeId.POIS)
             features.forEach { feature ->
@@ -581,7 +580,7 @@ class GeocoderTest {
                     val ld = feature.toLocationDescription(
                         LocationSource.OfflineGeocoder,
                         getDistanceToFeature(milngavie, feature, gridState.ruler).point,
-                        getTextForFeature(ComposeLocalizedStrings(), mvt)
+                        mvt.getText(ComposeLocalizedStrings())
                     )
                 }
             }

--- a/app/src/androidTest/java/org/scottishtecharmy/soundscape/MvtPerformanceTest.kt
+++ b/app/src/androidTest/java/org/scottishtecharmy/soundscape/MvtPerformanceTest.kt
@@ -145,7 +145,8 @@ class MvtPerformanceTest {
         runBlocking {
             gridState.locationUpdate(
                 LngLatAlt(location.longitude, location.latitude),
-                emptySet()
+                emptySet(),
+                null
             )
         }
 
@@ -234,7 +235,8 @@ class MvtPerformanceTest {
                             // Update the grid state
                             gridState.locationUpdate(
                                 LngLatAlt(location.longitude, location.latitude),
-                                emptySet()
+                                emptySet(),
+                                null
                             )
                         }
                         if (duration > longestDuration) {
@@ -276,7 +278,8 @@ class MvtPerformanceTest {
             // Update the grid state
             gridState.locationUpdate(
                 LngLatAlt(location.longitude, location.latitude),
-                emptySet()
+                emptySet(),
+                null
             )
         }
 

--- a/app/src/androidTest/java/org/scottishtecharmy/soundscape/SearchTest.kt
+++ b/app/src/androidTest/java/org/scottishtecharmy/soundscape/SearchTest.kt
@@ -245,7 +245,7 @@ class SearchTest {
         gridState.validateContext = false
         gridState.startWithContext(ApplicationProvider.getApplicationContext(), offlineExtractPath)
         runBlocking {
-            gridState.locationUpdate(location, emptySet())
+            gridState.locationUpdate(location, emptySet(), ComposeLocalizedStrings())
         }
 
         val nearbyWays = gridState.getFeatureTree(TreeId.WAYS_SELECTION)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
@@ -6,6 +6,7 @@ import android.os.Process
 import android.util.Log
 import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -80,15 +81,23 @@ fun HomeScreen(
             MainActivity.RECORD_TRAVEL_KEY,
             MainActivity.RECORD_TRAVEL_DEFAULT
         )
-        MutableStateFlow(initial).also { flow ->
-            preferences.registerOnSharedPreferenceChangeListener { sp, key ->
-                if (key == MainActivity.RECORD_TRAVEL_KEY) {
-                    flow.value = sp.getBoolean(
-                        MainActivity.RECORD_TRAVEL_KEY,
-                        MainActivity.RECORD_TRAVEL_DEFAULT
-                    )
-                }
+        MutableStateFlow(initial)
+    }
+    val recordingEnabledListener = remember(preferences, recordingEnabledFlow) {
+        SharedPreferences.OnSharedPreferenceChangeListener { sp, key ->
+            if (key == MainActivity.RECORD_TRAVEL_KEY) {
+                recordingEnabledFlow.value = sp.getBoolean(
+                    MainActivity.RECORD_TRAVEL_KEY,
+                    MainActivity.RECORD_TRAVEL_DEFAULT
+                )
+                Log.d("Home", "value change: $key -> ${recordingEnabledFlow.value}")
             }
+        }
+    }
+    DisposableEffect(preferences, recordingEnabledListener) {
+        preferences.registerOnSharedPreferenceChangeListener(recordingEnabledListener)
+        onDispose {
+            preferences.unregisterOnSharedPreferenceChangeListener(recordingEnabledListener)
         }
     }
 

--- a/app/src/test/java/org/scottishtecharmy/soundscape/ComplexIntersections.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/ComplexIntersections.kt
@@ -35,7 +35,8 @@ class ComplexIntersections {
 
         val intersection = getRoadsDescriptionFromFov(
             gridState,
-            userGeometry
+            userGeometry,
+            null
         ).intersection
 
         Assert.assertEquals(3, intersection!!.members.size)
@@ -92,7 +93,8 @@ class ComplexIntersections {
 
         val intersection = getRoadsDescriptionFromFov(
             gridState,
-            userGeometry
+            userGeometry,
+            null
         ).intersection
 
         Assert.assertEquals(4, intersection!!.members.size)

--- a/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTestMvt.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/IntersectionsTestMvt.kt
@@ -25,7 +25,8 @@ class IntersectionsTestMvt {
             location = currentLocation,
             gridState = gridState,
             collection = FeatureCollection(),
-            dump = false
+            dump = false,
+            strings = null
         )
         val userGeometry = UserGeometry(
             location = currentLocation,
@@ -36,7 +37,8 @@ class IntersectionsTestMvt {
 
         return getRoadsDescriptionFromFov(
             gridState,
-            userGeometry
+            userGeometry,
+            null
         ).intersection
     }
 

--- a/app/src/test/java/org/scottishtecharmy/soundscape/MvtTileTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/MvtTileTest.kt
@@ -128,7 +128,8 @@ fun getGridStateForLocation(
         // Update the grid state
         gridState.locationUpdate(
             LngLatAlt(location.longitude, location.latitude),
-            enabledCategories
+            enabledCategories,
+            null
         )
     }
     return gridState
@@ -390,7 +391,7 @@ class MvtTileTest {
         var roads = gridState.getFeatureCollection(TreeId.WAYS_SELECTION)
         val confectionTime2 = measureTimeMillis {
             for (road in roads) {
-                confectNamesForRoad(road as Way, gridState)
+                confectNamesForRoad(road as Way, gridState, null)
             }
         }
         println("Confection time: $confectionTime ms")
@@ -692,11 +693,13 @@ class MvtTileTest {
                 // Update the grid state
                 val gridChanged = gridState.locationUpdate(
                     LngLatAlt(location.longitude, location.latitude),
-                    enabledCategories
+                    enabledCategories,
+                    null
                 )
                 settlementGrid.locationUpdate(
                     LngLatAlt(location.longitude, location.latitude),
-                    emptySet()
+                    emptySet(),
+                    null
                 )
 
                 if (gridChanged) {
@@ -704,7 +707,7 @@ class MvtTileTest {
                     // expensive and is only done on individual Ways as needed when running the app.
                     val roads = gridState.getFeatureCollection(TreeId.WAYS_SELECTION)
                     for (road in roads) {
-                        confectNamesForRoad(road as Way, gridState)
+                        confectNamesForRoad(road as Way, gridState, null)
                     }
                 }
 
@@ -713,7 +716,8 @@ class MvtTileTest {
                     LngLatAlt(location.longitude, location.latitude),
                     gridState,
                     collection,
-                    false
+                    false,
+                    null
                 )
 
                 if (mapMatchedResult.first != null) {
@@ -853,7 +857,8 @@ class MvtTileTest {
                 // Update the grid state
                 val gridChanged = gridState.locationUpdate(
                     LngLatAlt(location.longitude, location.latitude),
-                    enabledCategories
+                    enabledCategories,
+                    null
                 )
 
                 if (gridChanged) {
@@ -861,7 +866,7 @@ class MvtTileTest {
                     // expensive and is only done on individual Ways as needed when running the app.
                     val roads = gridState.getFeatureCollection(TreeId.WAYS_SELECTION)
                     for (road in roads) {
-                        confectNamesForRoad(road as Way, gridState)
+                        confectNamesForRoad(road as Way, gridState, null)
                     }
                 }
 
@@ -870,7 +875,8 @@ class MvtTileTest {
                     LngLatAlt(location.longitude, location.latitude),
                     gridState,
                     collection,
-                    false
+                    false,
+                    null
                 )
 
                 val userGeometry = UserGeometry(
@@ -995,7 +1001,8 @@ class MvtTileTest {
                     // Update the grid state
                     gridState.locationUpdate(
                         LngLatAlt(location.longitude, location.latitude),
-                        emptySet()
+                        emptySet(),
+                        null
                     )
                     if (false) {
                         // This code is useful for comparing before and after changes of grid parsing
@@ -1335,7 +1342,8 @@ class MvtTileTest {
                 assertEquals(
                     gridState.locationUpdate(
                         location.first,
-                        enabledCategories
+                        enabledCategories,
+                        null
                     ), location.second
                 )
             }

--- a/app/src/test/java/org/scottishtecharmy/soundscape/PoiTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/PoiTest.kt
@@ -6,7 +6,6 @@ import org.scottishtecharmy.soundscape.geoengine.GRID_SIZE
 import org.scottishtecharmy.soundscape.geoengine.MAX_ZOOM_LEVEL
 import org.scottishtecharmy.soundscape.geoengine.TreeId
 import org.scottishtecharmy.soundscape.geoengine.UserGeometry
-import org.scottishtecharmy.soundscape.geoengine.getTextForFeature
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.MvtFeature
 import org.scottishtecharmy.soundscape.geoengine.utils.RelativeDirections
 import org.scottishtecharmy.soundscape.geoengine.utils.circleToPolygon
@@ -243,8 +242,8 @@ class PoiTest {
         val poiTree = gridState.getFeatureTree(TreeId.POIS)
         val pois = poiTree.getNearbyCollection(userGeometry.location, 50.0, gridState.ruler)
         for (poi in pois) {
-            println("Poi: ${(poi as MvtFeature).name} ${getTextForFeature(null, poi)}")
-            assertNotEquals("Unknown", getTextForFeature(null, poi).text)
+            println("Poi: ${(poi as MvtFeature).name} ${poi.getText(null)}")
+            assertNotEquals("Unknown", poi.getText(null).text)
         }
     }
 }

--- a/app/src/test/java/org/scottishtecharmy/soundscape/RefreshOfflineMapsTest.kt
+++ b/app/src/test/java/org/scottishtecharmy/soundscape/RefreshOfflineMapsTest.kt
@@ -29,16 +29,16 @@ class RefreshOfflineMapsTest {
 
         runBlocking {
             // The first update always recomputes, starting from an empty central bounding box.
-            assertTrue(gridState.locationUpdate(location, enabledCategories))
+            assertTrue(gridState.locationUpdate(location, enabledCategories, null))
 
             // A second update at the same, unmoved location is a no-op - it's still within the
             // grid's existing central area.
-            assertFalse(gridState.locationUpdate(location, enabledCategories))
+            assertFalse(gridState.locationUpdate(location, enabledCategories, null))
 
             // refreshOfflineMaps() (called when an offline map extract is downloaded or deleted)
             // must force the very next update to recompute, even without the location moving.
             gridState.refreshOfflineMaps()
-            assertTrue(gridState.locationUpdate(location, enabledCategories))
+            assertTrue(gridState.locationUpdate(location, enabledCategories, null))
         }
     }
 }

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/GeoEngine.kt
@@ -374,11 +374,13 @@ class GeoEngine {
 
                     val updated = gridState.locationUpdate(
                         LngLatAlt(location.longitude, location.latitude),
-                        createSuperCategoriesSet()
+                        createSuperCategoriesSet(),
+                        localizedStrings
                     )
                     settlementGrid.locationUpdate(
                         LngLatAlt(location.longitude, location.latitude),
-                        createSuperCategoriesSet()
+                        createSuperCategoriesSet(),
+                        localizedStrings
                     )
 
                     runBlocking {
@@ -392,11 +394,12 @@ class GeoEngine {
                                         ),
                                         gridState,
                                         FeatureCollection(),
-                                        false
+                                        false,
+                                        localizedStrings
                                     )
                                 }
                                 val matchedWay = mapMatchFilter.matchedWay
-                                println("MapMatch: $mapMatchTime to get ${matchedWay?.getName()}")
+                                println("MapMatch: $mapMatchTime to get ${matchedWay?.getName(strings = localizedStrings)}")
                             }
                         }
                     }
@@ -566,7 +569,7 @@ class GeoEngine {
 
         CoroutineScope(Job()).launch(gridState.treeContext) {
             val userGeometry = getCurrentUserGeometry(UserGeometry.HeadingMode.Phone)
-            val choices = streetPreview.getDirectionChoices(gridState, userGeometry.location)
+            val choices = streetPreview.getDirectionChoices(gridState, userGeometry.location, localizedStrings)
             var heading = 0.0
             if (choices.isNotEmpty()) {
                 val lastHeading = streetPreview.getLastHeading()
@@ -589,7 +592,7 @@ class GeoEngine {
                 }
             }
             userGeometry.phoneHeading = heading
-            streetPreview.go(userGeometry, gridState, locationProvider)
+            streetPreview.go(userGeometry, gridState, locationProvider, localizedStrings)
         }
     }
 
@@ -598,11 +601,11 @@ class GeoEngine {
         val results = runBlocking {
             withContext(gridState.treeContext) {
                 val userGeometry = getCurrentUserGeometry(UserGeometry.HeadingMode.Phone)
-                val newLocation = streetPreview.go(userGeometry, gridState, locationProvider)
+                val newLocation = streetPreview.go(userGeometry, gridState, locationProvider, localizedStrings)
                 if (newLocation != null) {
-                    streetPreview.getDirectionChoices(gridState, newLocation)
+                    streetPreview.getDirectionChoices(gridState, newLocation, localizedStrings)
                 } else {
-                    streetPreview.getDirectionChoices(gridState, userGeometry.location)
+                    streetPreview.getDirectionChoices(gridState, userGeometry.location, localizedStrings)
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/GeoEngineHelpers.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/GeoEngineHelpers.kt
@@ -25,116 +25,6 @@ import kotlin.math.roundToInt
  */
 var metric = true
 
-/**
- * getTextForFeature returns text describing the feature for callouts. Usually it returns a name
- * or if it doesn't have one then a localized description of the type of feature it is e.g. bike
- * parking, or style. Some types of Feature have more info e.g. bus stops and railway stations
- * name from the OSM tag rather than an actual name.
- */
-fun getTextForFeature(localized: LocalizedStrings?, feature: MvtFeature): TextForFeature {
-    var generic = false
-    val name = feature.name
-    val entranceType = feature.properties?.get("entrance") as String?
-    val featureValue = feature.featureValue
-    val isMarker = feature.superCategory == SuperCategoryId.MARKER
-
-    if (feature.superCategory == SuperCategoryId.HOUSENUMBER) {
-        return TextForFeature(name ?: feature.housenumber ?: "", false)
-    }
-
-    if (isMarker) {
-        val description = feature.properties?.get("description")
-        var text = name
-        if (description != null) {
-            if (text != null)
-                text += ", $description"
-            else
-                text = description as String
-        }
-        return if (text != null)
-            TextForFeature(
-                localized?.get(StringKey.MarkersMarkerWithName, text) ?: "Marker. $text",
-                false
-            )
-        else
-            TextForFeature(localized?.get(StringKey.MarkersGenericName) ?: "Marker", false)
-    }
-
-    var text = name
-
-    // The default OSM descriptor is based on the feature class/subclass, but can be overridden
-    // by more complex OSM tagging structures like transit stops.
-    var osmFeatureKey: StringKey? = null
-
-    val namedTransit = when (featureValue) {
-        "bus_stop" -> Pair(StringKey.OsmBusStopNamed, StringKey.OsmBusStop)
-        "station" -> Pair(StringKey.OsmTrainStationNamed, StringKey.OsmTrainStation)
-        "tram_stop" -> Pair(StringKey.OsmTramStopNamed, StringKey.OsmTramStop)
-        "subway" -> Pair(StringKey.OsmSubwayNamed, StringKey.OsmSubway)
-        "ferry_terminal" -> Pair(StringKey.OsmFerryTerminalNamed, StringKey.OsmFerryTerminal)
-        else -> null
-    }
-    if (namedTransit != null) {
-        osmFeatureKey = namedTransit.second
-        text = if (name != null)
-            localized?.get(namedTransit.first, name) ?: "$name Transit Stop"
-        else
-            localized?.get(namedTransit.second) ?: "Transit"
-    }
-
-    if (entranceType != null) {
-        val entranceName = feature.properties?.get("entrance_name") as String?
-        val destinationName = text
-
-        val entranceText =
-            if (entranceType == "main")
-                localized?.get(StringKey.OsmMainEntrance) ?: "Main entrance"
-            else
-                localized?.get(StringKey.OsmEntrance) ?: "Entrance"
-
-        text = if (entranceName != null) {
-            localized?.get(
-                StringKey.OsmEntranceNamedWithDestination,
-                destinationName,
-                entranceText,
-                entranceName,
-            ) ?: "$destinationName $entranceText to $entranceName"
-        } else {
-            localized?.get(StringKey.OsmEntranceWithDestination, destinationName, entranceText)
-                ?: "$destinationName $entranceText"
-        }
-    }
-
-    if ((feature.featureClass == null) && (feature.featureSubClass == null)) {
-        return if (text == null)
-            TextForFeature("", true)
-        else
-            TextForFeature(text, false)
-    }
-
-    val osmText = if (localized != null) {
-        osmFeatureKey?.let { localized.get(it) }
-            ?: feature.featureClass?.let { localized.resolveFeatureClass(it) }
-            ?: feature.featureSubClass?.let { localized.resolveFeatureClass(it) }
-    } else {
-        "OSM Feature"
-    }
-    var additionalText: String? = null
-    if (text == null) {
-        text = osmText
-        generic = true
-    } else {
-        additionalText = osmText
-    }
-    val capitalizedText = text?.replaceFirstChar {
-        if (it.isLowerCase()) it.titlecase() else it.toString()
-    }
-    if (capitalizedText == null)
-        return TextForFeature("", generic, additionalText)
-
-    return TextForFeature(capitalizedText, generic, additionalText)
-}
-
 fun formatDistanceAndDirection(
     distance: Double,
     heading: Double?,
@@ -265,7 +155,7 @@ private fun travellingReverseGeocodeName(
     val busStopTree = gridState.getFeatureTree(TreeId.TRANSIT_STOPS)
     val nearestBusStop = busStopTree.getNearestFeature(location, gridState.ruler, 20.0)
     if (nearestBusStop != null) {
-        val busStopText = getTextForFeature(localized, nearestBusStop as MvtFeature)
+        val busStopText = (nearestBusStop as MvtFeature).getText(localized)
         if (!busStopText.generic) {
             return localized?.get(StringKey.DirectionsNearName, busStopText.text)
                 ?: "Near ${busStopText.text}"

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/GridState.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/GridState.kt
@@ -30,6 +30,7 @@ import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LineString
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+import org.scottishtecharmy.soundscape.i18n.LocalizedStrings
 import org.scottishtecharmy.soundscape.network.VectorTileClient
 import org.scottishtecharmy.soundscape.platform.ioDispatcher
 import kotlin.concurrent.Volatile
@@ -140,7 +141,8 @@ open class GridState(
         newGridIntersections: List<HashMap<LngLatAlt, Intersection>>,
         localTrees: Array<FeatureTree>,
         intersectionAccumulator: HashMap<LngLatAlt, Intersection>,
-        grid: TileGrid
+        grid: TileGrid,
+        strings: LocalizedStrings?,
     ) {
 
         fixupCollections(featureCollections)
@@ -233,7 +235,7 @@ open class GridState(
 
             // And now update the names for the intersection to include the confections
             for (intersection in intersectionAccumulator) {
-                intersection.value.updateName()
+                intersection.value.updateName(strings = strings)
             }
 
 // The other confection is done lazily as it's relatively time consuming to do the whole tile at once
@@ -250,7 +252,11 @@ open class GridState(
      * has moved away from the center of the current tile grid and if it has calculates a new grid.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    suspend fun locationUpdate(location: LngLatAlt, enabledCategories: Set<String>): Boolean {
+    suspend fun locationUpdate(
+        location: LngLatAlt,
+        enabledCategories: Set<String>,
+        strings: LocalizedStrings?,
+    ): Boolean {
         // Check if we're still within the central area of our grid
         if (!pointIsWithinBoundingBox(location, centralBoundingBox)) {
             //println("Update central grid area")
@@ -288,7 +294,8 @@ open class GridState(
                                 newGridIntersections,
                                 featureTrees,
                                 gridIntersections,
-                                tileGrid
+                                tileGrid,
+                                strings
                             )
                             gridStreetNumberTreeMap.clear()
                             for (collection in newGridStreetNumberMap)

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/StreetPreview.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/StreetPreview.kt
@@ -7,6 +7,7 @@ import org.scottishtecharmy.soundscape.geoengine.mvttranslation.WayType
 import org.scottishtecharmy.soundscape.geoengine.utils.calculateHeadingOffset
 import org.scottishtecharmy.soundscape.geoengine.utils.rulers.CheapRuler
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+import org.scottishtecharmy.soundscape.i18n.LocalizedStrings
 import org.scottishtecharmy.soundscape.locationprovider.LocationProvider
 import org.scottishtecharmy.soundscape.locationprovider.SoundscapeLocation
 
@@ -52,7 +53,8 @@ class StreetPreview {
     fun go(
         userGeometry: UserGeometry,
         gridState: GridState,
-        locationProvider: LocationProvider
+        locationProvider: LocationProvider,
+        strings: LocalizedStrings?,
     ): LngLatAlt? {
 
         when (previewState) {
@@ -95,7 +97,7 @@ class StreetPreview {
             }
 
             PreviewState.AT_NODE -> {
-                val choices = getDirectionChoices(gridState, userGeometry.location)
+                val choices = getDirectionChoices(gridState, userGeometry.location, strings)
                 var bestIndex = -1
                 var bestHeadingDiff = Double.POSITIVE_INFINITY
 
@@ -169,7 +171,11 @@ class StreetPreview {
         return null
     }
 
-    fun getDirectionChoices(gridState: GridState, location: LngLatAlt): List<StreetPreviewChoice> {
+    fun getDirectionChoices(
+        gridState: GridState,
+        location: LngLatAlt,
+        strings: LocalizedStrings?,
+    ): List<StreetPreviewChoice> {
         val choices = mutableListOf<StreetPreviewChoice>()
 
         val ruler = CheapRuler(location.latitude)
@@ -182,7 +188,8 @@ class StreetPreview {
                         heading = member.heading(nearestIntersection),
                         name = member.getName(
                             member.intersections[WayEnd.START.id] == nearestIntersection,
-                            gridState
+                            gridState,
+                            strings
                         ),
                         way = member
                     )

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/callouts/AutoCallout.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/callouts/AutoCallout.kt
@@ -14,7 +14,6 @@ import org.scottishtecharmy.soundscape.geoengine.filters.CalloutHistory
 import org.scottishtecharmy.soundscape.geoengine.filters.LocationUpdateFilter
 import org.scottishtecharmy.soundscape.geoengine.filters.TrackedCallout
 import org.scottishtecharmy.soundscape.geoengine.formatDistanceAndDirection
-import org.scottishtecharmy.soundscape.geoengine.getTextForFeature
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.MvtFeature
 import org.scottishtecharmy.soundscape.geoengine.utils.SuperCategoryId
 import org.scottishtecharmy.soundscape.geoengine.utils.getDistanceToFeature
@@ -144,7 +143,8 @@ class AutoCallout(
 
         val roadsDescription = getRoadsDescriptionFromFov(
             gridState,
-            userGeometry
+            userGeometry,
+            localized
         )
 
         // Don't describe the road we're on if there's an intersection
@@ -187,7 +187,7 @@ class AutoCallout(
         val uniquelyNamedPOIs = mutableMapOf<String, Feature>()
         pois.features.filter { feature ->
 
-            val name = getTextForFeature(localized, feature as MvtFeature)
+            val name = (feature as MvtFeature).getText(localized)
             val nearestPoint =
                 getDistanceToFeature(userGeometry.location, feature, userGeometry.ruler)
 

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/callouts/IntersectionUtils.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/callouts/IntersectionUtils.kt
@@ -41,13 +41,15 @@ data class IntersectionDescription(
  *
  * @param gridState The current GridState which is the state of the downloaded tiles
  * @param userGeometry This includes location, heading and other data
+ * @param strings An optional LocalizedStrings used when confecting names for unnamed roads
  *
  * @return An IntersectionDescription containing all the data required for callouts to describe the
  * intersection.
  */
 fun getRoadsDescriptionFromFov(
     gridState: GridState,
-    userGeometry: UserGeometry
+    userGeometry: UserGeometry,
+    strings: LocalizedStrings?,
 ): IntersectionDescription {
 
     // Create FOV triangle
@@ -94,7 +96,7 @@ fun getRoadsDescriptionFromFov(
         if (nearestRoad.properties?.get("pavement") == null) {
             // Confect the names for the sidewalk first, this should come up with the name of the
             // associated road.
-            confectNamesForRoad(nearestRoad, gridState)
+            confectNamesForRoad(nearestRoad, gridState, strings)
         }
         // There could be multiple Ways which share the same pavement name, and we want to pick the
         // right one to use. We want the Way to be running in the same direction as the pavement is,
@@ -156,7 +158,7 @@ fun getRoadsDescriptionFromFov(
             for (way in i.members) {
                 if (way.isSidewalkOrCrossing())
                     ++disposalCount
-                else if (way.isSidewalkConnector(intersection, nearestRoad, gridState))
+                else if (way.isSidewalkConnector(intersection, nearestRoad, gridState, strings))
                     ++disposalCount
             }
             if ((i.members.size - disposalCount) < 2) {
@@ -224,7 +226,8 @@ fun getRoadsDescriptionFromFov(
                                                 !member.isSidewalkConnector(
                                                     intersection,
                                                     nearestRoad,
-                                                    gridState
+                                                    gridState,
+                                                    strings
                                                 )
                                             ) {
                                                 count++

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/callouts/ManualCallouts.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/callouts/ManualCallouts.kt
@@ -11,7 +11,6 @@ import org.scottishtecharmy.soundscape.geoengine.TreeId
 import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.filters.TrackedCallout
 import org.scottishtecharmy.soundscape.geoengine.formatDistanceAndDirection
-import org.scottishtecharmy.soundscape.geoengine.getTextForFeature
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.MvtFeature
 import org.scottishtecharmy.soundscape.geoengine.utils.RelativeDirections
 import org.scottishtecharmy.soundscape.geoengine.utils.geocoders.SoundscapeGeocoder
@@ -193,14 +192,11 @@ fun buildWhatsAroundMeCallout(
                             for (feature in featureCollection) {
                                 var duplicate = false
                                 val featureName =
-                                    getTextForFeature(localizedStrings, feature as MvtFeature).text
+                                    (feature as MvtFeature).getText(localizedStrings).text
                                 for (otherFeature in featuresByDirection) {
                                     if (otherFeature == null) continue
                                     val otherName =
-                                        getTextForFeature(
-                                            localizedStrings,
-                                            otherFeature as MvtFeature
-                                        ).text
+                                        (otherFeature as MvtFeature).getText(localizedStrings).text
                                     if (featureName == otherName) duplicate = true
                                 }
                                 if (!duplicate) {
@@ -220,7 +216,7 @@ fun buildWhatsAroundMeCallout(
                     if (feature == null) continue
                     val poiLocation =
                         getDistanceToFeature(userGeometry.location, feature, userGeometry.ruler)
-                    val name = getTextForFeature(localizedStrings, feature as MvtFeature)
+                    val name = (feature as MvtFeature).getText(localizedStrings)
                     val text = "${name.text}. ${
                         formatDistanceAndDirection(
                             poiLocation.distance,
@@ -281,7 +277,7 @@ fun buildAheadOfMeCallout(
 
                     val poiLocation =
                         getDistanceToFeature(userGeometry.location, feature, userGeometry.ruler)
-                    val name = getTextForFeature(localizedStrings, feature as MvtFeature)
+                    val name = (feature as MvtFeature).getText(localizedStrings)
                     val text = "${name.text}. ${
                         formatDistanceAndDirection(
                             poiLocation.distance,
@@ -352,7 +348,7 @@ fun buildNearbyMarkersCallout(
                 if (nearestMarkers != null) {
                     for (feature in nearestMarkers.features) {
                         val featureText =
-                            getTextForFeature(localizedStrings, feature as MvtFeature)
+                            (feature as MvtFeature).getText(localizedStrings)
                         val markerLocation =
                             getDistanceToFeature(userGeometry.location, feature, userGeometry.ruler)
                         val text = "${featureText.text}. ${

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/filters/MapMatchFilter.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/filters/MapMatchFilter.kt
@@ -21,6 +21,7 @@ import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.FeatureCollection
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LineString
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+import org.scottishtecharmy.soundscape.i18n.LocalizedStrings
 import kotlin.math.asin
 import kotlin.math.cos
 import kotlin.math.max
@@ -718,7 +719,8 @@ class MapMatchFilter {
         location: LngLatAlt,
         gridState: GridState,
         collection: FeatureCollection,
-        dump: Boolean
+        dump: Boolean,
+        strings: LocalizedStrings?,
     ): Triple<LngLatAlt?, Feature?, String> {
 
         extendFollowerList(location, gridState)
@@ -761,8 +763,8 @@ class MapMatchFilter {
                             // We're matching on a sidewalk, see if the other way is either the
                             // associated way or another sidewalk for the associated way
                             val roadTree = gridState.getFeatureTree(TreeId.WAYS_SELECTION)
-                            addSidewalk(matched, roadTree, gridState.ruler)
-                            addSidewalk(way, roadTree, gridState.ruler)
+                            addSidewalk(matched, roadTree, gridState.ruler, strings)
+                            addSidewalk(way, roadTree, gridState.ruler, strings)
 
                             val matchedPavement = matched.properties?.get("pavement")
                             val matchedName = matched.name

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/mvttranslation/MvtFeature.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/mvttranslation/MvtFeature.kt
@@ -1,7 +1,10 @@
 package org.scottishtecharmy.soundscape.geoengine.mvttranslation
 
+import org.scottishtecharmy.soundscape.geoengine.TextForFeature
 import org.scottishtecharmy.soundscape.geoengine.utils.SuperCategoryId
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
+import org.scottishtecharmy.soundscape.i18n.LocalizedStrings
+import org.scottishtecharmy.soundscape.i18n.StringKey
 
 open class MvtFeature : Feature() {
     var osmId: Long = 0L
@@ -35,5 +38,115 @@ open class MvtFeature : Feature() {
         featureType = other.featureType
         featureValue = other.featureValue
         superCategory = other.superCategory
+    }
+
+    /**
+     * getText returns text describing the feature for callouts. Usually it returns a name
+     * or if it doesn't have one then a localized description of the type of feature it is e.g. bike
+     * parking, or style. Some types of Feature have more info e.g. bus stops and railway stations
+     * name from the OSM tag rather than an actual name.
+     */
+    fun getText(localized: LocalizedStrings?): TextForFeature {
+        var generic = false
+        val name = name
+        val entranceType = properties?.get("entrance") as String?
+        val featureValue = featureValue
+        val isMarker = superCategory == SuperCategoryId.MARKER
+
+        if (superCategory == SuperCategoryId.HOUSENUMBER) {
+            return TextForFeature(name ?: housenumber ?: "", false)
+        }
+
+        if (isMarker) {
+            val description = properties?.get("description")
+            var text = name
+            if (description != null) {
+                if (text != null)
+                    text += ", $description"
+                else
+                    text = description as String
+            }
+            return if (text != null)
+                TextForFeature(
+                    localized?.get(StringKey.MarkersMarkerWithName, text) ?: "Marker. $text",
+                    false
+                )
+            else
+                TextForFeature(localized?.get(StringKey.MarkersGenericName) ?: "Marker", false)
+        }
+
+        var text = name
+
+        // The default OSM descriptor is based on the feature class/subclass, but can be overridden
+        // by more complex OSM tagging structures like transit stops.
+        var osmFeatureKey: StringKey? = null
+
+        val namedTransit = when (featureValue) {
+            "bus_stop" -> Pair(StringKey.OsmBusStopNamed, StringKey.OsmBusStop)
+            "station" -> Pair(StringKey.OsmTrainStationNamed, StringKey.OsmTrainStation)
+            "tram_stop" -> Pair(StringKey.OsmTramStopNamed, StringKey.OsmTramStop)
+            "subway" -> Pair(StringKey.OsmSubwayNamed, StringKey.OsmSubway)
+            "ferry_terminal" -> Pair(StringKey.OsmFerryTerminalNamed, StringKey.OsmFerryTerminal)
+            else -> null
+        }
+        if (namedTransit != null) {
+            osmFeatureKey = namedTransit.second
+            text = if (name != null)
+                localized?.get(namedTransit.first, name) ?: "$name Transit Stop"
+            else
+                localized?.get(namedTransit.second) ?: "Transit"
+        }
+
+        if (entranceType != null) {
+            val entranceName = properties?.get("entrance_name") as String?
+            val destinationName = text
+
+            val entranceText =
+                if (entranceType == "main")
+                    localized?.get(StringKey.OsmMainEntrance) ?: "Main entrance"
+                else
+                    localized?.get(StringKey.OsmEntrance) ?: "Entrance"
+
+            text = if (entranceName != null) {
+                localized?.get(
+                    StringKey.OsmEntranceNamedWithDestination,
+                    destinationName,
+                    entranceText,
+                    entranceName,
+                ) ?: "$destinationName $entranceText to $entranceName"
+            } else {
+                localized?.get(StringKey.OsmEntranceWithDestination, destinationName, entranceText)
+                    ?: "$destinationName $entranceText"
+            }
+        }
+
+        if ((featureClass == null) && (featureSubClass == null)) {
+            return if (text == null)
+                TextForFeature("", true)
+            else
+                TextForFeature(text, false)
+        }
+
+        val osmText = if (localized != null) {
+            osmFeatureKey?.let { localized.get(it) }
+                ?: featureClass?.let { localized.resolveFeatureClass(it) }
+                ?: featureSubClass?.let { localized.resolveFeatureClass(it) }
+        } else {
+            "OSM Feature"
+        }
+        var additionalText: String? = null
+        if (text == null) {
+            text = osmText
+            generic = true
+        } else {
+            additionalText = osmText
+        }
+        val capitalizedText = text?.replaceFirstChar {
+            if (it.isLowerCase()) it.titlecase() else it.toString()
+        }
+        if (capitalizedText == null)
+            return TextForFeature("", generic, additionalText)
+
+        return TextForFeature(capitalizedText, generic, additionalText)
     }
 }

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/mvttranslation/WayGenerator.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/mvttranslation/WayGenerator.kt
@@ -57,7 +57,7 @@ class Intersection : MvtFeature() {
 
     fun updateName(
         gridState: GridState? = null,
-        strings: LocalizedStrings? = null
+        strings: LocalizedStrings?
     ) {
         val updatedName = StringBuilder()
         val namesUsed = mutableSetOf<String>()
@@ -106,7 +106,7 @@ class Way : MvtFeature() {
     fun getName(
         direction: Boolean? = null,
         gridState: GridState? = null,
-        strings: LocalizedStrings? = null,
+        strings: LocalizedStrings?,
         nonGenericOnly: Boolean = false,
         noGenericDeadEnds: Boolean = false
     ): String {
@@ -128,7 +128,7 @@ class Way : MvtFeature() {
             }
 
             if (gridState != null) {
-                confectNamesForRoad(this, gridState)
+                confectNamesForRoad(this, gridState, strings)
             }
 
             if (direction != null) {
@@ -270,6 +270,7 @@ class Way : MvtFeature() {
         intersection: Intersection,
         mainWay: Way?,
         gridState: GridState,
+        strings: LocalizedStrings?,
     ): Boolean {
 
         // It's not a connector if the mainWay isn't named
@@ -293,7 +294,7 @@ class Way : MvtFeature() {
                     // connector i.e. it may connect to a sidewalk, but it goes further.
                     return false
                 } else if (way.properties?.get("pavement") == null) {
-                    confectNamesForRoad(way, gridState)
+                    confectNamesForRoad(way, gridState, strings)
                 }
                 // And then return true if it's the pavement for this Way
                 val pavement = way.properties?.get("pavement")

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/utils/WayNaming.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/utils/WayNaming.kt
@@ -18,7 +18,7 @@ fun addSidewalk(
     currentRoad: Way,
     roadTree: FeatureTree,
     ruler: Ruler,
-    strings: LocalizedStrings? = null,
+    strings: LocalizedStrings?,
 ): Boolean {
 
     var found = false
@@ -124,7 +124,8 @@ fun checkNearbyPoi(
 
 fun addPoiDestinations(
     way: Way,
-    gridState: GridState
+    gridState: GridState,
+    strings: LocalizedStrings?,
 ): Boolean {
 
     // We want to use the locations at the furthest extent of the way as the start and end points.
@@ -215,15 +216,15 @@ fun addPoiDestinations(
 
     if (startPoi != endPoi) {
         if (!startDestinationAdded) {
-            val startName = (startPoi as MvtFeature?)?.name
-            if (startName != null) {
+            val startName = (startPoi as MvtFeature?)?.getText(strings)?.text
+            if (!startName.isNullOrEmpty()) {
                 way.setProperty("destination:backward", startName)
                 addedDestinations = true
             }
         }
         if (!endDestinationAdded) {
-            val endName = (endPoi as MvtFeature?)?.name
-            if (endName != null) {
+            val endName = (endPoi as MvtFeature?)?.getText(strings)?.text
+            if (!endName.isNullOrEmpty()) {
                 way.setProperty("destination:forward", endName)
                 addedDestinations = true
             }
@@ -234,7 +235,8 @@ fun addPoiDestinations(
 
 fun confectNamesForRoad(
     road: Way,
-    gridState: GridState
+    gridState: GridState,
+    strings: LocalizedStrings?,
 ) {
 
     // rtree searches take time and so we should avoid them where possible.
@@ -243,11 +245,11 @@ fun confectNamesForRoad(
     val cycleway = (road.featureType == "highway") && (road.featureValue == "cycleway")
     if ((road.name == null) || cycleway) {
 
-        if (addSidewalk(road, roadTree, gridState.ruler)) {
+        if (addSidewalk(road, roadTree, gridState.ruler, strings)) {
             return
         }
 
-        addPoiDestinations(road, gridState)
+        addPoiDestinations(road, gridState, strings)
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/utils/geocoders/OfflineGeocoder.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/utils/geocoders/OfflineGeocoder.kt
@@ -7,7 +7,6 @@ import org.scottishtecharmy.soundscape.geoengine.GridState
 import org.scottishtecharmy.soundscape.geoengine.TreeId
 import org.scottishtecharmy.soundscape.geoengine.UserGeometry
 import org.scottishtecharmy.soundscape.geoengine.formatDistanceAndDirection
-import org.scottishtecharmy.soundscape.geoengine.getTextForFeature
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.MvtFeature
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.Way
 import org.scottishtecharmy.soundscape.geoengine.utils.getDistanceToFeature
@@ -187,7 +186,7 @@ class OfflineGeocoder(
         val busStopTree = gridState.getFeatureTree(TreeId.TRANSIT_STOPS)
         val nearestBusStop = busStopTree.getNearestFeature(location, gridState.ruler, 20.0)
         if (nearestBusStop != null) {
-            val busStopText = getTextForFeature(null, nearestBusStop as MvtFeature)
+            val busStopText = (nearestBusStop as MvtFeature).getText(localizedStrings)
             return LocationDescription(
                 name = busStopText.text,
                 location = getNearestPointOnFeature(nearestBusStop, location)
@@ -200,7 +199,7 @@ class OfflineGeocoder(
         insidePois.forEach { poi ->
             val mvt = poi as MvtFeature
             if (!mvt.name.isNullOrEmpty()) {
-                val featureText = getTextForFeature(null, mvt)
+                val featureText = mvt.getText(localizedStrings)
                 return LocationDescription(
                     name = featureText.text,
                     location = getNearestPointOnFeature(mvt, location)
@@ -214,7 +213,7 @@ class OfflineGeocoder(
             val mvt = poi as MvtFeature
             if (!mvt.name.isNullOrEmpty()) {
                 return LocationDescription(
-                    name = getTextForFeature(null, mvt).text,
+                    name = mvt.getText(localizedStrings).text,
                     location = getNearestPointOnFeature(mvt, location),
                 )
             }

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/utils/geocoders/PhotonGeocoder.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/utils/geocoders/PhotonGeocoder.kt
@@ -2,7 +2,6 @@ package org.scottishtecharmy.soundscape.geoengine.utils.geocoders
 
 import org.scottishtecharmy.soundscape.components.LocationSource
 import org.scottishtecharmy.soundscape.geoengine.UserGeometry
-import org.scottishtecharmy.soundscape.geoengine.getTextForFeature
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.MvtFeature
 import org.scottishtecharmy.soundscape.geoengine.utils.rulers.CheapRuler
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.Feature
@@ -72,7 +71,7 @@ class PhotonGeocoder(
                 mvt.featureClass = "residential_street"
             feature.deferredToLocationDescription(
                 LocationSource.PhotonGeocoder,
-                featureName = getTextForFeature(localizedStrings, mvt)
+                featureName = mvt.getText(localizedStrings)
             ).also(processor)
         }
     }

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/utils/geocoders/StreetDescription.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/utils/geocoders/StreetDescription.kt
@@ -2,7 +2,6 @@ package org.scottishtecharmy.soundscape.geoengine.utils.geocoders
 
 import org.scottishtecharmy.soundscape.geoengine.GridState
 import org.scottishtecharmy.soundscape.geoengine.TreeId
-import org.scottishtecharmy.soundscape.geoengine.getTextForFeature
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.Intersection
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.IntersectionType
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.MvtFeature
@@ -735,7 +734,7 @@ class StreetDescription(val name: String, val gridState: GridState) {
                     aheadValue as? Intersection?,
                     nearestWay,
                     localizedStrings
-                ) ?: getTextForFeature(localizedStrings, aheadValue).text
+                ) ?: aheadValue.getText(localizedStrings).text
 
                 tmpAhead = StreetPosition(text, ahead - distance)
             }
@@ -748,7 +747,7 @@ class StreetDescription(val name: String, val gridState: GridState) {
                     behindValue as? Intersection?,
                     nearestWay,
                     localizedStrings
-                ) ?: getTextForFeature(localizedStrings, behindValue).text
+                ) ?: behindValue.getText(localizedStrings).text
                 tmpBehind = StreetPosition(
                     text,
                     distance - behind
@@ -770,7 +769,7 @@ class StreetDescription(val name: String, val gridState: GridState) {
     fun describeStreet() {
         println("Describe $name")
         for (point in sortedDescriptivePoints) {
-            val text = getTextForFeature(null, point.value)
+            val text = point.value.getText(null)
             when (point.value.side) {
                 null -> println("\t\t\t\t\t${point.key.toInt()}m (${text.text})")
                 true -> println("\t\t\t\t\t${point.key.toInt()}m ${text.text}")

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/utils/geocoders/TileSearch.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/utils/geocoders/TileSearch.kt
@@ -8,7 +8,6 @@ import org.scottishtecharmy.soundscape.components.LocationSource
 import org.scottishtecharmy.soundscape.geoengine.GridState
 import org.scottishtecharmy.soundscape.geoengine.MAX_ZOOM_LEVEL
 import org.scottishtecharmy.soundscape.geoengine.TreeId
-import org.scottishtecharmy.soundscape.geoengine.getTextForFeature
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.MvtFeature
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.Way
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.convertGeometry
@@ -682,7 +681,7 @@ class TileSearch(
         return streetResults.map { (mvt, result) ->
             mvt.toLocationDescription(
                 LocationSource.OfflineGeocoder,
-                featureName = getTextForFeature(localizedStrings, mvt)
+                featureName = mvt.getText(localizedStrings)
             )
         }
     }

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/home/placesnearby/PlacesNearbyFolders.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/home/placesnearby/PlacesNearbyFolders.kt
@@ -10,14 +10,13 @@ import androidx.compose.material.icons.rounded.LocalGroceryStore
 import androidx.compose.ui.graphics.vector.ImageVector
 import org.jetbrains.compose.resources.StringResource
 import org.scottishtecharmy.soundscape.components.LocationSource
-import org.scottishtecharmy.soundscape.geoengine.getTextForFeature
 import org.scottishtecharmy.soundscape.geoengine.mvttranslation.MvtFeature
 import org.scottishtecharmy.soundscape.geoengine.utils.featureHasEntrances
 import org.scottishtecharmy.soundscape.geoengine.utils.featureIsInFilterGroup
 import org.scottishtecharmy.soundscape.geoengine.utils.getDistanceToFeature
 import org.scottishtecharmy.soundscape.geoengine.utils.rulers.CheapRuler
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
-import org.scottishtecharmy.soundscape.i18n.ComposeLocalizedStrings
+import org.scottishtecharmy.soundscape.i18n.LocalizedStrings
 import org.scottishtecharmy.soundscape.resources.Res
 import org.scottishtecharmy.soundscape.resources.all_places_nearby_description
 import org.scottishtecharmy.soundscape.resources.banks_places_nearby_description
@@ -80,7 +79,10 @@ val placesNearbyFolders = listOf(
     ),
 )
 
-fun filterLocations(uiState: PlacesNearbyUiState): List<LocationDescription> {
+fun filterLocations(
+    uiState: PlacesNearbyUiState,
+    strings: LocalizedStrings,
+): List<LocationDescription> {
     val location = uiState.userLocation ?: LngLatAlt()
     val ruler = CheapRuler(location.latitude)
     return if (uiState.filter == "intersections") {
@@ -102,15 +104,12 @@ fun filterLocations(uiState: PlacesNearbyUiState): List<LocationDescription> {
             // Filter based on any folder selected and filter out POIs with entrances
             !featureHasEntrances(feature) &&
                     featureIsInFilterGroup(feature, uiState.filter) &&
-                    getTextForFeature(
-                        ComposeLocalizedStrings(),
-                        feature as MvtFeature
-                    ).text.isNotEmpty()
+                    (feature as MvtFeature).getText(strings).text.isNotEmpty()
         }.map { feature ->
             feature.deferredToLocationDescription(
                 LocationSource.OfflineGeocoder,
                 getDistanceToFeature(location, feature, ruler).point,
-                getTextForFeature(ComposeLocalizedStrings(), feature as MvtFeature)
+                (feature as MvtFeature).getText(strings)
             )
         }.sortedBy {
             uiState.userLocation?.let { location ->

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/home/placesnearby/PlacesNearbyList.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/home/placesnearby/PlacesNearbyList.kt
@@ -15,6 +15,7 @@ import org.scottishtecharmy.soundscape.components.EnabledFunction
 import org.scottishtecharmy.soundscape.components.FolderItem
 import org.scottishtecharmy.soundscape.components.LocationItem
 import org.scottishtecharmy.soundscape.components.LocationItemDecoration
+import org.scottishtecharmy.soundscape.i18n.ComposeLocalizedStrings
 import org.scottishtecharmy.soundscape.resources.Res
 import org.scottishtecharmy.soundscape.resources.location_detail_action_beacon_hint
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
@@ -30,8 +31,9 @@ fun PlacesNearbyList(
     onStartBeacon: (LocationDescription) -> Unit,
     modifier: Modifier,
 ) {
+    val localizedStrings = remember { ComposeLocalizedStrings() }
     val locations = remember(uiState) {
-        filterLocations(uiState)
+        filterLocations(uiState, localizedStrings)
     }
 
     LazyColumn(

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/AddWaypointsList.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/markers_routes/screens/addandeditroutescreen/AddWaypointsList.kt
@@ -40,6 +40,7 @@ import org.scottishtecharmy.soundscape.components.FolderItem
 import org.scottishtecharmy.soundscape.components.LocationItem
 import org.scottishtecharmy.soundscape.components.LocationItemDecoration
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+import org.scottishtecharmy.soundscape.i18n.ComposeLocalizedStrings
 import org.scottishtecharmy.soundscape.platform.ioDispatcher
 import org.scottishtecharmy.soundscape.resources.Res
 import org.scottishtecharmy.soundscape.resources.general_loading_start
@@ -116,8 +117,9 @@ fun AddWaypointsList(
         ),
     )
     val levelOneFolders = placesNearbyFolders
+    val localizedStrings = remember { ComposeLocalizedStrings() }
     val nearbyLocations = remember(placesNearbyUiState) {
-        filterLocations(placesNearbyUiState)
+        filterLocations(placesNearbyUiState, localizedStrings)
     }
     val coroutineScope = rememberCoroutineScope()
     var fetchingLocation by remember { mutableStateOf(false) }


### PR DESCRIPTION
Two changes: 

1. Changing the setting "Enable recording of travel" wasn't causing "Share recording of travel" to immediately show up in the main menu.
2. GeoEngine localization in KMP wasn't consistent and many strings were being left in English.