### PR TITLE
[SPIKE] Gradle optimisations

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -292,6 +292,7 @@ jobs:
     # the Android emulator has room in its 16 GB budget.
     env:
       GRADLE_OPTS: -Xmx8192m
+      GRADLE_ARGS: -PincludeIos=true
 
     steps:
       # Pull the latest commit on the branch (including the version-bump

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -133,7 +133,7 @@ jobs:
       # test sources to catch Kotlin/iOS errors; the XCTest step below
       # exercises the linked code via xcodebuild.
       - name: Compile shared Kotlin/Native tests for iOS simulator
-        run: ./gradlew --configure-on-demand :shared:compileTestKotlinIosSimulatorArm64
+        run: ./gradlew --configure-on-demand :shared:compileTestKotlinIosSimulatorArm64 -PincludeIos=true
 
       # The runner image does not always pre-register a concrete simulator
       # device (xcodebuild only sees the "Any iOS Simulator" placeholder), so

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,13 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx6144m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -84,10 +84,13 @@ kotlin {
             resources.srcDir("src/commonMain/resources")
         }
         if (includeIos) {
-            getByName("iosMain") {
-                dependencies {
-                    implementation(libs.ktor.client.darwin)
-                }
+            // Ensure iosMain exists and has its dependency; the default hierarchy
+            // will link it to the iOS targets if they were created.
+            val iosMain = findByName("iosMain") ?: create("iosMain").apply {
+                dependsOn(commonMain.get())
+            }
+            iosMain.dependencies {
+                implementation(libs.ktor.client.darwin)
             }
         }
     }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -83,13 +83,16 @@ kotlin {
             // in a single canonical location consumed by both platforms.
             resources.srcDir("src/commonMain/resources")
         }
-        if (includeIos) {
-            // Ensure iosMain exists and has its dependency; the default hierarchy
-            // will link it to the iOS targets if they were created.
-            val iosMain = findByName("iosMain") ?: create("iosMain").apply {
-                dependsOn(commonMain.get())
-            }
-            iosMain.dependencies {
+        
+        // iosMain is created automatically by the default hierarchy template
+        // when iOS targets are enabled. We configure its dependencies below
+        // using configureEach to avoid "SourceSet not found" errors when 
+        // iOS targets are disabled.
+    }
+
+    sourceSets.configureEach {
+        if (name == "iosMain") {
+            dependencies {
                 implementation(libs.ktor.client.darwin)
             }
         }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -83,9 +83,11 @@ kotlin {
             // in a single canonical location consumed by both platforms.
             resources.srcDir("src/commonMain/resources")
         }
-        findByName("iosMain")?.apply {
-            dependencies {
-                implementation(libs.ktor.client.darwin)
+        if (includeIos) {
+            getByName("iosMain") {
+                dependencies {
+                    implementation(libs.ktor.client.darwin)
+                }
             }
         }
     }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -28,14 +28,17 @@ kotlin {
         // for iosSimulatorArm64Test on the macOS CI runner, and never run at all on Android.
         withHostTest {}
     }
-    listOf(
-        iosArm64(),
-        iosSimulatorArm64(),
-    ).forEach {
-        it.binaries.framework {
-            baseName = "Shared"
-            isStatic = true
-            freeCompilerArgs += listOf("-Xbinary=bundleId=org.scottishtecharmy.soundscape.shared")
+    val isMac = System.getProperty("os.name").lowercase().contains("mac")
+    if (isMac) {
+        listOf(
+            iosArm64(),
+            iosSimulatorArm64(),
+        ).forEach {
+            it.binaries.framework {
+                baseName = "Shared"
+                isStatic = true
+                freeCompilerArgs += listOf("-Xbinary=bundleId=org.scottishtecharmy.soundscape.shared")
+            }
         }
     }
 
@@ -78,8 +81,12 @@ kotlin {
             // in a single canonical location consumed by both platforms.
             resources.srcDir("src/commonMain/resources")
         }
-        iosMain.dependencies {
-            implementation(libs.ktor.client.darwin)
+        if (isMac) {
+            named("iosMain") {
+                dependencies {
+                    implementation(libs.ktor.client.darwin)
+                }
+            }
         }
     }
 }
@@ -94,8 +101,10 @@ wire {
 
 dependencies {
     add("kspAndroid", libs.androidx.room.compiler)
-    add("kspIosArm64", libs.androidx.room.compiler)
-    add("kspIosSimulatorArm64", libs.androidx.room.compiler)
+    if (System.getProperty("os.name").lowercase().contains("mac")) {
+        add("kspIosArm64", libs.androidx.room.compiler)
+        add("kspIosSimulatorArm64", libs.androidx.room.compiler)
+    }
 }
 
 room {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -28,8 +28,10 @@ kotlin {
         // for iosSimulatorArm64Test on the macOS CI runner, and never run at all on Android.
         withHostTest {}
     }
-    val isMac = System.getProperty("os.name").lowercase().contains("mac")
-    if (isMac) {
+    // Only configure iOS targets on macOS (local dev) or if explicitly requested via -PincludeIos=true.
+    // This speeds up build/sync times on Linux/Windows where iOS targets cannot be compiled.
+    val includeIos = System.getProperty("os.name").lowercase().contains("mac") || project.hasProperty("includeIos")
+    if (includeIos) {
         listOf(
             iosArm64(),
             iosSimulatorArm64(),
@@ -81,11 +83,9 @@ kotlin {
             // in a single canonical location consumed by both platforms.
             resources.srcDir("src/commonMain/resources")
         }
-        if (isMac) {
-            named("iosMain") {
-                dependencies {
-                    implementation(libs.ktor.client.darwin)
-                }
+        findByName("iosMain")?.apply {
+            dependencies {
+                implementation(libs.ktor.client.darwin)
             }
         }
     }
@@ -101,7 +101,8 @@ wire {
 
 dependencies {
     add("kspAndroid", libs.androidx.room.compiler)
-    if (System.getProperty("os.name").lowercase().contains("mac")) {
+    val includeIos = System.getProperty("os.name").lowercase().contains("mac") || project.hasProperty("includeIos")
+    if (includeIos) {
         add("kspIosArm64", libs.androidx.room.compiler)
         add("kspIosSimulatorArm64", libs.androidx.room.compiler)
     }


### PR DESCRIPTION
1. Enabled Gradle Performance Features:
◦
Parallel Execution: Enabled org.gradle.parallel to allow building independent modules (like :app and :shared) simultaneously. ◦
Build Caching: Enabled org.gradle.caching to reuse results from previous builds, significantly speeding up re-builds. ◦
Configuration Caching: Enabled org.gradle.configuration-cache to skip the configuration phase when build files haven't changed. ◦
Increased Memory: Increased the Gradle daemon's heap size to 6GB (-Xmx6144m) to reduce garbage collection overhead during large builds. 2.
Optimized Multiplatform Configuration:
◦
Modified shared/build.gradle.kts to only configure iOS targets and dependencies when building on macOS. This will speed up Gradle sync and compilation on Linux/Windows by avoiding redundant work for platforms you aren't currently targeting. ◦
Modernized the iosMain source set configuration to use the latest Gradle APIs, resolving several deprecation warnings.