### PR TITLE
Enable Firebase Analytics + Crashlytics on iOS

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -325,6 +325,17 @@ jobs:
           search_provider_url: ${{ secrets.SEARCH_PROVIDER_URL }}
           extract_provider_url: ${{ secrets.EXTRACT_PROVIDER_URL }}
 
+      # Overwrite the committed placeholder GoogleService-Info.plist with the
+      # real one so Firebase Analytics + Crashlytics initialise on Release
+      # builds. FirebaseAnalyticsBridge.swift's gate keeps Firebase off in
+      # Debug/XCTest, so the placeholder is enough for PR CI and the
+      # ios-firebase Test Lab job.
+      - name: Decode Google service info
+        uses: ./.github/actions/decode-base64-secret
+        with:
+          encoded: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST }}
+          output_path: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST_PATH }}
+
       - name: Generate Xcode project
         working-directory: iosApp
         run: xcodegen generate

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -258,6 +258,15 @@ jobs:
           search_provider_url: ${{ secrets.SEARCH_PROVIDER_URL }}
           extract_provider_url: ${{ secrets.EXTRACT_PROVIDER_URL }}
 
+      # Overwrite the committed placeholder GoogleService-Info.plist with the
+      # real one for the archive step. Firebase itself is only initialised on
+      # Release + non-XCTest, gated in FirebaseAnalyticsBridge.swift.
+      - name: Decode Google service info
+        uses: ./.github/actions/decode-base64-secret
+        with:
+          encoded: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST }}
+          output_path: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST_PATH }}
+
       - name: Generate Xcode project
         working-directory: iosApp
         run: xcodegen generate

