### PR TITLE
Move MIX_AUDIO setting out of shared settings screen, into iOS only

### DIFF
--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/home/settings/SharedSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/home/settings/SharedSettingsScreen.kt
@@ -64,8 +64,6 @@ import org.scottishtecharmy.soundscape.resources.settings_head_tracking
 import org.scottishtecharmy.soundscape.resources.settings_head_tracking_description
 import org.scottishtecharmy.soundscape.resources.settings_media_controls_audio_menu
 import org.scottishtecharmy.soundscape.resources.settings_media_controls_original
-import org.scottishtecharmy.soundscape.resources.settings_mix_audio
-import org.scottishtecharmy.soundscape.resources.settings_mix_audio_description
 import org.scottishtecharmy.soundscape.resources.settings_relative_directions_clockface
 import org.scottishtecharmy.soundscape.resources.settings_relative_directions_degrees
 import org.scottishtecharmy.soundscape.resources.settings_relative_directions_description
@@ -541,19 +539,6 @@ fun SharedSettingsScreen(
                         Text(
                             text = "${((it * 10).toInt() / 10.0)}x",
                             color = textColor
-                        )
-                    },
-                )
-
-                switchPreference(
-                    key = PreferenceKeys.MIX_AUDIO,
-                    defaultValue = PreferenceDefaults.MIX_AUDIO,
-                    modifier = expandedSectionModifier,
-                    title = {
-                        SettingDetails(
-                            Res.string.settings_mix_audio,
-                            Res.string.settings_mix_audio_description,
-                            textColor
                         )
                     },
                 )

--- a/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/MainViewController.kt
+++ b/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/MainViewController.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import me.zhanghai.compose.preference.listPreference
+import me.zhanghai.compose.preference.switchPreference
 import org.jetbrains.compose.resources.stringResource
 import org.scottishtecharmy.soundscape.audio.TourButton
 import org.scottishtecharmy.soundscape.audio.availableTtsVoicesForCurrentLanguage
@@ -23,6 +24,8 @@ import org.scottishtecharmy.soundscape.preferences.PreferenceDefaults
 import org.scottishtecharmy.soundscape.preferences.PreferenceKeys
 import org.scottishtecharmy.soundscape.preferences.PreferencesListener
 import org.scottishtecharmy.soundscape.resources.Res
+import org.scottishtecharmy.soundscape.resources.settings_mix_audio
+import org.scottishtecharmy.soundscape.resources.settings_mix_audio_description
 import org.scottishtecharmy.soundscape.resources.settings_theme_auto
 import org.scottishtecharmy.soundscape.resources.voice_voices
 import org.scottishtecharmy.soundscape.screens.home.data.LocationDescription
@@ -30,6 +33,7 @@ import org.scottishtecharmy.soundscape.screens.home.home.AdvancedMarkersAndRoute
 import org.scottishtecharmy.soundscape.screens.home.placesnearby.PlacesNearbyViewModel
 import org.scottishtecharmy.soundscape.screens.home.settings.ClickableOption
 import org.scottishtecharmy.soundscape.screens.home.settings.ListPreferenceItem
+import org.scottishtecharmy.soundscape.screens.home.settings.SettingDetails
 import org.scottishtecharmy.soundscape.screens.markers_routes.screens.addandeditroutescreen.AddAndEditRouteViewModel
 import org.scottishtecharmy.soundscape.screens.markers_routes.screens.markersscreen.MarkersViewModel
 import org.scottishtecharmy.soundscape.screens.markers_routes.screens.routesscreen.RoutesViewModel
@@ -129,6 +133,18 @@ fun MainViewController() = ComposeUIViewController {
                 ClickableOption(
                     text = ttsVoiceDescriptions[idx],
                     textColor = textColor,
+                )
+            },
+        )
+        switchPreference(
+            key = PreferenceKeys.MIX_AUDIO,
+            defaultValue = PreferenceDefaults.MIX_AUDIO,
+            modifier = expandedSectionModifier,
+            title = {
+                SettingDetails(
+                    Res.string.settings_mix_audio,
+                    Res.string.settings_mix_audio_description,
+                    textColor,
                 )
             },
         )


### PR DESCRIPTION
The setting is only read by IosSoundscapeService, so it doesn't belong in the cross-platform SharedSettingsScreen. It now lives in iOS's settingsPlatformAudioContent alongside the other iOS-only audio prefs.