### PR TITLE
Remove unused osm_highway_named/refed and osm_atm_named/refed strings

### DIFF
--- a/shared/src/commonMain/composeResources/values-arz/strings.xml
+++ b/shared/src/commonMain/composeResources/values-arz/strings.xml
@@ -315,8 +315,6 @@
     <string name="osm_service_road">طريق الخدمة</string>
     <string name="osm_road">طريق</string>
     <string name="osm_highway">الطريق السريع</string>
-    <string name="osm_highway_named">%1$s الطريق السريع</string>
-    <string name="osm_highway_refed">الطريق السريع %1$s</string>
     <string name="osm_intersection">التقاطع</string>
     <string name="osm_roundabout">دوار</string>
     <string name="osm_highway_ramp">منحدر الطريق السريع</string>
@@ -347,8 +345,6 @@
     <string name="osm_gas_station">محطة بنزين</string>
     <string name="osm_bank">بنك</string>
     <string name="osm_atm">جهاز الصراف الآلي</string>
-    <string name="osm_atm_named">%1$s أجهزة الصراف الآلي</string>
-    <string name="osm_atm_refed">أجهزة الصراف الآلي\n\n%1$s</string>
     <string name="osm_bus_stop_named">محطة حافلات %1$s</string>
     <string name="osm_recycling_bin">سلة المهملات</string>
     <string name="osm_fountain">نافورة</string>

--- a/shared/src/commonMain/composeResources/values-da/strings.xml
+++ b/shared/src/commonMain/composeResources/values-da/strings.xml
@@ -288,8 +288,6 @@
     <string name="osm_service_road">Stikvej</string>
     <string name="osm_road">Vej</string>
     <string name="osm_highway">Motorvej</string>
-    <string name="osm_highway_named">%1$s motorvej</string>
-    <string name="osm_highway_refed">Motorvej %1$s</string>
     <string name="osm_intersection">Kryds</string>
     <string name="osm_roundabout">Rundkørsel</string>
     <string name="osm_highway_ramp">Motorvejsrampe</string>
@@ -320,8 +318,6 @@
     <string name="osm_gas_station">Tankstation</string>
     <string name="osm_bank">Bank</string>
     <string name="osm_atm">Hæveautomat</string>
-    <string name="osm_atm_named">%1$s-hæveautomat</string>
-    <string name="osm_atm_refed">Hæveautomat %1$s</string>
     <string name="osm_bus_stop">Busstoppested</string>
     <string name="osm_bus_stop_named">%1$s busstoppested</string>
     <string name="osm_recycling_bin">Skraldespand</string>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -288,8 +288,6 @@
     <string name="osm_service_road">Zufahrtsstraße</string>
     <string name="osm_road">Straße</string>
     <string name="osm_highway">Autobahn</string>
-    <string name="osm_highway_named">%1$s Autobahn</string>
-    <string name="osm_highway_refed">Autobahn %1$s</string>
     <string name="osm_intersection">Kreuzung</string>
     <string name="osm_roundabout">Kreisverkehr</string>
     <string name="osm_highway_ramp">Autobahnauffahrt</string>
@@ -320,8 +318,6 @@
     <string name="osm_gas_station">Tankstelle</string>
     <string name="osm_bank">Bank</string>
     <string name="osm_atm">Geldautomat</string>
-    <string name="osm_atm_named">%1$s Geldautomat</string>
-    <string name="osm_atm_refed">Geldautomat %1$s</string>
     <string name="osm_bus_stop">Bushaltestelle</string>
     <string name="osm_bus_stop_named">%1$s Bushaltestelle</string>
     <string name="osm_recycling_bin">Mülltonne</string>

--- a/shared/src/commonMain/composeResources/values-el/strings.xml
+++ b/shared/src/commonMain/composeResources/values-el/strings.xml
@@ -288,8 +288,6 @@
     <string name="osm_service_road">Βοηθητική οδός</string>
     <string name="osm_road">Δρόμος</string>
     <string name="osm_highway">Αυτοκινητόδρομος</string>
