### PR TITLE
Add test coverage for legacy iOS database import + migration orchestr…

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -31,7 +31,13 @@ jobs:
       - name: Run lint over the repo
         run: ./gradlew lint
 
-  test:
+  # The unit tests and the instrumentation tests are independent of each other,
+  # so they run as separate parallel jobs rather than one long serial job. Both
+  # need the offline map fixtures (the unit tests read them out of the test
+  # resources, the instrumentation job pushes one onto the emulator), but that
+  # step is cached so fetching it twice costs little.
+  unit-test:
+    name: Run unit tests
 
     runs-on: ubuntu-latest
     environment: development
@@ -67,6 +73,40 @@ jobs:
       - name: Run tests
         run: ./gradlew test :shared:testAndroidHostTest
 
+  instrumentation-test:
+    name: Run instrumentation tests
+
+    runs-on: ubuntu-latest
+    environment: development
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup offline maps for tests
+        uses: ./.github/actions/setup-offline-maps
+        with:
+          output_dir: ${{ env.main_project_module }}/src/test/res/org/scottishtecharmy/soundscape
+
+      - name: Setup JDK + Gradle
+        uses: ./.github/actions/setup-jdk-gradle
+
+#      See the note in the unit-test job: provider secrets are unavailable to
+#      fork-triggered runs, and the tests that need them check at runtime.
+
+      - name: Setup tile and search providers
+        uses: ./.github/actions/write-provider-config
+        with:
+          platform: android
+          tile_provider_url: ${{ secrets.TILE_PROVIDER_URL }}
+          tile_provider_api_key: ${{ secrets.TILE_PROVIDER_API_KEY }}
+          search_provider_url: ${{ secrets.SEARCH_PROVIDER_URL }}
+          search_provider_api_key: ${{ secrets.SEARCH_PROVIDER_API_KEY }}
+          extract_provider_url: ${{ secrets.EXTRACT_PROVIDER_URL }}
+
+      # Build the APK before the emulator boots so the slow Gradle work doesn't
+      # happen with an emulator sitting open waiting on it.
       - name: Build debug version
         run: ./gradlew assembleDebug
 

