### PR TITLE
Fix NPE crash in SoundscapeBinder.getSoundscapeService()

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/SoundscapeServiceConnection.kt
@@ -91,7 +91,12 @@ class SoundscapeServiceConnection @Inject constructor() {
             Log.d(TAG, "onServiceConnected")
 
             val binder = service as SoundscapeBinder
-            soundscapeService = binder.getSoundscapeService()
+            val boundService = binder.getSoundscapeService()
+            if (boundService == null) {
+                Log.w(TAG, "onServiceConnected but underlying service already destroyed; ignoring")
+                return
+            }
+            soundscapeService = boundService
             _serviceBoundState.value = true
         }
 

--- a/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/services/SoundscapeService.kt
@@ -1156,8 +1156,8 @@ class SoundscapeService : MediaSessionService() {
 // Binder to allow local clients to Bind to our service
 class SoundscapeBinder(newService: SoundscapeService?) : Binder() {
     var service: SoundscapeService? = newService
-    fun getSoundscapeService(): SoundscapeService {
-        return service!!
+    fun getSoundscapeService(): SoundscapeService? {
+        return service
     }
 
     fun reset() {


### PR DESCRIPTION
The binder's service reference can be nulled by onDestroy() (via binder.reset()) before a pending onServiceConnected callback is delivered, since bindService's callback is posted asynchronously. The unguarded service!! then threw a fatal NPE. Make the getter nullable and have onServiceConnected ignore the callback if the service was already torn down.