-    <string name="osm_highway_named">Αυτοκινητόδρομος %1$s</string>
-    <string name="osm_highway_refed">Αυτοκινητόδρομος %1$s</string>
     <string name="osm_intersection">Διασταύρωση</string>
     <string name="osm_roundabout">Κυκλικός κόμβος</string>
     <string name="osm_highway_ramp">Έξοδος αυτοκινητόδρομου</string>
@@ -320,8 +318,6 @@
     <string name="osm_gas_station">Πρατήριο καυσίμων</string>
     <string name="osm_bank">Τράπεζα</string>
     <string name="osm_atm">ATM</string>
-    <string name="osm_atm_named">%1$s ATM</string>
-    <string name="osm_atm_refed">ATM %1$s</string>
     <string name="osm_bus_stop">Στάση</string>
     <string name="osm_bus_stop_named">%1$s Στάση</string>
     <string name="osm_recycling_bin">Κάδος ανακύκλωσης</string>

--- a/shared/src/commonMain/composeResources/values-en-rGB/strings.xml
+++ b/shared/src/commonMain/composeResources/values-en-rGB/strings.xml
@@ -287,8 +287,6 @@
     <string name="osm_service_road">Service Road</string>
     <string name="osm_road">Road</string>
     <string name="osm_highway">Highway</string>
-    <string name="osm_highway_named">%1$s Highway</string>
-    <string name="osm_highway_refed">Highway %1$s</string>
     <string name="osm_intersection">Intersection</string>
     <string name="osm_roundabout">Roundabout</string>
     <string name="osm_highway_ramp">Highway Ramp</string>
@@ -319,8 +317,6 @@
     <string name="osm_gas_station">Petrol Station</string>
     <string name="osm_bank">Bank</string>
     <string name="osm_atm">ATM</string>
-    <string name="osm_atm_named">%1$s ATM</string>
-    <string name="osm_atm_refed">ATM %1$s</string>
     <string name="osm_bus_stop">Bus Stop</string>
     <string name="osm_bus_stop_named">%1$s Bus Stop</string>
     <string name="osm_recycling_bin">Recycling Bin</string>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -288,8 +288,6 @@
     <string name="osm_service_road">Vía de servicio</string>
     <string name="osm_road">Carretera</string>
     <string name="osm_highway">Autopista</string>
-    <string name="osm_highway_named">Autopista %1$s</string>
-    <string name="osm_highway_refed">Autopista %1$s</string>
     <string name="osm_intersection">Cruce</string>
     <string name="osm_roundabout">Rotonda</string>
     <string name="osm_highway_ramp">Rampa de autopista</string>
@@ -320,8 +318,6 @@
     <string name="osm_gas_station">Gasolinera</string>
     <string name="osm_bank">Banco</string>
     <string name="osm_atm">Cajero automático</string>
-    <string name="osm_atm_named">Cajero automático de %1$s</string>
-    <string name="osm_atm_refed">Cajero automático %1$s</string>
     <string name="osm_bus_stop">Parada de autobús</string>
     <string name="osm_bus_stop_named">Parada de autobús %1$s</string>
     <string name="osm_recycling_bin">Contenedor de reciclaje</string>

--- a/shared/src/commonMain/composeResources/values-fa/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fa/strings.xml
@@ -316,8 +316,6 @@
     <string name="osm_service_road">کنار‌گذر</string>
     <string name="osm_road">جاده</string>
     <string name="osm_highway">بزرگراه</string>
-    <string name="osm_highway_named">بزرگراه %1$s</string>
-    <string name="osm_highway_refed">بزرگراه %1$s</string>
     <string name="osm_intersection">تقاطع</string>
     <string name="osm_roundabout">فلکه</string>
     <string name="osm_highway_ramp">رمپ بزرگراه</string>
@@ -348,8 +346,6 @@
     <string name="osm_gas_station">پمپ بنزین</string>
     <string name="osm_bank">بانک</string>
     <string name="osm_atm">دستگاه خودپرداز</string>
-    <string name="osm_atm_named">خودپرداز %1$s</string>
-    <string name="osm_atm_refed">خودپرداز %1$s</string>
     <string name="osm_bus_stop">ایستگاه اتوبوس</string>
     <string name="osm_bus_stop_named">ایستگاه اتوبوس %1$s</string>
     <string name="osm_recycling_bin">سطل بازیافت</string>

