### PR TITLE
Fix onboarding reset and permissions

### DIFF
--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/home/HomeScreen.kt
@@ -326,9 +326,18 @@ fun HomeScreen(
             onOfflineMapsDelete = { feature -> offlineMaps.deleteExtractByFeature(feature) },
             onOfflineMapsCancelDownload = { offlineMaps.cancelDownload() },
             onResetSettings = {
-                // SharedNavGraph has already cleared the preferences. Relaunch
-                // MainActivity in a fresh task and kill the current process so
-                // the rebuilt app sees the cleared state from a clean slate.
+                // Android supplies its own settingsContent below, so SharedNavGraph's
+                // clearAll()-wrapping lambda is never built for this platform - clear here
+                // instead. Then relaunch MainActivity in a fresh task and kill the current
+                // process so the rebuilt app sees the cleared state from a clean slate.
+                prefsProvider.clearAll()
+                // Explicitly stop the foreground service first. SoundscapeService is a
+                // MediaSessionService (effectively START_STICKY); killing the process
+                // without stopping it first leaves Android's restart bookkeeping intact,
+                // so it auto-restarts the old service instance - with its already-running
+                // GeoEngine/AutoCallout speaking a stale location callout - independent of
+                // the freshly relaunched activity. Same fix as onSetApplicationLocale above.
+                activity.setServiceState(false)
                 val launch = activity.packageManager.getLaunchIntentForPackage(activity.packageName)
                 if (launch != null) {
                     launch.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/OnboardingNavGraph.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/OnboardingNavGraph.kt
@@ -75,13 +75,27 @@ fun SetUpOnboardingNavGraph(
             )
         }
         composable(OnboardingScreens.Navigating.route) {
+            // Pop this screen off the back stack on the way out, whether the user
+            // just granted everything or it was already satisfied - there's nothing
+            // left to review here either way, and leaving it on the back stack means
+            // swiping back into it re-triggers its own skip check and immediately
+            // bounces forward again.
             NavigatingScreen(
-                onNavigate = { navController.navigate(OnboardingScreens.BatteryOptimization.route) }
+                onNavigate = {
+                    navController.navigate(OnboardingScreens.BatteryOptimization.route) {
+                        popUpTo(OnboardingScreens.Navigating.route) { inclusive = true }
+                    }
+                },
             )
         }
         composable(OnboardingScreens.BatteryOptimization.route) {
+            // Same reasoning as Navigating above.
             BatteryOptimizationScreen(
-                onNavigate = { navController.navigate(OnboardingScreens.Listening.route) }
+                onNavigate = {
+                    navController.navigate(OnboardingScreens.Listening.route) {
+                        popUpTo(OnboardingScreens.BatteryOptimization.route) { inclusive = true }
+                    }
+                },
             )
         }
         composable(OnboardingScreens.AudioBeacons.route) {

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/battery/BatteryOptimizationAndroid.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/battery/BatteryOptimizationAndroid.kt
@@ -19,8 +19,13 @@ import androidx.core.net.toUri
 
 @Composable
 fun BatteryOptimizationScreen(
+    // Called both when the system permission dialog returns and when the screen
+    // skips itself because the exemption is already granted. Either way there's
+    // nothing left to review on this screen once it's satisfied, so callers should
+    // have this pop the screen off the back stack - otherwise swiping back reveals
+    // it, its skip check re-fires immediately, and it bounces straight forward again.
     onNavigate: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val alreadyExempted = remember { isIgnoringBatteryOptimizations(context) }

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/battery/BatteryOptimizationAndroid.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/battery/BatteryOptimizationAndroid.kt
@@ -5,7 +5,11 @@ import android.content.Context
 import android.content.Intent
 import android.os.PowerManager
 import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
@@ -19,17 +23,56 @@ fun BatteryOptimizationScreen(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
+    val alreadyExempted = remember { isIgnoringBatteryOptimizations(context) }
+
+    // Skip this screen entirely if the exemption is already granted (e.g. the
+    // user re-runs onboarding after already having granted it).
+    LaunchedEffect(Unit) {
+        if (alreadyExempted) {
+            onNavigate()
+        }
+    }
+
+    // Android doesn't report whether the user tapped Allow or Deny in the system
+    // dialog - either way there's nothing more to ask, so move straight on to the
+    // next screen once it returns, rather than showing a separate Continue button.
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult(),
+    ) {
+        onNavigate()
+    }
+
+    // Always render real content, even on the frame before the LaunchedEffect above
+    // navigates away - swiping back into this screen from Listening re-enters this
+    // composable, and if it rendered nothing while alreadyExempted, the predictive
+    // back animation showed a blank/grey frame instead of this screen's background.
     BatteryOptimization(
         onContinue = onNavigate,
         modifier = modifier,
-        onGrantPermission = { requestBatteryOptimizationExemption(context) },
+        onGrantPermission = if (alreadyExempted) {
+            null
+        } else {
+            { launcher.launch(batteryOptimizationExemptionIntent(context)) }
+        },
     )
 }
 
+private fun isIgnoringBatteryOptimizations(context: Context): Boolean {
+    val pm = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+    return pm.isIgnoringBatteryOptimizations(context.packageName)
+}
+
+// No FLAG_ACTIVITY_NEW_TASK here: this is launched via an ActivityResultLauncher,
+// and that flag prevents the result being delivered back to the launcher.
+@SuppressLint("BatteryLife")
+private fun batteryOptimizationExemptionIntent(context: Context) =
+    Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+        data = "package:${context.packageName}".toUri()
+    }
+
 @SuppressLint("BatteryLife")
 fun requestBatteryOptimizationExemption(context: Context) {
-    val pm = context.getSystemService(Context.POWER_SERVICE) as PowerManager
-    if (!pm.isIgnoringBatteryOptimizations(context.packageName)) {
+    if (!isIgnoringBatteryOptimizations(context)) {
         val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
             data = "package:${context.packageName}".toUri()
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/navigating/NavigatingScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/navigating/NavigatingScreen.kt
@@ -99,6 +99,11 @@ enum class Permission(
 
 @Composable
 fun NavigatingScreen(
+    // Called both when the user taps Continue and when the screen skips itself
+    // because every permission is already granted. Either way there's nothing left
+    // to review on this screen once it's satisfied, so callers should have this pop
+    // the screen off the back stack - otherwise swiping back re-reveals it, its skip
+    // check re-fires immediately, and it bounces straight forward again.
     onNavigate: () -> Unit,
     modifier: Modifier = Modifier,
     vm: NavigatingScreenViewModel = viewModel(),

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/navigating/NavigatingScreen.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/navigating/NavigatingScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -54,8 +55,10 @@ import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.scottishtecharmy.soundscape.components.OnboardButton
 import org.scottishtecharmy.soundscape.resources.Res
+import org.scottishtecharmy.soundscape.resources.first_launch_permissions_granted
 import org.scottishtecharmy.soundscape.resources.first_launch_permissions_location
 import org.scottishtecharmy.soundscape.resources.first_launch_permissions_message
+import org.scottishtecharmy.soundscape.resources.first_launch_permissions_not_granted
 import org.scottishtecharmy.soundscape.resources.first_launch_permissions_notification
 import org.scottishtecharmy.soundscape.resources.first_launch_permissions_record_audio
 import org.scottishtecharmy.soundscape.resources.first_launch_permissions_required
@@ -126,6 +129,14 @@ fun NavigatingScreen(
 
     LaunchedEffect(permissionsStatus) {
         vm.permissionsRequired(permissionsStatus)
+    }
+
+    // Skip this screen entirely if every required permission is already granted
+    // (e.g. the user re-runs onboarding after already having granted them).
+    LaunchedEffect(Unit) {
+        if (requiredPermissionsGranted(permissionsStatus)) {
+            onNavigate()
+        }
     }
 
     val onPermissionResult = remember(vm) {
@@ -286,7 +297,20 @@ fun PermissionRationale(
     Row(
         modifier = modifier
             .mediumPadding()
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .focusable()
+            .semantics(mergeDescendants = true) {}
+            .testTag(clickableTestTag)
+            .then(
+                // Once granted there's nothing left for a tap to do - permissions can't be
+                // withdrawn from here - so drop the click action rather than leaving a
+                // "double tap to activate" hint that does nothing.
+                if (granted) {
+                    Modifier
+                } else {
+                    Modifier.clickable { onClick() }
+                }
+            ),
     )
     {
         Icon(
@@ -296,14 +320,7 @@ fun PermissionRationale(
         )
         Spacer(modifier = Modifier.width(spacing.extraSmall))
         Column(
-            modifier = Modifier
-                .weight(1f)
-                .focusable()
-                .semantics(mergeDescendants = true) {}
-                .testTag(clickableTestTag)
-                .clickable {
-                    onClick()
-                }
+            modifier = Modifier.weight(1f)
         ) {
             Text(
                 text = stringResource(mainText),
@@ -314,20 +331,25 @@ fun PermissionRationale(
                 text = stringResource(subtitleText),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurface,
+                // The rationale text is only useful while the permission is still
+                // outstanding - once granted, TalkBack should just say "<name>,
+                // permission granted" rather than repeating the now-irrelevant
+                // rationale.
+                modifier = if (granted) Modifier.clearAndSetSemantics {} else Modifier,
             )
         }
         Spacer(modifier = Modifier.weight(0.05f))
         if (granted) {
             Icon(
                 Icons.Default.Check,
-                contentDescription = null,
+                contentDescription = stringResource(Res.string.first_launch_permissions_granted),
                 modifier = Modifier.align(Alignment.CenterVertically),
                 tint = MaterialTheme.colorScheme.onSurface
             )
         } else {
             Icon(
                 Icons.Default.Cancel,
-                contentDescription = null,
+                contentDescription = stringResource(Res.string.first_launch_permissions_not_granted),
                 modifier = Modifier.align(Alignment.CenterVertically),
                 tint = MaterialTheme.colorScheme.onSurface
             )

--- a/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/navigating/NavigatingScreenViewModel.kt
+++ b/app/src/main/java/org/scottishtecharmy/soundscape/screens/onboarding/navigating/NavigatingScreenViewModel.kt
@@ -5,17 +5,20 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
+fun requiredPermissionsGranted(permissionsStatus: Map<Permission, Boolean>): Boolean =
+    permissionsStatus.filterKeys {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            it == Permission.ACCESS_FINE_LOCATION || it == Permission.POST_NOTIFICATIONS
+        } else {
+            it == Permission.ACCESS_FINE_LOCATION
+        }
+    }.none { !it.value }
+
 data class NavigatingScreenState(
     val permissionsStatus: Map<Permission, Boolean>
 ) {
     val continueEnabled: Boolean
-        get() = permissionsStatus.filterKeys {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                it == Permission.ACCESS_FINE_LOCATION || it == Permission.POST_NOTIFICATIONS
-            } else {
-                it == Permission.ACCESS_FINE_LOCATION
-            }
-        }.none { !it.value }
+        get() = requiredPermissionsGranted(permissionsStatus)
 }
 
 class NavigatingScreenViewModel : ViewModel() {

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -918,7 +918,7 @@
     <string name="first_launch_permissions_required_for_voice_control">This permission is optional, but is required if you want to use voice commands to control the app</string>
     <!-- Battery optimization - needed so that Android doesn't stop the app working in the background -->
     <string name="battery_optimization_title">Background Battery Usage</string>
-    <string name="battery_optimization_message">Soundscape requires unrestricted battery usage to keep providing audio navigation when your phone is locked. Please allow this in the next dialog. If you close Soundscape, all services will stop and it will no longer use battery.</string>
+    <string name="battery_optimization_message">Soundscape requires unrestricted battery usage to keep providing audio navigation when your phone is locked. Please allow this in the next dialog. If you close Soundscape, all services will stop and it will no longer use battery</string>
     <!-- Message appears as notification when app is running -->
     <string name="notification_text">The Soundscape location service runs even when the phone is locked.</string>
     <!-- Option to cancel searching for a location -->

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -675,6 +675,10 @@
     <string name="first_launch_permissions_motion">Motion and Fitness</string>
     <!-- Text to indicate that a permission is required -->
     <string name="first_launch_permissions_required">This permission is required</string>
+    <!-- Accessibility description read by screen readers for the status icon next to a permission row that has already been granted -->
+    <string name="first_launch_permissions_granted">Permission granted</string>
+    <!-- Accessibility description read by screen readers for the status icon next to a permission row that has not been granted yet -->
+    <string name="first_launch_permissions_not_granted">Not yet granted</string>
     <!-- Text to indicate that a permission is required -->
     <string name="permissions_required">The app requires location permissions to be able to run.</string>
     <string name="permissions_button">Change the permissions in app settings</string>
@@ -911,7 +915,7 @@
     <!-- For voice commands to work we need permission to access the microphone and record audio -->
     <string name="first_launch_permissions_record_audio">Record audio</string>
     <!-- The app will run without record audio permissions, but voice control won't be available -->
-    <string name="first_launch_permissions_required_for_voice_control">This permission is optional, but is required if you want to use voice commands to control the app.</string>
+    <string name="first_launch_permissions_required_for_voice_control">This permission is optional, but is required if you want to use voice commands to control the app</string>
     <!-- Battery optimization - needed so that Android doesn't stop the app working in the background -->
     <string name="battery_optimization_title">Background Battery Usage</string>
     <string name="battery_optimization_message">Soundscape requires unrestricted battery usage to keep providing audio navigation when your phone is locked. Please allow this in the next dialog. If you close Soundscape, all services will stop and it will no longer use battery.</string>

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/onboarding/battery/BatteryOptimizationScreen.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/onboarding/battery/BatteryOptimizationScreen.kt
@@ -14,10 +14,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -44,7 +41,6 @@ fun BatteryOptimization(
     onGrantPermission: (() -> Unit)? = null,
 ) {
     val focusRequester = remember { FocusRequester() }
-    var canContinue by remember { mutableStateOf(onGrantPermission == null) }
 
     BoxWithGradientBackground(
         modifier = modifier,
@@ -81,27 +77,28 @@ fun BatteryOptimization(
 
             Column(modifier = Modifier.padding(horizontal = spacing.medium)) {
                 if (onGrantPermission != null) {
+                    // Moving on to the next screen once the system permission dialog
+                    // returns is the caller's responsibility (Android doesn't report
+                    // whether the user tapped Allow or Deny), so there's no separate
+                    // Continue button - this is the only control on screen.
                     OnboardButton(
                         text = stringResource(Res.string.ui_grant_permission),
-                        onClick = {
-                            onGrantPermission()
-                            canContinue = true
-                        },
+                        onClick = onGrantPermission,
                         modifier = Modifier
                             .fillMaxWidth()
                             .focusable()
                             .testTag("batteryOptimizationGrantPermissionButton"),
                     )
+                } else {
+                    OnboardButton(
+                        text = stringResource(Res.string.ui_continue),
+                        onClick = onContinue,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .focusable()
+                            .testTag("batteryOptimizationContinueButton"),
+                    )
                 }
-                OnboardButton(
-                    text = stringResource(Res.string.ui_continue),
-                    onClick = { onContinue() },
-                    enabled = canContinue,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .focusable()
-                        .testTag("batteryOptimizationContinueButton"),
-                )
             }
         }
     }


### PR DESCRIPTION
This started off as just fixing the running of the onboarding activity when settings were reset to the default. However, because permissions were already granted I then noticed some other issues, particularly with Talkback feedback on permissions. As a result a lot of the changes are to try and make the permissions and battery saver screen work better with Talkback and to be skipped if permissions have already been granted.