### PR TITLE
Publish a finished download only once its list is refreshed

### DIFF
--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/network/OfflineMapManager.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/network/OfflineMapManager.kt
@@ -228,8 +228,15 @@ class OfflineMapManager(
                             } catch (_: Exception) {
                             }
                             systemFileSystem.atomicMove(tempFile, finalFile)
-                            _downloadState.value = DownloadStateCommon.Success
+                            // Refresh before publishing Success, not after. Success is what
+                            // releases anything waiting on downloadState, and the natural next
+                            // thing for a waiter to do is read downloadedExtracts - which, the
+                            // other way round, still held the list from before this download for
+                            // the width of one statement. Rare, but it is exactly what
+                            // OfflineMapManagerTest.startDownload_success_movesTempFileToFinal-
+                            // PathAndUpdatesDownloadedExtracts intermittently caught on CI.
                             refreshDownloaded()
+                            _downloadState.value = DownloadStateCommon.Success
                             return@launch
                         }
 


### PR DESCRIPTION
startDownload set downloadState to Success and refreshed downloadedExtracts immediately afterwards. Success is what releases anything waiting on the state, and the natural next thing for a waiter to do is read the list - which for the width of one statement still held the extracts from before this download.

The UI has the same exposure as the test does, so fix the ordering rather than the assertion: refresh first, then publish Success.

The error path is unchanged. refreshDownloaded is a plain synchronous assignment, and if it did throw, the surrounding catch overwrites Success with Error either way - the old order just showed a transient Success with a stale list first.

This is what OfflineMapManagerTest.startDownload_success_movesTempFileTo- FinalPathAndUpdatesDownloadedExtracts caught on CI, in the Weblate translation merge run where nothing related had changed. Note it is not reproducible locally - twelve consecutive runs passed, the window being a single statement - so this rests on reading the code rather than on a reproduction.