--- a/shared/src/commonMain/composeResources/values-fi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fi/strings.xml
@@ -288,8 +288,6 @@
     <string name="osm_service_road">Huoltotie</string>
     <string name="osm_road">Tie</string>
     <string name="osm_highway">Maantie</string>
-    <string name="osm_highway_named">%1$s maantie</string>
-    <string name="osm_highway_refed">Maantie %1$s</string>
     <string name="osm_intersection">Risteys</string>
     <string name="osm_roundabout">Liikenneympyrä</string>
     <string name="osm_highway_ramp">Maantien liittymä</string>
@@ -320,8 +318,6 @@
     <string name="osm_gas_station">Huoltoasema</string>
     <string name="osm_bank">Pankki</string>
     <string name="osm_atm">Pankkiautomaatti</string>
-    <string name="osm_atm_named">%1$s Pankkiautomaatti</string>
-    <string name="osm_atm_refed">Pankkiautomaatti %1$s</string>
     <string name="osm_bus_stop">Linja-autopysäkki</string>
     <string name="osm_bus_stop_named">%1$s Linja-autopysäkki</string>
     <string name="osm_recycling_bin">Kierrätysastia</string>

--- a/shared/src/commonMain/composeResources/values-fr-rCA/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr-rCA/strings.xml
@@ -288,8 +288,6 @@
     <string name="osm_service_road">Ruelle</string>
     <string name="osm_road">Route</string>
     <string name="osm_highway">Autoroute</string>
-    <string name="osm_highway_named">Autoroute de %1$s</string>
-    <string name="osm_highway_refed">Autoroute %1$s</string>
     <string name="osm_intersection">Intersection</string>
     <string name="osm_roundabout">Carrefour giratoire</string>
     <string name="osm_highway_ramp">Bretelle d’autoroute</string>
@@ -320,8 +318,6 @@
     <string name="osm_gas_station">Station-service</string>
     <string name="osm_bank">Banque</string>
     <string name="osm_atm">Guichet automatique bancaire</string>
-    <string name="osm_atm_named">Guichet automatique bancaire %1$s</string>
-    <string name="osm_atm_refed">Guichet automatique bancaire %1$s</string>
     <string name="osm_bus_stop">Arrêt de bus</string>
     <string name="osm_bus_stop_named">Arrêt de bus %1$s</string>
     <string name="osm_recycling_bin">Poubelle de recyclage</string>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -288,8 +288,6 @@
     <string name="osm_service_road">Voie de service</string>
     <string name="osm_road">Route</string>
     <string name="osm_highway">Autoroute</string>
-    <string name="osm_highway_named">Autoroute de %1$s</string>
-    <string name="osm_highway_refed">Autoroute %1$s</string>
     <string name="osm_intersection">Intersection</string>
     <string name="osm_roundabout">Rond-point</string>
     <string name="osm_highway_ramp">Bretelle d’autoroute</string>
@@ -320,8 +318,6 @@
     <string name="osm_gas_station">Station-service</string>
     <string name="osm_bank">Banque</string>
     <string name="osm_atm">Distributeur de billets</string>
-    <string name="osm_atm_named">Distributeur de billets %1$s</string>
-    <string name="osm_atm_refed">Distributeur de billets %1$s</string>
     <string name="osm_bus_stop">Arrêt de bus</string>
     <string name="osm_bus_stop_named">Arrêt de bus %1$s</string>
     <string name="osm_recycling_bin">Poubelle de recyclage</string>

--- a/shared/src/commonMain/composeResources/values-hi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hi/strings.xml
@@ -532,8 +532,6 @@
     <string name="osm_service_road">सर्विस रोड</string>
     <string name="osm_road">सड़क</string>
     <string name="osm_highway">राजमार्ग</string>
-    <string name="osm_highway_named">राजमार्ग का नाम</string>
-    <string name="osm_highway_refed">राजमार्ग संदर्भ</string>
     <string name="osm_intersection">चौराहा</string>
     <string name="osm_roundabout">गोल चक्कर</string>
     <string name="osm_highway_ramp">राजमार्ग रैंप</string>
