### PR TITLE
SA-379 - Fix Activity Leak

### DIFF
--- a/shared/src/androidMain/kotlin/org/scottishtecharmy/soundscape/platform/MapRenderOptions.android.kt
+++ b/shared/src/androidMain/kotlin/org/scottishtecharmy/soundscape/platform/MapRenderOptions.android.kt
@@ -3,4 +3,4 @@ package org.scottishtecharmy.soundscape.platform
 import org.maplibre.compose.map.RenderOptions
 
 actual fun nativeMapRenderOptions(): RenderOptions =
-    RenderOptions(renderMode = RenderOptions.RenderMode.TextureView)
+    RenderOptions(renderMode = RenderOptions.RenderMode.SurfaceView)

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/platform/MapRenderOptions.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/platform/MapRenderOptions.kt
@@ -4,8 +4,7 @@ import org.maplibre.compose.map.RenderOptions
 
 /**
  * Platform-specific RenderOptions for the MapLibre map. On Android we force a
- * TextureView so the map participates in Compose nav/transition animations
- * (the default SurfaceView is a hardware overlay that doesn't fade or slide).
+ * SurfaceView due to a leak in MapLibre: See SA-379
  * iOS already renders into a layer that composites correctly, so it falls back
  * to RenderOptions.Standard.
  */

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/home/home/MapContainerLibre.kt
@@ -193,8 +193,8 @@ fun MapContainerLibre(
                 gestureOptions = if (allowScrolling) GestureOptions.RotationLocked
                 else GestureOptions.ZoomOnly,
                 ornamentOptions = OrnamentOptions.AllDisabled,
-                // Platform-specific render options: Android uses TextureView so
-                // the map participates in Compose's fade/slide nav transitions
+                // Platform-specific render options: Android uses SurfaceView due to a leak in
+                // MapLibre: See SA-379
                 // (the default SurfaceView is a hardware overlay that doesn't
                 // animate). iOS keeps Standard.
                 renderOptions = nativeMapRenderOptions(),


### PR DESCRIPTION
- Defaulting to SurfaceView rendering for MapLibre map as TextureView causes an Activity leak