### PR TITLE
Fix iOS splash hang: Firebase 12.18.0 closes Sessions deadlock

### DIFF
--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -29,7 +29,7 @@ packages:
     from: 20.0.4
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk
-    from: 11.7.0
+    from: 12.18.0
 targets:
   iosApp:
     type: application


### PR DESCRIPTION
Release Firebase 11.15.0 intermittently deadlocked on cold launch when Sessions.init's promise chain hit RemoteSettings.fetchAndCacheSettings on a background queue at the same time the first UIApplication activation notification fired SessionInitiator.appForegrounded on main. Both paths race for FIRAllocatedUnfairLock inside RemoteSettings.sessionsCache; main is the reader, background holds it and blocks in SettingsCache.removeCache -> GULUserDefaults notification post -> NSOperation waitUntilFinished waiting on main. Timing-dependent so Debug never reproduced it.

Fixed upstream in firebase-ios-sdk 12.10.0 (release note: "Fixed a deadlock in Firebase Sessions where the main thread could block waiting for a lock held by a background thread during settings updates"). Bumping to 12.18.0 for the accompanying Crashlytics fixes as well.