@@ -565,8 +563,6 @@
     <string name="osm_fuel">ईंधन स्टेशन</string>
     <string name="osm_bank">बैंक</string>
     <string name="osm_atm">ATM</string>
-    <string name="osm_atm_named">नामित ATM</string>
-    <string name="osm_atm_refed">ATM संदर्भ</string>
     <string name="osm_bus_stop">बस स्टॉप</string>
     <string name="osm_recycling">रीसाइक्लिंग</string>
     <string name="osm_fountain">फव्वारा</string>

--- a/shared/src/commonMain/composeResources/values-is/strings.xml
+++ b/shared/src/commonMain/composeResources/values-is/strings.xml
@@ -286,8 +286,6 @@
     <string name="osm_service_road">ómerkt gata</string>
     <string name="osm_road">vegur</string>
     <string name="osm_highway">hraðbraut</string>
-    <string name="osm_highway_named">%1$s hraðgata</string>
-    <string name="osm_highway_refed">hraðgata %1$s</string>
     <string name="osm_intersection">gatnamot</string>
     <string name="osm_roundabout">hringtorg</string>
     <string name="osm_highway_ramp">aðrein-frárein</string>
@@ -318,8 +316,6 @@
     <string name="osm_gas_station">bensínstöð</string>
     <string name="osm_bank">banki</string>
     <string name="osm_atm">hraðbanki</string>
-    <string name="osm_atm_named">%1$s hraðbnki</string>
-    <string name="osm_atm_refed">hraðbanki %1$s</string>
     <string name="osm_bus_stop">stoppistöð</string>
     <string name="osm_bus_stop_named">%1$s stoppistöð</string>
     <string name="osm_recycling_bin">endurvinnslutunna</string>

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -288,8 +288,6 @@
     <string name="osm_service_road">Strada d’accesso</string>
     <string name="osm_road">Strada</string>
     <string name="osm_highway">Autostrada</string>
-    <string name="osm_highway_named">Autostrada %1$s</string>
-    <string name="osm_highway_refed">Autostrada %1$s</string>
     <string name="osm_intersection">Incrocio</string>
     <string name="osm_roundabout">Rotonda</string>
     <string name="osm_highway_ramp">Svincolo dell'autostrada</string>
@@ -320,8 +318,6 @@
     <string name="osm_gas_station">Stazione di servizio</string>
     <string name="osm_bank">Banca</string>
     <string name="osm_atm">Sportello bancomat</string>
-    <string name="osm_atm_named">Sportello bancomat %1$s</string>
-    <string name="osm_atm_refed">Sportello bancomat %1$s</string>
     <string name="osm_bus_stop">Fermata dell'autobus</string>
     <string name="osm_bus_stop_named">Fermata dell'autobus %1$s</string>
     <string name="osm_recycling_bin">Contenitore per la raccolta differenziata</string>

--- a/shared/src/commonMain/composeResources/values-ja/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ja/strings.xml
@@ -288,8 +288,6 @@
     <string name="osm_service_road">連絡道路</string>
     <string name="osm_road">道路</string>
     <string name="osm_highway">車道</string>
-    <string name="osm_highway_named">%1$s 車道</string>
-    <string name="osm_highway_refed">車道 %1$s</string>
     <string name="osm_intersection">交差点</string>
     <string name="osm_roundabout">環状交差点</string>
     <string name="osm_highway_ramp">接続道路</string>
@@ -320,8 +318,6 @@
     <string name="osm_gas_station">ガソリン スタンド</string>
     <string name="osm_bank">銀行</string>
     <string name="osm_atm">ATM</string>
-    <string name="osm_atm_named">%1$s ATM</string>
-    <string name="osm_atm_refed">ATM %1$s</string>
     <string name="osm_bus_stop">バス停</string>
     <string name="osm_bus_stop_named">%1$s バス停</string>
     <string name="osm_recycling_bin">リサイクル用ごみ箱</string>

