### PR TITLE
Fix untranslated "dead-end" in intersection callouts for unnamed ways

### DIFF
--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/mvttranslation/WayGenerator.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/mvttranslation/WayGenerator.kt
@@ -160,8 +160,11 @@ class Way : MvtFeature() {
                 }
 
                 if (destinationModifier != null) {
-                    if ((destinationModifier == "dead-end") && noGenericDeadEnds)
-                        return ""
+                    if (destinationModifier == "dead-end") {
+                        if (noGenericDeadEnds)
+                            return ""
+                        destinationModifier = strings?.getOrNull(StringKey.ConfectNameDeadEnd) ?: "dead end"
+                    }
 
                     return if (passesString.isNotEmpty()) {
                         strings?.getOrNull(


### PR DESCRIPTION
The unnamed-way branch of Way.getName() used the raw "dead-end" tag literal directly instead of routing it through the localized ConfectNameDeadEnd string, unlike the named-way branch below it.