### PR TITLE
Overwrite Gradle cache on self-hosted iOS runners

### DIFF
--- a/.github/actions/setup-jdk-gradle/action.yml
+++ b/.github/actions/setup-jdk-gradle/action.yml
@@ -14,3 +14,7 @@ runs:
       uses: gradle/actions/setup-gradle@v6
       with:
         gradle-version: current
+        # Self-hosted runners are long-lived, so a cache left by a previous
+        # job would otherwise carry over into this build; hosted runners are
+        # ephemeral and always start with no cache anyway.
+        cache-overwrite-existing: ${{ runner.environment == 'self-hosted' }}


### PR DESCRIPTION
Self-hosted macOS runners are long-lived, so a cache left by a previous job could otherwise leak into the next build.