--- a/shared/src/commonMain/composeResources/values-nb/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nb/strings.xml
@@ -288,8 +288,6 @@
     <string name="osm_service_road">Stikkvei</string>
     <string name="osm_road">Vei</string>
     <string name="osm_highway">Motorvei</string>
-    <string name="osm_highway_named">%1$s-motorvei</string>
-    <string name="osm_highway_refed">Motorvei %1$s</string>
     <string name="osm_intersection">Veikryss</string>
     <string name="osm_roundabout">Rundkjøring</string>
     <string name="osm_highway_ramp">Motorveirampe</string>
@@ -320,8 +318,6 @@
     <string name="osm_gas_station">Bensinstasjon</string>
     <string name="osm_bank">Bank</string>
     <string name="osm_atm">Minibank</string>
-    <string name="osm_atm_named">%1$s-minibank</string>
-    <string name="osm_atm_refed">Minibank %1$s</string>
     <string name="osm_bus_stop">Busstopp</string>
     <string name="osm_bus_stop_named">%1$s-busstopp</string>
     <string name="osm_recycling_bin">Søppelkasse</string>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -288,8 +288,6 @@
     <string name="osm_service_road">Vluchtstrook</string>
     <string name="osm_road">Weg</string>
     <string name="osm_highway">Snelweg</string>
-    <string name="osm_highway_named">Snelweg van %1$s</string>
-    <string name="osm_highway_refed">Snelweg %1$s</string>
     <string name="osm_intersection">Kruispunt</string>
     <string name="osm_roundabout">Rotonde</string>
     <string name="osm_highway_ramp">Oprit naar snelweg</string>
@@ -320,8 +318,6 @@
     <string name="osm_gas_station">Benzinepomp</string>
     <string name="osm_bank">Bank</string>
     <string name="osm_atm">Geldautomaat</string>
-    <string name="osm_atm_named">Geldautomaat van %1$s</string>
-    <string name="osm_atm_refed">Geldautomaat %1$s</string>
     <string name="osm_bus_stop">Bushalte</string>
     <string name="osm_bus_stop_named">Bushalte van %1$s</string>
     <string name="osm_recycling_bin">Vuilnisbak</string>

--- a/shared/src/commonMain/composeResources/values-pl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pl/strings.xml
@@ -318,8 +318,6 @@
     <string name="osm_service_road">Droga serwisowa</string>
     <string name="osm_road">Droga</string>
     <string name="osm_highway">Droga</string>
-    <string name="osm_highway_named">%1$s — droga</string>
-    <string name="osm_highway_refed">Droga %1$s</string>
     <string name="osm_intersection">Skrzyżowanie</string>
     <string name="osm_roundabout">Rondo</string>
     <string name="osm_highway_ramp">Zjazd z drogi</string>
@@ -350,8 +348,6 @@
     <string name="osm_gas_station">Stacja paliw</string>
     <string name="osm_bank">Bank</string>
     <string name="osm_atm">ATM</string>
-    <string name="osm_atm_named">%1$s ATM</string>
-    <string name="osm_atm_refed">ATM %1$s</string>
     <string name="osm_bus_stop">Przystanek autobusowy</string>
     <string name="osm_bus_stop_named">Przystanek autobusowy – %1$s</string>
     <string name="osm_recycling_bin">Kosz na recykling</string>

--- a/shared/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -288,8 +288,6 @@
     <string name="osm_service_road">Via Lateral</string>
     <string name="osm_road">Rua</string>
     <string name="osm_highway">Rodovia</string>
-    <string name="osm_highway_named">Rodovia %1$s</string>
-    <string name="osm_highway_refed">Rodovia %1$s</string>
     <string name="osm_intersection">Cruzamento</string>
     <string name="osm_roundabout">Rotatória</string>
     <string name="osm_highway_ramp">Acesso a Rodovia</string>
@@ -320,8 +318,6 @@
     <string name="osm_gas_station">Posto de Gasolina</string>
     <string name="osm_bank">Agência bancária</string>
     <string name="osm_atm">Caixa Eletrônico</string>