--- a/docs/developers/actions.md
+++ b/docs/developers/actions.md
@@ -37,6 +37,13 @@ Authenticate for talking to the Firebase servers is done using [google-github-ac
 * GCLOUD_CREDENTIALS_JSON - the value passed in to  `credentials_json`.
 * FIREBASE_PROJECT_ID - This is the Project ID from Firebase. 
 
+#### iOS Firebase
+Same pattern for iOS. The iOS app must be registered in the same Firebase project as the Android one (bundle id `org.scottishtecharmy.soundscape`) so its `GoogleService-Info.plist` can be downloaded.
+* GOOGLE_SERVICE_INFO_PLIST - base64 encoded `GoogleService-Info.plist` from the Firebase console. Generated with `base64 -i GoogleService-Info.plist`.
+* GOOGLE_SERVICE_INFO_PLIST_PATH - not really secret, always set to `iosApp/iosApp/GoogleService-Info.plist`.
+
+A placeholder `GoogleService-Info.plist` is committed so PR CI (which has no access to secrets) still builds. The real plist is written over the top by the `ios-build` jobs in `build-app.yaml` and `nightly.yaml`. The `ios-firebase` (Test Lab XCTest) job and `run-tests.yaml`'s ios-test job do not need the real plist — Firebase's iOS runtime gate (`shouldEnableFirebase()` in `FirebaseAnalyticsBridge.swift`) returns false whenever XCTest is present, so no Firebase call is ever made in those jobs. Unlike Android, iOS Firebase Test Lab does not set a well-known env var; instead the gate checks for `XCTestConfigurationFilePath` in the environment and for the `XCTestCase` class in the running process.
+
 ### Tile provider secrets
 These are the secrets that are used to get mapping tiles from the protomaps server.
 * TILE_PROVIDER_URL - the base URL pointing at our protomaps server

--- a/docs/developers/build-types.md
+++ b/docs/developers/build-types.md
@@ -77,3 +77,30 @@ EXTRACT_PROVIDER_URL
 ```
 
 `local.properties` is not under version control. Each developer fills it in by hand (the format is documented in [Developer information]({% link developers/developers.md %})). On GitHub Actions, the workflow writes `local.properties` from a repo secret before invoking Gradle — see [GitHub actions]({% link developers/actions.md %}). If a value is missing the build still succeeds but those `BuildConfig` strings are empty, and the corresponding feature will fail at runtime.
+
+## iOS gating
+
+iOS does not use Android-style build-type source-set splitting — the same `iosApp` target compiles for both Debug and Release. Instead, `iosApp/iosApp/FirebaseAnalyticsBridge.swift` runs a `shouldEnableFirebase()` gate at launch inside `FirebaseBootstrap.configureIfEnabled()`:
+
+```swift
+#if DEBUG
+return false
+#else
+let env = ProcessInfo.processInfo.environment
+if env["XCTestConfigurationFilePath"] != nil { return false }
+if NSClassFromString("XCTestCase") != nil { return false }
+return true
+#endif
+```
+
+Mapping to Android's three-way gate:
+
+| Android | iOS |
+| --- | --- |
+| `BuildConfig.DUMMY_ANALYTICS` (from `debug` / `releaseTest`) | `#if DEBUG` |
+| `firebase.test.lab` system setting | `XCTestConfigurationFilePath` env var + `XCTestCase` class presence |
+| `hasPlayServices()` | No analog — Firebase iOS has no equivalent hard runtime dependency |
+
+Only Release, non-XCTest launches call `FirebaseApp.configure()` and inject `FirebaseAnalyticsBridge` into `IosSoundscapeService` via `setAnalyticsFactory { ... }`. Debug builds and XCTest runs leave the shared code's default `NoOpAnalytics` in place, so no Firebase framework code runs even though it is linked in.
+
+The shared Kotlin `Analytics` interface is renamed for Objective-C export using `@ObjCName("SoundscapeAnalytics", exact = true)` in `shared/src/commonMain/kotlin/.../utils/Analytics.kt` — Firebase's Swift API also exports a class called `Analytics`, and renaming the Kotlin symbol at the source avoids module-qualified references at every Swift call site.

--- a/docs/developers/multiplatform.md
+++ b/docs/developers/multiplatform.md
@@ -24,6 +24,16 @@ EXTRACT_PROVIDER_URL = https:/$()/extracts.example.com/
 ```
 You can find your `DEVELOPMENT_TEAM_ID` at https://developer.apple.com/
 
+## Firebase (optional for local dev)
+
+Firebase Analytics and Crashlytics are wired up on iOS but skipped on Debug builds and
+whenever XCTest is running, so the placeholder `iosApp/iosApp/GoogleService-Info.plist`
+checked into the repo is enough for local development and PR CI. If you need to exercise
+the Firebase path, download the real plist for the `org.scottishtecharmy.soundscape`
+iOS app from the Firebase console and drop it in over the placeholder, then archive
+Release. See [Build types and analytics]({% link developers/build-types.md %}) for the
+gating detail.
+
 ### If using Android Studio
 
 - Build configurations should auto generate, and you can run the app on a **Simulator** / **Device** in the same way as you would an 

--- a/iosApp/iosApp/FirebaseAnalyticsBridge.swift
+++ b/iosApp/iosApp/FirebaseAnalyticsBridge.swift
@@ -1,0 +1,62 @@
+import Foundation
+import FirebaseCore
+import FirebaseAnalytics
+import FirebaseCrashlytics
+import Shared
+
+// Firebase wiring for iOS. Mirrors the Android FirebaseAnalyticsImpl.
+//
+// Gating (matches app/src/main/.../MainActivity.kt):
+//   - Debug builds: never initialise Firebase.
+//   - XCTest runs (local unit tests or Firebase Test Lab): never initialise.
+//   - Release, non-test: initialise Firebase and inject the bridge into
+//     IosSoundscapeService before the shared code fetches the singleton.
+
+enum FirebaseBootstrap {
+    static func configureIfEnabled() {
+        guard shouldEnableFirebase() else { return }
+        FirebaseApp.configure()
+        IosSoundscapeService.companion.setAnalyticsFactory(factory: {
+            FirebaseAnalyticsBridge()
+        })
+    }
+}
+
+private func shouldEnableFirebase() -> Bool {
+    #if DEBUG
+    return false
+    #else
+    let env = ProcessInfo.processInfo.environment
+    if env["XCTestConfigurationFilePath"] != nil { return false }
+    if NSClassFromString("XCTestCase") != nil { return false }
+    return true
+    #endif
+}
+
+final class FirebaseAnalyticsBridge: NSObject, SoundscapeAnalytics {
+
+    // Kotlin `Map<String, Any?>?` reaches Swift as `[String: Any]?` via NSDictionary.
+    // Nullable Kotlin values arrive as NSNull, which Firebase rejects, so strip them.
+    private func sanitize(_ params: [String: Any]?) -> [String: Any]? {
+        guard let params else { return nil }
+        var out: [String: Any] = [:]
+        for (k, v) in params where !(v is NSNull) { out[k] = v }
+        return out.isEmpty ? nil : out
+    }
+
+    func logEvent(name: String, params: [String: Any]?) {
+        FirebaseAnalytics.Analytics.logEvent(name, parameters: sanitize(params))
+    }
+
+    func logCostlyEvent(name: String, params: [String: Any]?) {
+        // Mirror Android: costly events are dropped to control monthly event count.
+    }
+
+    func crashSetCustomKey(key: String, value: String) {
+        Crashlytics.crashlytics().setCustomValue(value, forKey: key)
+    }
+
+    func crashLogNotes(name: String) {
+        Crashlytics.crashlytics().log(name)
+    }
+}

--- a/iosApp/iosApp/GoogleService-Info.plist
+++ b/iosApp/iosApp/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string></string>
+	<key>GCM_SENDER_ID</key>
+	<string>123456789012</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>org.scottishtecharmy.soundscape</string>
+	<key>PROJECT_ID</key>
+	<string></string>
+	<key>STORAGE_BUCKET</key>
+	<string></string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<true></true>
+	<key>IS_APPINVITE_ENABLED</key>
+	<false></false>
+	<key>IS_GCM_ENABLED</key>
+	<false></false>
+	<key>IS_SIGNIN_ENABLED</key>
+	<false></false>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:123456789012:ios:1234567890123456</string>
+</dict>
+</plist>

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -11,6 +11,11 @@ struct iOSApp: App {
         // database are populated before MainViewController reads them.
         // See LegacyMigrator.swift.
         LegacyMigrator.runIfNeeded()
+
+        // Initialise Firebase and inject the analytics bridge into the
+        // shared iOS singleton. Skipped on Debug/XCTest.
+        // See FirebaseAnalyticsBridge.swift.
+        FirebaseBootstrap.configureIfEnabled()
     }
 
     var body: some Scene {

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -27,6 +27,9 @@ packages:
   RealmSwift:
     url: https://github.com/realm/realm-swift
     from: 20.0.4
+  Firebase:
+    url: https://github.com/firebase/firebase-ios-sdk
+    from: 11.7.0
 targets:
   iosApp:
     type: application
@@ -37,6 +40,10 @@ targets:
       - package: RealmSwift
         product: RealmSwift
         embed: true
+      - package: Firebase
+        product: FirebaseAnalytics
+      - package: Firebase
+        product: FirebaseCrashlytics
       - target: ShareExtension
         embed: true
     sources:
@@ -137,6 +144,8 @@ targets:
           - "-framework"
           - "Shared"
         CODE_SIGN_ENTITLEMENTS: iosApp/iosApp.entitlements
+        # Full DWARF with dSYM so Crashlytics can symbolicate crash reports.
+        DEBUG_INFORMATION_FORMAT: dwarf-with-dsym
       configs:
         # CI archives with manual signing so xcodebuild uses the
         # distribution cert + profile imported by setup-ios-signing rather
@@ -155,6 +164,18 @@ targets:
         script: |
           cd "$SRCROOT/.."
           ./gradlew --configure-on-demand :shared:embedAndSignAppleFrameworkForXcode
+        basedOnDependencyAnalysis: false
+    postBuildScripts:
+      # Crashlytics needs dSYMs uploaded so crash reports symbolicate. The
+      # Firebase SDK ships a `run` script inside its SPM checkout that handles
+      # this. Uses BUILD_DIR to locate the SourcePackages checkouts directory
+      # (SPM unpacks packages under DerivedData/…/SourcePackages/checkouts).
+      - name: "Crashlytics: upload dSYMs"
+        script: |
+          "${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"
+        inputFiles:
+          - ${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}
+          - $(SRCROOT)/iosApp/GoogleService-Info.plist
         basedOnDependencyAnalysis: false
 
   iosAppTests:

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/utils/Analytics.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/utils/Analytics.kt
@@ -1,5 +1,13 @@
 package org.scottishtecharmy.soundscape.utils
 
+import kotlin.experimental.ExperimentalObjCName
+import kotlin.native.ObjCName
+
+// Firebase's iOS SDK also exports a class called `Analytics`, so rename the
+// ObjC-visible symbol to avoid collision in Swift call sites. Kotlin call
+// sites still use the plain `Analytics` name.
+@OptIn(ExperimentalObjCName::class)
+@ObjCName("SoundscapeAnalytics", exact = true)
 interface Analytics {
     fun logEvent(name: String, params: Map<String, Any?>? = null)
     fun logCostlyEvent(name: String, params: Map<String, Any?>? = null)

--- a/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/IosSoundscapeService.kt
+++ b/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/IosSoundscapeService.kt
@@ -98,6 +98,11 @@ class IosSoundscapeService : GeoEngineListener, MediaControllableService, Servic
     val preferencesProvider = IosPreferencesProvider()
     val networkUtils = IosNetworkUtils()
 
+    // Swift injects a Firebase-backed impl on Release via
+    // FirebaseBootstrap.configureIfEnabled(). Default stays NoOp so Debug
+    // builds and unit tests do not touch Firebase.
+    private val analytics: Analytics = analyticsFactory()
+
     // GeoEngine
     val geoEngine = GeoEngine()
     private var geoEngineStarted = false
@@ -340,7 +345,7 @@ class IosSoundscapeService : GeoEngineListener, MediaControllableService, Servic
             listener = this,
             localizedStrings = ComposeLocalizedStrings(),
             preferencesProvider = preferencesProvider,
-            analytics = NoOpAnalytics,
+            analytics = analytics,
             tileClient = tileClient,
             routeDao = routeDao,
             offlineExtractPath = documentsPath,
@@ -823,6 +828,12 @@ class IosSoundscapeService : GeoEngineListener, MediaControllableService, Servic
                 ?: ""
 
         private var INSTANCE: IosSoundscapeService? = null
+
+        private var analyticsFactory: () -> Analytics = { NoOpAnalytics }
+
+        fun setAnalyticsFactory(factory: () -> Analytics) {
+            analyticsFactory = factory
+        }
 
         fun getInstance(): IosSoundscapeService {
             return INSTANCE ?: IosSoundscapeService().also { INSTANCE = it }


### PR DESCRIPTION
Adds Firebase iOS SDK via SPM, a Swift bridge implementing the shared Analytics interface, and Release-only initialisation gated on #if DEBUG plus XCTest-presence checks (iOS analog of Android's DUMMY_ANALYTICS + firebase.test.lab gate). Placeholder GoogleService-Info.plist ships in the repo; CI overwrites it from a base64 secret. The shared Analytics interface is renamed to SoundscapeAnalytics in ObjC export to avoid colliding with Firebase's own Analytics class in Swift.