### PR TITLE
SA-339 - Change waypoint marker colour when it's the current beacon

### DIFF
--- a/shared/src/commonMain/composeResources/drawable/current_beacon_location_marker.xml
+++ b/shared/src/commonMain/composeResources/drawable/current_beacon_location_marker.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="245.21"
+    android:viewportHeight="280.3"
+    android:tint="#0044CC"
+    android:alpha="0.8">
+    <group
+        android:scaleX="0.9996331"
+        android:translateX="0.04498349"
+        android:translateY="35">
+        <path
+            android:pathData="M0,94.76a122.6,94.76 0,1 0,245.21 0a122.6,94.76 0,1 0,-245.21 0z"
+            android:strokeWidth="2.82405"
+            android:fillColor="#0044CC" />
+        <path
+            android:pathData="m90.3,169.17 l37.78,76.13 33.14,-77.63z"
+            android:strokeWidth="2.36976"
+            android:fillColor="#0044CC" />
+    </group>
+</vector>

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
@@ -51,6 +51,7 @@ import org.scottishtecharmy.soundscape.database.local.model.RouteWithMarkers
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import org.scottishtecharmy.soundscape.platform.nativeMapRenderOptions
 import org.scottishtecharmy.soundscape.resources.Res
+import org.scottishtecharmy.soundscape.resources.current_beacon_location_marker
 import org.scottishtecharmy.soundscape.resources.location_detail_exit_full_screen_hint
 import org.scottishtecharmy.soundscape.resources.location_detail_full_screen_hint
 import org.scottishtecharmy.soundscape.resources.location_marker
@@ -160,6 +161,7 @@ fun MapContainerLibre(
 
     val navigationMarker = painterResource(Res.drawable.navigation)
     val locationMarker = painterResource(Res.drawable.location_marker)
+    val currentBeaconLocationMarker = painterResource(Res.drawable.current_beacon_location_marker)
 
     Box(
         modifier = modifier.pointerInput(Unit) {
@@ -237,35 +239,6 @@ fun MapContainerLibre(
                     iconAllowOverlap = const(true)
                 )
             }
-            if (beaconLocation != null) {
-                val position = Position(
-                    latitude = beaconLocation.latitude,
-                    longitude = beaconLocation.longitude
-                )
-                val beaconLocationGeoJson =
-                    rememberGeoJsonSource(
-                        data = GeoJsonData.Features(Point(position))
-                    )
-
-                SymbolLayer(
-                    id = "beacon-location",
-                    source = beaconLocationGeoJson,
-                    iconImage = image(locationMarker),
-                    iconSize = const(1.2F),
-                    iconAllowOverlap = const(true),
-                    iconAnchor = const(SymbolAnchor.Bottom),
-                    // Default font stack (Open Sans, Arial Unicode MS) is not
-                    // bundled — must use a Roboto variant that ships with the
-                    // glyph PBFs in osm-liberty-accessible/fonts/.
-                    textField = format(span("${currentBeaconWaypointIndex + 1}")),
-                    textFont = const(listOf("Roboto Bold")),
-                    textColor = const(Color.White),
-                    textSize = const(11.sp),
-                    textAllowOverlap = const(true),
-                    textAnchor = const(SymbolAnchor.Center),
-                    textOffset = offset(0f.em, (-1.3f).em),
-                )
-            }
 
             if (routeData != null) {
                 for ((index, waypoint) in routeData.markers.withIndex()) {
@@ -309,6 +282,37 @@ fun MapContainerLibre(
                         )
                     }
                 }
+            }
+
+            // Draw beacon location marker last to prevent waypoint marker being drawn on top.
+            if (beaconLocation != null) {
+                val position = Position(
+                    latitude = beaconLocation.latitude,
+                    longitude = beaconLocation.longitude
+                )
+                val beaconLocationGeoJson =
+                    rememberGeoJsonSource(
+                        data = GeoJsonData.Features(Point(position))
+                    )
+
+                SymbolLayer(
+                    id = "beacon-location",
+                    source = beaconLocationGeoJson,
+                    iconImage = image(currentBeaconLocationMarker),
+                    iconSize = const(1.2F),
+                    iconAllowOverlap = const(true),
+                    iconAnchor = const(SymbolAnchor.Bottom),
+                    // Default font stack (Open Sans, Arial Unicode MS) is not
+                    // bundled — must use a Roboto variant that ships with the
+                    // glyph PBFs in osm-liberty-accessible/fonts/.
+                    textField = format(span("${currentBeaconWaypointIndex + 1}")),
+                    textFont = const(listOf("Roboto Bold")),
+                    textColor = const(Color.White),
+                    textSize = const(11.sp),
+                    textAllowOverlap = const(true),
+                    textAnchor = const(SymbolAnchor.Center),
+                    textOffset = offset(0f.em, (-1.3f).em),
+                )
             }
         }
     }


### PR DESCRIPTION
- Added drawable for active beacon marker
- Changed order of SymbolLayer rendering: Route markers are drawn first and then the beacon marker to prevent the beacon marker from being obfuscated