-    <string name="osm_atm_named">Caixa Eletrônico - %1$s</string>
-    <string name="osm_atm_refed">Caixa Eletrônico - %1$s</string>
     <string name="osm_bus_stop">Ponto de Ônibus</string>
     <string name="osm_bus_stop_named">%1$s Ponto de Ônibus</string>
     <string name="osm_recycling_bin">Lixeira</string>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -288,8 +288,6 @@
     <string name="osm_service_road">Estrada de Serviço</string>
     <string name="osm_road">Estrada</string>
     <string name="osm_highway">Autoestrada</string>
-    <string name="osm_highway_named">Autoestrada de %1$s</string>
-    <string name="osm_highway_refed">Autoestrada %1$s</string>
     <string name="osm_intersection">Cruzamento</string>
     <string name="osm_roundabout">Rotunda</string>
     <string name="osm_highway_ramp">Acesso a Autoestrada</string>
@@ -320,8 +318,6 @@
     <string name="osm_gas_station">Posto de Combustível</string>
     <string name="osm_bank">Agência bancária</string>
     <string name="osm_atm">Caixa Multibanco</string>
-    <string name="osm_atm_named">Caixa Multibanco %1$s</string>
-    <string name="osm_atm_refed">Caixa Multibanco %1$s</string>
     <string name="osm_bus_stop">Paragem de Autocarro</string>
     <string name="osm_bus_stop_named">Paragem de Autocarro de %1$s</string>
     <string name="osm_recycling_bin">Contentor de Reciclagem</string>

--- a/shared/src/commonMain/composeResources/values-ro/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ro/strings.xml
@@ -532,8 +532,6 @@
     <string name="osm_service_road">Drum de serviciu</string>
     <string name="osm_road">Drum</string>
     <string name="osm_highway">Autostradă</string>
-    <string name="osm_highway_named">Nume autostradă</string>
-    <string name="osm_highway_refed">Referință autostradă</string>
     <string name="osm_intersection">Intersecție</string>
     <string name="osm_roundabout">Sens giratoriu</string>
     <string name="osm_highway_ramp">Rampă de autostradă</string>
@@ -565,8 +563,6 @@
     <string name="osm_fuel">Stație de combustibil</string>
     <string name="osm_bank">Bancă</string>
     <string name="osm_atm">Bancomat</string>
-    <string name="osm_atm_named">Bancomat cu denumire</string>
-    <string name="osm_atm_refed">Referință bancomat</string>
     <string name="osm_bus_stop">Stație de autobuz</string>
     <string name="osm_recycling">Reciclare</string>
     <string name="osm_fountain">Fântână</string>

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -249,8 +249,6 @@
     <string name="osm_service_road">Подъездная дорога</string>
     <string name="osm_road">Дорога</string>
     <string name="osm_highway">Шоссе</string>
-    <string name="osm_highway_named">Шоссе %1$s</string>
-    <string name="osm_highway_refed">Шоссе %1$s</string>
     <string name="osm_intersection">Перекрёсток</string>
     <string name="osm_roundabout">Круглое движение</string>
     <string name="osm_highway_ramp">Съезд с шоссе</string>
@@ -278,8 +276,6 @@
     <string name="osm_restaurant">Ресторан</string>
     <string name="osm_telephone">Телефон</string>
     <string name="osm_gas_station">Заправка</string>
-    <string name="osm_atm_named">Банкомат %1$s</string>
-    <string name="osm_atm_refed">Банкомат %1$s</string>
     <string name="osm_bus_stop">Автобусная остановка</string>
     <string name="osm_bus_stop_named">Автобусная остановка %1$s</string>
     <string name="osm_recycling_bin">Контейнер для сбора мусора</string>

--- a/shared/src/commonMain/composeResources/values-sv/strings.xml
+++ b/shared/src/commonMain/composeResources/values-sv/strings.xml
@@ -288,8 +288,6 @@
     <string name="osm_service_road">Serviceväg</string>
     <string name="osm_road">Väg</string>
     <string name="osm_highway">Motorväg</string>
-    <string name="osm_highway_named">Motorvägen %1$s</string>
-    <string name="osm_highway_refed">Motorväg %1$s</string>
     <string name="osm_intersection">Vägkorsning</string>
     <string name="osm_roundabout">Rondell</string>
     <string name="osm_highway_ramp">Motorvägsramp</string>