--- a/iosApp/iosApp/LegacyMigrator.swift
+++ b/iosApp/iosApp/LegacyMigrator.swift
@@ -82,19 +82,24 @@ enum LegacyMigrator {
     /// already-clean defaults and lets us ship later fixes without needing
     /// to reset the done flag. Synchronous so the caller can be sure
     /// preferences are settled before the Compose UI reads them.
-    static func runIfNeeded() {
-        let defaults = UserDefaults.standard
-
+    ///
+    /// `defaults`, `documentsPath` and `importDatabase` default to the real
+    /// production values/behaviour; tests override them to drive each
+    /// branch deterministically without touching real Realm/Room state.
+    static func runIfNeeded(
+        defaults: UserDefaults = .standard,
+        documentsPath: String = NSHomeDirectory() + "/Documents",
+        importDatabase: (String) -> Int32 = { importLegacyDatabase(at: $0) }
+    ) {
         if !defaults.bool(forKey: doneKey) {
-            let docs = NSHomeDirectory() + "/Documents"
-            let legacyRealmPath = docs + "/database.realm"
+            let legacyRealmPath = documentsPath + "/database.realm"
 
             if !FileManager.default.fileExists(atPath: legacyRealmPath) {
                 // Fresh install: no legacy data to migrate. Mark done so we
                 // never probe again.
                 defaults.set(true, forKey: doneKey)
             } else {
-                let importedCount = importDatabase(at: legacyRealmPath)
+                let importedCount = importDatabase(legacyRealmPath)
                 if importedCount < 0 {
                     // Database import failed. Leave the legacy files in
                     // place so the user can retry on next launch (or we
@@ -102,7 +107,7 @@ enum LegacyMigrator {
                     print("[LegacyMigrator] database import failed; will retry on next launch")
                 } else {
                     migrateSettings(defaults: defaults)
-                    deleteLegacyArtefacts(documentsPath: docs)
+                    deleteLegacyArtefacts(documentsPath: documentsPath)
                     defaults.set(true, forKey: doneKey)
                     print("[LegacyMigrator] migrated \(importedCount) markers + routes")
                 }
@@ -114,33 +119,12 @@ enum LegacyMigrator {
 
     // MARK: Database import
 
-    private static func importDatabase(at realmPath: String) -> Int32 {
-        // Open the legacy realm read-write. Read-only mode refuses to touch
-        // the file, but RealmSwift 20.x will reject any legacy file at an
-        // older on-disk format (e.g. v22) unless it can upgrade in place.
-        // Letting Realm upgrade is harmless because we delete the file
-        // after a successful import.
-        var config = Realm.Configuration(
-            fileURL: URL(fileURLWithPath: realmPath),
-            objectTypes: [LegacyReferenceEntity.self, LegacyRoute.self, LegacyRouteWaypoint.self],
-        )
-        // Schema migration block. The legacy app shipped at schemaVersion 0
-        // and our model is shape-compatible (we declare every @Persisted
-        // column the legacy file has). Bumping schemaVersion to 1 with a
-        // no-op block lets Realm treat any minor mismatch as a migration
-        // it can handle without prompting.
-        config.schemaVersion = 1
-        config.migrationBlock = { _, _ in }
-        config.deleteRealmIfMigrationNeeded = false
-
-        let realm: Realm
-        do {
-            realm = try Realm(configuration: config)
-        } catch {
-            print("[LegacyMigrator] could not open legacy realm: \(error)")
-            return -1
-        }
-
+    /// Reads markers and routes out of an already-open legacy `realm` and
+    /// encodes them as the JSON payload the Kotlin importer expects. Pure —
+    /// no file I/O, no Kotlin/Room call — so tests can exercise it against
+    /// an in-memory fixture Realm without touching the production database.
+    /// Returns nil only if the payload can't be JSON-encoded.
+    static func buildLegacyPayload(realm: Realm) -> String? {
         let savedReferences = realm.objects(LegacyReferenceEntity.self).filter("isTemp == false")
         var markersJson: [[String: Any]] = []
         markersJson.reserveCapacity(savedReferences.count)
@@ -179,14 +163,44 @@ enum LegacyMigrator {
 
         let payload: [String: Any] = ["markers": markersJson, "routes": routesJson]
 
-        let data: Data
+        guard let data = try? JSONSerialization.data(withJSONObject: payload, options: []) else {
+            print("[LegacyMigrator] could not encode payload")
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Opens the legacy Realm at `realmPath`, builds the JSON payload via
+    /// [buildLegacyPayload], and hands it to the Kotlin side to write into
+    /// the production Room database.
+    private static func importLegacyDatabase(at realmPath: String) -> Int32 {
+        // Open the legacy realm read-write. Read-only mode refuses to touch
+        // the file, but RealmSwift 20.x will reject any legacy file at an
+        // older on-disk format (e.g. v22) unless it can upgrade in place.
+        // Letting Realm upgrade is harmless because we delete the file
+        // after a successful import.
+        var config = Realm.Configuration(
+            fileURL: URL(fileURLWithPath: realmPath),
+            objectTypes: [LegacyReferenceEntity.self, LegacyRoute.self, LegacyRouteWaypoint.self],
+        )
+        // Schema migration block. The legacy app shipped at schemaVersion 0
+        // and our model is shape-compatible (we declare every @Persisted
+        // column the legacy file has). Bumping schemaVersion to 1 with a
+        // no-op block lets Realm treat any minor mismatch as a migration
+        // it can handle without prompting.
+        config.schemaVersion = 1
+        config.migrationBlock = { _, _ in }
+        config.deleteRealmIfMigrationNeeded = false
+
+        let realm: Realm
         do {
-            data = try JSONSerialization.data(withJSONObject: payload, options: [])
+            realm = try Realm(configuration: config)
         } catch {
-            print("[LegacyMigrator] could not encode payload: \(error)")
+            print("[LegacyMigrator] could not open legacy realm: \(error)")
             return -1
         }
-        guard let json = String(data: data, encoding: .utf8) else { return -1 }
+
+        guard let json = buildLegacyPayload(realm: realm) else { return -1 }
 
         return LegacyMigrationKt.runLegacyMigrationImport(payloadJson: json)
     }
@@ -373,7 +387,7 @@ enum LegacyMigrator {
 
     // MARK: Cleanup
 
-    private static func deleteLegacyArtefacts(documentsPath: String) {
+    static func deleteLegacyArtefacts(documentsPath: String) {
         let fm = FileManager.default
         let realmFiles = [
             documentsPath + "/database.realm",

--- a/iosApp/iosAppTests/LegacyMigratorDatabaseTests.swift
+++ b/iosApp/iosAppTests/LegacyMigratorDatabaseTests.swift
@@ -1,0 +1,390 @@
+//
+//  LegacyMigratorDatabaseTests.swift
+//
+//  Unit tests for the parts of LegacyMigrator that LegacyMigratorTests.swift
+//  doesn't cover: the Realm→JSON payload builder, the legacy-file cleanup,
+//  and the runIfNeeded orchestration across its four branches (fresh
+//  install, successful import, failed import, already done). All of these
+//  run against in-memory Realm fixtures, temp directories and isolated
+//  UserDefaults suites — never the production Realm/Room/UserDefaults.standard.
+//
+
+import XCTest
+import RealmSwift
+@testable import Soundscape
+
+final class LegacyMigratorDatabaseTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var documentsPath: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "LegacyMigratorDatabaseTests-" + UUID().uuidString
+        defaults = UserDefaults(suiteName: suiteName)!
+        documentsPath = NSTemporaryDirectory() + "LegacyMigratorDatabaseTests-" + UUID().uuidString
+        try! FileManager.default.createDirectory(atPath: documentsPath, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        try? FileManager.default.removeItem(atPath: documentsPath)
+        documentsPath = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeInMemoryRealm() -> Realm {
+        let config = Realm.Configuration(
+            inMemoryIdentifier: UUID().uuidString,
+            objectTypes: [LegacyReferenceEntity.self, LegacyRoute.self, LegacyRouteWaypoint.self],
+        )
+        return try! Realm(configuration: config)
+    }
+
+    private func addMarker(
+        to realm: Realm,
+        id: String,
+        isTemp: Bool = false,
+        nickname: String? = nil,
+        estimatedAddress: String? = nil,
+        entityKey: String? = nil,
+        latitude: Double = 0,
+        longitude: Double = 0
+    ) {
+        try! realm.write {
+            let marker = LegacyReferenceEntity()
+            marker.id = id
+            marker.isTemp = isTemp
+            marker.nickname = nickname
+            marker.estimatedAddress = estimatedAddress
+            marker.entityKey = entityKey
+            marker.latitude = latitude
+            marker.longitude = longitude
+            realm.add(marker)
+        }
+    }
+
+    private func addRoute(to realm: Realm, id: String, name: String, waypointIds: [String]) {
+        try! realm.write {
+            let route = LegacyRoute()
+            route.id = id
+            route.name = name
+            for (index, markerId) in waypointIds.enumerated() {
+                let waypoint = LegacyRouteWaypoint()
+                waypoint.index = index
+                waypoint.markerId = markerId
+                route.waypoints.append(waypoint)
+            }
+            realm.add(route)
+        }
+    }
+
+    private func decodePayload(_ json: String?, file: StaticString = #filePath, line: UInt = #line) -> [String: Any] {
+        guard let json, let data = json.data(using: .utf8) else {
+            XCTFail("Expected a non-nil JSON payload", file: file, line: line)
+            return [:]
+        }
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            XCTFail("Payload wasn't a JSON object: \(json)", file: file, line: line)
+            return [:]
+        }
+        return object
+    }
+
+    private func createFile(at path: String) {
+        FileManager.default.createFile(atPath: path, contents: Data())
+    }
+
+    // MARK: - buildLegacyPayload
+
+    func testBuildPayloadIncludesSavedMarkerWithAllFields() {
+        let realm = makeInMemoryRealm()
+        addMarker(
+            to: realm,
+            id: "leg-1",
+            nickname: "Pub",
+            estimatedAddress: "1 Royal Mile",
+            latitude: 55.95,
+            longitude: -3.19,
+        )
+
+        let payload = decodePayload(LegacyMigrator.buildLegacyPayload(realm: realm))
+        let markers = payload["markers"] as? [[String: Any]]
+
+        XCTAssertEqual(markers?.count, 1)
+        let marker = markers?.first
+        XCTAssertEqual(marker?["legacyId"] as? String, "leg-1")
+        XCTAssertEqual(marker?["name"] as? String, "Pub")
+        XCTAssertEqual(marker?["latitude"] as? Double, 55.95)
+        XCTAssertEqual(marker?["longitude"] as? Double, -3.19)
+        XCTAssertEqual(marker?["fullAddress"] as? String, "1 Royal Mile")
+    }
+
+    func testBuildPayloadExcludesTempMarkers() {
+        let realm = makeInMemoryRealm()
+        addMarker(to: realm, id: "temp-1", isTemp: true, nickname: "En route beacon")
+        addMarker(to: realm, id: "saved-1", isTemp: false, nickname: "Saved")
+
+        let payload = decodePayload(LegacyMigrator.buildLegacyPayload(realm: realm))
+        let markers = payload["markers"] as? [[String: Any]]
+
+        XCTAssertEqual(markers?.count, 1)
+        XCTAssertEqual(markers?.first?["legacyId"] as? String, "saved-1")
+    }
+
+    func testBuildPayloadNameFallsBackToNicknameWhenPresent() {
+        let realm = makeInMemoryRealm()
+        addMarker(to: realm, id: "m1", nickname: "Nickname", estimatedAddress: "Address", entityKey: "EntityKey")
+
+        let payload = decodePayload(LegacyMigrator.buildLegacyPayload(realm: realm))
+        let marker = (payload["markers"] as? [[String: Any]])?.first
+        XCTAssertEqual(marker?["name"] as? String, "Nickname")
+    }
+
+    func testBuildPayloadNameFallsBackToAddressWhenNoNickname() {
+        let realm = makeInMemoryRealm()
+        addMarker(to: realm, id: "m1", nickname: nil, estimatedAddress: "Address", entityKey: "EntityKey")
+
+        let payload = decodePayload(LegacyMigrator.buildLegacyPayload(realm: realm))
+        let marker = (payload["markers"] as? [[String: Any]])?.first
+        XCTAssertEqual(marker?["name"] as? String, "Address")
+    }
+
+    func testBuildPayloadNameFallsBackToEntityKeyWhenNoNicknameOrAddress() {
+        let realm = makeInMemoryRealm()
+        addMarker(to: realm, id: "m1", nickname: nil, estimatedAddress: nil, entityKey: "EntityKey")
+
+        let payload = decodePayload(LegacyMigrator.buildLegacyPayload(realm: realm))
+        let marker = (payload["markers"] as? [[String: Any]])?.first
+        XCTAssertEqual(marker?["name"] as? String, "EntityKey")
+    }
+
+    func testBuildPayloadNameFallsBackToUnnamedWhenAllFallbacksMissing() {
+        let realm = makeInMemoryRealm()
+        addMarker(to: realm, id: "m1", nickname: nil, estimatedAddress: nil, entityKey: nil)
+
+        let payload = decodePayload(LegacyMigrator.buildLegacyPayload(realm: realm))
+        let marker = (payload["markers"] as? [[String: Any]])?.first
+        XCTAssertEqual(marker?["name"] as? String, "Unnamed")
+    }
+
+    func testBuildPayloadOrdersRouteWaypointsByIndexRegardlessOfInsertionOrder() {
+        let realm = makeInMemoryRealm()
+        addMarker(to: realm, id: "m1", nickname: "M1")
+        addMarker(to: realm, id: "m2", nickname: "M2")
+        addMarker(to: realm, id: "m3", nickname: "M3")
+
+        try! realm.write {
+            let route = LegacyRoute()
+            route.id = "r1"
+            route.name = "Loop"
+            // Append out of index order to prove sorting isn't insertion order.
+            let w2 = LegacyRouteWaypoint(); w2.index = 2; w2.markerId = "m3"
+            let w0 = LegacyRouteWaypoint(); w0.index = 0; w0.markerId = "m1"
+            let w1 = LegacyRouteWaypoint(); w1.index = 1; w1.markerId = "m2"
+            route.waypoints.append(w2)
+            route.waypoints.append(w0)
+            route.waypoints.append(w1)
+            realm.add(route)
+        }
+
+        let payload = decodePayload(LegacyMigrator.buildLegacyPayload(realm: realm))
+        let routes = payload["routes"] as? [[String: Any]]
+        XCTAssertEqual(routes?.count, 1)
+        XCTAssertEqual(routes?.first?["waypointLegacyIds"] as? [String], ["m1", "m2", "m3"])
+    }
+
+    func testBuildPayloadExcludesRouteWithNoResolvableWaypoints() {
+        let realm = makeInMemoryRealm()
+        try! realm.write {
+            let route = LegacyRoute()
+            route.id = "r1"
+            route.name = "Broken"
+            let empty = LegacyRouteWaypoint(); empty.index = 0; empty.markerId = ""
+            route.waypoints.append(empty)
+            realm.add(route)
+        }
+
+        let payload = decodePayload(LegacyMigrator.buildLegacyPayload(realm: realm))
+        XCTAssertEqual((payload["routes"] as? [[String: Any]])?.count, 0)
+    }
+
+    func testBuildPayloadIncludesMultipleRoutesSharingMarkers() {
+        let realm = makeInMemoryRealm()
+        addMarker(to: realm, id: "m1", nickname: "M1")
+        addMarker(to: realm, id: "m2", nickname: "M2")
+        addRoute(to: realm, id: "r1", name: "A", waypointIds: ["m1", "m2"])
+        addRoute(to: realm, id: "r2", name: "B", waypointIds: ["m2", "m1"])
+
+        let payload = decodePayload(LegacyMigrator.buildLegacyPayload(realm: realm))
+        let routes = (payload["routes"] as? [[String: Any]])?.sorted {
+            ($0["name"] as? String ?? "") < ($1["name"] as? String ?? "")
+        }
+
+        XCTAssertEqual(routes?.count, 2)
+        XCTAssertEqual(routes?[0]["waypointLegacyIds"] as? [String], ["m1", "m2"])
+        XCTAssertEqual(routes?[1]["waypointLegacyIds"] as? [String], ["m2", "m1"])
+    }
+
+    func testBuildPayloadEmptyRealmProducesEmptyArrays() {
+        let realm = makeInMemoryRealm()
+
+        let payload = decodePayload(LegacyMigrator.buildLegacyPayload(realm: realm))
+
+        XCTAssertEqual((payload["markers"] as? [[String: Any]])?.count, 0)
+        XCTAssertEqual((payload["routes"] as? [[String: Any]])?.count, 0)
+    }
+
+    // MARK: - deleteLegacyArtefacts
+
+    func testDeleteLegacyArtefactsRemovesAllFourRealmFiles() {
+        let suffixes = ["", ".lock", ".note", ".management"]
+        for suffix in suffixes {
+            createFile(at: documentsPath + "/database.realm" + suffix)
+        }
+
+        LegacyMigrator.deleteLegacyArtefacts(documentsPath: documentsPath)
+
+        for suffix in suffixes {
+            XCTAssertFalse(
+                FileManager.default.fileExists(atPath: documentsPath + "/database.realm" + suffix),
+                "Expected database.realm\(suffix) to be removed",
+            )
+        }
+    }
+
+    func testDeleteLegacyArtefactsToleratesMissingFiles() {
+        // Nothing created in documentsPath - must not throw or crash.
+        LegacyMigrator.deleteLegacyArtefacts(documentsPath: documentsPath)
+    }
+
+    func testDeleteLegacyArtefactsLeavesUnrelatedFilesAlone() {
+        createFile(at: documentsPath + "/database.realm")
+        createFile(at: documentsPath + "/settings.json")
+
+        LegacyMigrator.deleteLegacyArtefacts(documentsPath: documentsPath)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: documentsPath + "/settings.json"))
+    }
+
+    func testDeleteLegacyArtefactsSweepsCacheRealmsInLibrary() {
+        // deleteLegacyArtefacts hardcodes NSHomeDirectory()/Library for the
+        // cache-realm sweep (not parameterized), so this case isn't fully
+        // hermetic - it touches the real test-runner home Library, scoped to
+        // a uniquely-named file so it can't collide with anything real.
+        let libraryPath = NSHomeDirectory() + "/Library"
+        let cacheFile = libraryPath + "/cache.test-\(UUID().uuidString).realm"
+        createFile(at: cacheFile)
+        defer { try? FileManager.default.removeItem(atPath: cacheFile) }
+
+        LegacyMigrator.deleteLegacyArtefacts(documentsPath: documentsPath)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cacheFile))
+    }
+
+    // MARK: - runIfNeeded orchestration
+
+    func testRunIfNeededFreshInstallNoRealmFileSetsDoneFlagWithoutImporting() {
+        var importCalled = false
+
+        LegacyMigrator.runIfNeeded(
+            defaults: defaults,
+            documentsPath: documentsPath,
+            importDatabase: { _ in
+                importCalled = true
+                return 0
+            },
+        )
+
+        XCTAssertFalse(importCalled)
+        XCTAssertTrue(defaults.bool(forKey: "LegacyMigrationDone"))
+    }
+
+    func testRunIfNeededSuccessfulImportRunsSettingsDeletesArtefactsAndSetsDone() {
+        let realmPath = documentsPath + "/database.realm"
+        createFile(at: realmPath)
+        defaults.set(true, forKey: "GDASettingsMetric")
+
+        var callCount = 0
+        var capturedPath: String?
+
+        LegacyMigrator.runIfNeeded(
+            defaults: defaults,
+            documentsPath: documentsPath,
+            importDatabase: { path in
+                callCount += 1
+                capturedPath = path
+                return 2
+            },
+        )
+
+        XCTAssertEqual(callCount, 1)
+        XCTAssertEqual(capturedPath, realmPath)
+        // migrateSettings ran.
+        XCTAssertEqual(defaults.string(forKey: "MeasurementUnits"), "Metric")
+        // deleteLegacyArtefacts ran.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: realmPath))
+        XCTAssertTrue(defaults.bool(forKey: "LegacyMigrationDone"))
+    }
+
+    func testRunIfNeededFailedImportLeavesArtefactsAndDoesNotSetDone() {
+        let realmPath = documentsPath + "/database.realm"
+        createFile(at: realmPath)
+
+        LegacyMigrator.runIfNeeded(
+            defaults: defaults,
+            documentsPath: documentsPath,
+            importDatabase: { _ in -1 },
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: realmPath))
+        XCTAssertFalse(defaults.bool(forKey: "LegacyMigrationDone"))
+    }
+
+    func testRunIfNeededAlreadyDoneIsNoOp() {
+        defaults.set(true, forKey: "LegacyMigrationDone")
+        createFile(at: documentsPath + "/database.realm")
+        var importCalled = false
+
+        LegacyMigrator.runIfNeeded(
+            defaults: defaults,
+            documentsPath: documentsPath,
+            importDatabase: { _ in
+                importCalled = true
+                return 0
+            },
+        )
+
+        XCTAssertFalse(importCalled)
+    }
+
+    func testRunIfNeededAlwaysRunsHygieneSweepRegardlessOfBranch() {
+        // Already-done branch: hygiene sweep still fires even though import is skipped.
+        defaults.set(true, forKey: "LegacyMigrationDone")
+        defaults.set(true, forKey: "GDAStaleKey")
+        LegacyMigrator.runIfNeeded(
+            defaults: defaults,
+            documentsPath: documentsPath,
+            importDatabase: { _ in 0 },
+        )
+        XCTAssertNil(defaults.object(forKey: "GDAStaleKey"))
+
+        // Fresh-install branch (no database.realm at documentsPath): hygiene sweep still fires.
+        let freshSuiteName = "LegacyMigratorDatabaseTests-fresh-" + UUID().uuidString
+        let freshDefaults = UserDefaults(suiteName: freshSuiteName)!
+        defer { freshDefaults.removePersistentDomain(forName: freshSuiteName) }
+        freshDefaults.set(true, forKey: "GDAStaleKey")
+
+        LegacyMigrator.runIfNeeded(
+            defaults: freshDefaults,
+            documentsPath: documentsPath,
+            importDatabase: { _ in 0 },
+        )
+        XCTAssertNil(freshDefaults.object(forKey: "GDAStaleKey"))
+    }
+}

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -201,6 +201,12 @@ targets:
       - path: iosAppTests
     dependencies:
       - target: iosApp
+      # LegacyMigratorDatabaseTests builds its fixtures with RealmSwift, so the
+      # test bundle needs to link it directly. `embed: false` because the host
+      # app already embeds the framework and the bundle loads inside it.
+      - package: RealmSwift
+        product: RealmSwift
+        embed: false
     settings:
       base:
         CODE_SIGNING_ALLOWED: "YES"


### PR DESCRIPTION
…ation

Splits LegacyMigrator.importDatabase into a pure buildLegacyPayload(realm:) (Realm -> JSON, no Room writes) plus a thin importLegacyDatabase(at:) wrapper, drops `private` from deleteLegacyArtefacts, and parameterizes runIfNeeded (defaults/documentsPath/importDatabase, all defaulting to production behaviour) so each is independently testable without touching real Realm/Room/UserDefaults.standard state.

Adds LegacyMigratorDatabaseTests.swift: 19 cases covering payload building (marker field mapping, isTemp exclusion, name-fallback chain, waypoint ordering, unresolvable-waypoint route skipping, shared markers across routes, empty realm), artefact deletion, and runIfNeeded's four branches (fresh install, successful import, failed import retry, already done).

Unverified locally - no macOS/Xcode toolchain available in this environment; needs an xcodebuild run before this is trusted.