@@ -320,8 +318,6 @@
     <string name="osm_gas_station">Bensinstation</string>
     <string name="osm_bank">Bank</string>
     <string name="osm_atm">Bankomat</string>
-    <string name="osm_atm_named">Bankomat vid %1$s</string>
-    <string name="osm_atm_refed">Bankomat %1$s</string>
     <string name="osm_bus_stop">Busshållplats</string>
     <string name="osm_bus_stop_named">Busshållplatsen %1$s</string>
     <string name="osm_recycling_bin">Återvinningskärl</string>

--- a/shared/src/commonMain/composeResources/values-tr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tr/strings.xml
@@ -546,8 +546,6 @@
     <string name="osm_service_road">Servis Yolu</string>
     <string name="osm_road">Yol</string>
     <string name="osm_highway">Otoyol</string>
-    <string name="osm_highway_named">Otoyol Adı</string>
-    <string name="osm_highway_refed">Otoyol Referans Kodu</string>
     <string name="osm_intersection">Kavşak</string>
     <string name="osm_roundabout">Döner Kavşak</string>
     <string name="osm_highway_ramp">Otoyol Bağlantı Yolu</string>
@@ -579,8 +577,6 @@
     <string name="osm_fuel">Akaryakıt İstasyonu</string>
     <string name="osm_bank">Banka</string>
     <string name="osm_atm">ATM</string>
-    <string name="osm_atm_named">İsimli ATM</string>
-    <string name="osm_atm_refed">ATM Referansı</string>
     <string name="osm_bus_stop">Otobüs Durağı</string>
     <string name="osm_recycling">Geri Dönüşüm</string>
     <string name="osm_fountain">Çeşme</string>

--- a/shared/src/commonMain/composeResources/values-uk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uk/strings.xml
@@ -312,8 +312,6 @@
     <string name="osm_service_road">Під'їзна дорога</string>
     <string name="osm_road">Дорога</string>
     <string name="osm_highway">Шосе</string>
-    <string name="osm_highway_named">%1$s шосе</string>
-    <string name="osm_highway_refed">Шосе %1$s</string>
     <string name="osm_intersection">Перехрестя</string>
     <string name="osm_roundabout">Круговий рух</string>
     <string name="osm_highway_ramp">З’їзд із шосе</string>
@@ -344,8 +342,6 @@
     <string name="osm_gas_station">Автозаправна станція</string>
     <string name="osm_bank">Банк</string>
     <string name="osm_atm">Банкомат</string>
-    <string name="osm_atm_named">%1$s Банкомат</string>
-    <string name="osm_atm_refed">Банкомат %1$s</string>
     <string name="osm_bus_stop">Автобусна зупинка</string>
     <string name="osm_bus_stop_named">%1$s Автобусна зупинка</string>
     <string name="osm_recycling_bin">Кошик для вторсировини</string>

--- a/shared/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -1079,8 +1079,6 @@
     <string name="osm_service_road">辅路</string>
     <string name="osm_road">道路</string>
     <string name="osm_highway">公路</string>
-    <string name="osm_highway_named">公路名称</string>
-    <string name="osm_highway_refed">公路编号</string>
     <string name="osm_intersection">交叉路口</string>
     <string name="osm_roundabout">环形交叉路口</string>
     <string name="osm_highway_ramp">公路匝道</string>
@@ -1112,8 +1110,6 @@
     <string name="osm_fuel">加油站</string>
     <string name="osm_bank">银行</string>
     <string name="osm_atm">自动取款机</string>
-    <string name="osm_atm_named">指定自动取款机</string>
-    <string name="osm_atm_refed">自动取款机编号</string>
     <string name="osm_bus_stop">公交站</string>
     <string name="osm_recycling">回收站</string>
     <string name="osm_fountain">喷泉</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -1301,10 +1301,6 @@ We're still working hard on improving the app, so please report any problems tha
     <string name="osm_transit">Transit Route</string>
     <!-- Open Street Map term highway. A major public road or motorway.-->
     <string name="osm_highway">Highway</string>
-    <!-- Open Street Map term highway_named. The name label for a highway.-->
-    <string name="osm_highway_named">Highway Name</string>
-    <!-- Open Street Map term highway_refed. The reference code or number for a highway.-->
-    <string name="osm_highway_refed">Highway Reference</string>
     <!-- Open Street Map term intersection. A point where two or more ways meet.-->
     <string name="osm_intersection">Intersection</string>
     <!-- Open Street Map term roundabout. A circular junction directing traffic around a central island.-->
@@ -1367,10 +1363,6 @@ We're still working hard on improving the app, so please report any problems tha
     <string name="osm_bank">Bank</string>
     <!-- Open Street Map term atm. An automated teller machine for cash services.-->
     <string name="osm_atm">ATM</string>
-    <!-- Open Street Map term atm_named. An ATM with a specific name or operator.-->
-    <string name="osm_atm_named">Named ATM</string>
-    <!-- Open Street Map term atm_refed. An ATM identified by a reference code.-->
-    <string name="osm_atm_refed">ATM Reference</string>
     <!-- Open Street Map term bus_stop. A designated place where buses stop to pick up passengers.-->
     <string name="osm_bus_stop">Bus Stop</string>
     <!-- Open Street Map term recycling. A point for depositing recyclable materials.-->

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/utils/ResourceMapper.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/geoengine/utils/ResourceMapper.kt
@@ -37,8 +37,6 @@ import org.scottishtecharmy.soundscape.resources.osm_assembly_point
 import org.scottishtecharmy.soundscape.resources.osm_association
 import org.scottishtecharmy.soundscape.resources.osm_athletics
 import org.scottishtecharmy.soundscape.resources.osm_atm
-import org.scottishtecharmy.soundscape.resources.osm_atm_named
-import org.scottishtecharmy.soundscape.resources.osm_atm_refed
 import org.scottishtecharmy.soundscape.resources.osm_attraction
 import org.scottishtecharmy.soundscape.resources.osm_australian_football
 import org.scottishtecharmy.soundscape.resources.osm_baby_goods
@@ -330,9 +328,7 @@ import org.scottishtecharmy.soundscape.resources.osm_help_point
 import org.scottishtecharmy.soundscape.resources.osm_herbalist
 import org.scottishtecharmy.soundscape.resources.osm_hifi
 import org.scottishtecharmy.soundscape.resources.osm_highway
-import org.scottishtecharmy.soundscape.resources.osm_highway_named
 import org.scottishtecharmy.soundscape.resources.osm_highway_ramp
-import org.scottishtecharmy.soundscape.resources.osm_highway_refed
 import org.scottishtecharmy.soundscape.resources.osm_historic_monument
 import org.scottishtecharmy.soundscape.resources.osm_hockey
 import org.scottishtecharmy.soundscape.resources.osm_horse_racing
@@ -782,8 +778,6 @@ class ResourceMapper {
                 put("track_construction", Res.string.osm_road_works)
                 put("raceway_construction", Res.string.osm_road_works)
                 put("highway", Res.string.osm_highway)
-                put("highway_named", Res.string.osm_highway_named)
-                put("highway_refed", Res.string.osm_highway_refed)
                 put("intersection", Res.string.osm_intersection)
                 put("roundabout", Res.string.osm_roundabout)
                 put("highway_ramp", Res.string.osm_highway_ramp)
@@ -815,8 +809,6 @@ class ResourceMapper {
                 put("fuel", Res.string.osm_gas_station)
                 put("bank", Res.string.osm_bank)
                 put("atm", Res.string.osm_atm)
-                put("atm_named", Res.string.osm_atm_named)
-                put("atm_refed", Res.string.osm_atm_refed)
                 put("bus_stop", Res.string.osm_bus_stop)
                 put("recycling", Res.string.osm_recycling_bin)
                 put("fountain", Res.string.osm_fountain)


### PR DESCRIPTION
Traced the resolveFeatureClass() call site: it calls getString(resource) with no format arguments, and no code in the tile pipeline ever produces a "highway_named"/"highway_refed"/"atm_named"/"atm_refed" feature-class key for these to be looked up by, so the strings (and their %1$s placeholder in several translations) were dead.