### PR TITLE
Leave the legacy iOS database and settings in place

### DIFF
--- a/docs/ios-upgrade-from-legacy.md
+++ b/docs/ios-upgrade-from-legacy.md
@@ -18,8 +18,10 @@ changed or are not yet present.
 
 When you launch the new build for the first time, a one-shot migration runs
 silently in the background. It reads the legacy database and preferences out of
-the app's existing container and writes them into the new app's storage. After
-it finishes, the legacy files are removed.
+the app's existing container and writes them into the new app's storage. It
+copies rather than moves: the legacy database and settings are left exactly
+where they were, untouched, so nothing is lost if you go back to the legacy
+build or if support needs to look at them later.
 
 Migrated automatically:
 
@@ -37,9 +39,9 @@ Migrated automatically:
   - Mix-with-other-audio
   - Marker sort preference (distance / alphabetical)
 
-The migration runs only once. If something goes wrong (e.g. a damaged database
-file), it leaves your legacy data untouched and tries again on the next launch
-rather than discarding anything.
+The migration runs only once, and never deletes anything belonging to the
+legacy app. If something goes wrong (e.g. a damaged database file), it tries
+again on the next launch rather than discarding anything.
 
 ## What's new
 
@@ -97,9 +99,9 @@ upgrading.
   app has a single speech rate plus a "mix with other audio" toggle; per-
   channel gain is no longer adjustable. These settings are not migrated.
 - **Marker notes.** The legacy "annotation" field on a marker (free-text user
-  notes) is not preserved by the migration — the new schema doesn't include a
-  notes field. If you've written notes on a marker that you want to keep,
-  export your markers from the legacy app as a backup before upgrading.
+  notes) is not carried over by the migration — the new schema doesn't include
+  a notes field. The legacy database still holds them, so nothing is lost, but
+  the new app has nowhere to show them.
 - **Beacon variants.** The "haptic-only" beacon and the legacy "Classic" /
   "V2" beacons are mapped to the closest current beacon style. The new
   catalogue is broader (Original, Current, Tactile, Flare, Shimmer, Ping,

--- a/iosApp/iosApp/LegacyMigrator.swift
+++ b/iosApp/iosApp/LegacyMigrator.swift
@@ -13,13 +13,20 @@
 //       which writes them into the new Room database.
 //    3. Migrates a curated subset of the GDA* preferences into their new
 //       PreferenceKeys equivalents.
-//    4. Deletes the legacy Realm files and the cache realms in Library/.
-//    5. Sets a `LegacyMigrationDone` flag so subsequent launches no-op.
+//    4. Sets a `LegacyMigrationDone` flag so subsequent launches no-op.
+//
+//  Nothing belonging to the legacy app is ever deleted. The Realm files
+//  and the GDA* preferences are left exactly as they were found, so a user
+//  who rolls back to the legacy build still has their data, and so support
+//  can recover anything a future release's import turns out to have
+//  missed. The import even reads from a throwaway copy of the database so
+//  that opening it can't upgrade the on-disk format underneath the legacy
+//  app.
 //
 //  Migration aborts (without setting the done flag) on any error during
-//  database import, so legacy data is never deleted before a successful
-//  import. Settings translation is best-effort — individual key failures
-//  are tolerated.
+//  database import, so a failed import is retried on the next launch.
+//  Settings translation is best-effort — individual key failures are
+//  tolerated.
 //
 
 import Foundation
@@ -29,8 +36,8 @@ import Shared
 // MARK: - Legacy Realm models (mirror of legacy app schema)
 //
 // We declare every @Persisted field that exists on disk so that opening the
-// realm read-only doesn't trip a schema-mismatch error. The migrator only
-// reads a subset, but Realm needs the model schema to cover every column.
+// realm doesn't trip a schema-mismatch error. The migrator only reads a
+// subset, but Realm needs the model schema to cover every column.
 
 final class LegacyReferenceEntity: Object {
     @Persisted(primaryKey: true) var id: String = ""
@@ -76,8 +83,8 @@ enum LegacyMigrator {
     private static let doneKey = "LegacyMigrationDone"
 
     /// One-shot legacy import + always-on UserDefaults hygiene. The import
-    /// half (database + settings translation + legacy file deletion) is
-    /// gated by `LegacyMigrationDone` and runs at most once per install.
+    /// half (database read + settings translation) is gated by
+    /// `LegacyMigrationDone` and runs at most once per install.
     /// The hygiene sweep runs on every launch — it's a fast no-op for
     /// already-clean defaults and lets us ship later fixes without needing
     /// to reset the done flag. Synchronous so the caller can be sure
@@ -101,13 +108,11 @@ enum LegacyMigrator {
             } else {
                 let importedCount = importDatabase(legacyRealmPath)
                 if importedCount < 0 {
-                    // Database import failed. Leave the legacy files in
-                    // place so the user can retry on next launch (or we
-                    // can ship a fix). Do NOT set the done flag.
+                    // Database import failed. Retry on next launch (or once
+                    // we can ship a fix). Do NOT set the done flag.
                     print("[LegacyMigrator] database import failed; will retry on next launch")
                 } else {
                     migrateSettings(defaults: defaults)
-                    deleteLegacyArtefacts(documentsPath: documentsPath)
                     defaults.set(true, forKey: doneKey)
                     print("[LegacyMigrator] migrated \(importedCount) markers + routes")
                 }
@@ -170,17 +175,54 @@ enum LegacyMigrator {
         return String(data: data, encoding: .utf8)
     }
 
-    /// Opens the legacy Realm at `realmPath`, builds the JSON payload via
-    /// [buildLegacyPayload], and hands it to the Kotlin side to write into
-    /// the production Room database.
+    /// Reads the legacy Realm at `realmPath` and hands the resulting JSON
+    /// payload to the Kotlin side to write into the production Room
+    /// database. Returns the Kotlin importer's count, or -1 if the legacy
+    /// database couldn't be read.
     private static func importLegacyDatabase(at realmPath: String) -> Int32 {
-        // Open the legacy realm read-write. Read-only mode refuses to touch
-        // the file, but RealmSwift 20.x will reject any legacy file at an
-        // older on-disk format (e.g. v22) unless it can upgrade in place.
-        // Letting Realm upgrade is harmless because we delete the file
-        // after a successful import.
+        guard let json = buildPayloadPreservingOriginal(at: realmPath) else { return -1 }
+
+        return LegacyMigrationKt.runLegacyMigrationImport(payloadJson: json)
+    }
+
+    /// Builds the JSON payload from the legacy database at `realmPath`
+    /// without modifying it in any way.
+    ///
+    /// Reads a throwaway copy rather than the file itself: opening a realm
+    /// read-write lets RealmSwift 20.x upgrade an older on-disk format
+    /// (e.g. v22) in place, and read-only mode refuses to open such a file
+    /// at all. Since we leave the legacy database behind for the user, the
+    /// original has to come out of this byte-for-byte unchanged, so we let
+    /// Realm upgrade the copy instead.
+    ///
+    /// Returns nil if the copy, the open or the JSON encode fails.
+    static func buildPayloadPreservingOriginal(at realmPath: String) -> String? {
+        let fm = FileManager.default
+        let scratchDirectory = NSTemporaryDirectory() + "LegacyMigration-" + UUID().uuidString
+        let scratchPath = scratchDirectory + "/database.realm"
+        do {
+            try fm.createDirectory(atPath: scratchDirectory, withIntermediateDirectories: true)
+            try fm.copyItem(atPath: realmPath, toPath: scratchPath)
+        } catch {
+            print("[LegacyMigrator] could not copy legacy realm: \(error)")
+            try? fm.removeItem(atPath: scratchDirectory)
+            return nil
+        }
+
+        // Realm's auxiliary files (.lock/.management) are created alongside
+        // the copy, so removing the whole directory cleans up after us. The
+        // payload is built in a nested scope so the Realm instance is
+        // released before we delete the files it was reading.
+        let json = readLegacyPayload(fromCopyAt: scratchPath)
+        try? fm.removeItem(atPath: scratchDirectory)
+        return json
+    }
+
+    /// Opens the copied legacy realm at `path` and returns the JSON payload,
+    /// or nil if it can't be opened or encoded.
+    private static func readLegacyPayload(fromCopyAt path: String) -> String? {
         var config = Realm.Configuration(
-            fileURL: URL(fileURLWithPath: realmPath),
+            fileURL: URL(fileURLWithPath: path),
             objectTypes: [LegacyReferenceEntity.self, LegacyRoute.self, LegacyRouteWaypoint.self],
         )
         // Schema migration block. The legacy app shipped at schemaVersion 0
@@ -197,12 +239,10 @@ enum LegacyMigrator {
             realm = try Realm(configuration: config)
         } catch {
             print("[LegacyMigrator] could not open legacy realm: \(error)")
-            return -1
+            return nil
         }
 
-        guard let json = buildLegacyPayload(realm: realm) else { return -1 }
-
-        return LegacyMigrationKt.runLegacyMigrationImport(payloadJson: json)
+        return buildLegacyPayload(realm: realm)
     }
 
     // MARK: Settings translation
@@ -300,64 +340,24 @@ enum LegacyMigrator {
             defaults.set(false, forKey: "FirstLaunch")
         }
 
-        // Remove the now-translated legacy keys to keep NSUserDefaults tidy
-        // and avoid confusion if a later release inspects them.
-        let legacyKeys = [
-            "GDASettingsMetric",
-            "GDASettingsLocaleIdentifier",
-            "GDASettingsSpeakingRate",
-            "GDASelectedBeaconName",
-            "GDASettingsAutomaticCalloutsEnabled",
-            "GDASettingsPlaceSenseEnabled",
-            "GDASettingsLandmarkSenseEnabled",
-            "GDASettingsMobilitySenseEnabled",
-            "GDASettingsInformationSenseEnabled",
-            "GDASettingsSafetySenseEnabled",
-            "GDASettingsIntersectionsSenseEnabled",
-            "GDASettingsDestinationSenseEnabled",
-            "GDAAudioSessionMixesWithOthers",
-            "GDAMarkerSortStyle",
-            "GDAFirstLaunchDidComplete",
-            "GDABeaconTutorialDidComplete",
-            "GDAMarkerTutorialDidComplete",
-            "GDAPreviewTutorialDidComplete",
-            "GDARouteTutorialDidComplete",
-            "GDAUserDefaultClientIdentifier",
-            "GDAAppUseCount",
-            "GDANewFeaturesLastDisplayedVersion",
-            "GDAAppleSynthVoice",
-            "GDABeaconVolume",
-            "GDATTSVolume",
-            "GDAOtherVolume",
-            "GDATTSAudioGain",
-            "GDABeaconAudioGain",
-            "GDAAFXAudioGain",
-            "GDASettingsTelemetryOptout",
-            "GDASettingsUseOldBeacon",
-            "GDAPlayBeaconStartEndMelody",
-            "GDASettingsAPNsDeviceToken",
-            "GDASettingsPushNotificationTags",
-            "GDASettingsPreviewIntersectionsIncludeUnnamedRoads",
-            "GDASettingsInitialCloudSyncCompleted",
-            "GDASettingsPreviewInitialRoadFinderComplete",
-            "GDASettingsPreviewInitialRoadFinderError",
-            "GDAFirstUseExperienceShare",
-            "GDAFirstUseExperienceDonateSiriShortcuts",
-        ]
-        for key in legacyKeys {
-            defaults.removeObject(forKey: key)
-        }
+        // The GDA* keys are deliberately left in place. They cost a few
+        // hundred bytes, the new app never reads them again, and keeping
+        // them means a user who rolls back to the legacy build still has
+        // their settings — and that support can see what the legacy app
+        // held if a translation above turns out to be wrong.
     }
 
     // MARK: Defaults hygiene
 
     /// Removes UserDefaults entries that would crash the Compose
-    /// preference library when it iterates `dictionaryRepresentation()`.
-    /// Drops anything still under the legacy `GDA*` prefix as well as any
-    /// non-primitive value (Data, Date, Dictionary, mixed Array) that
-    /// isn't owned by Apple/system frameworks. The new app stores only
+    /// preference library when it iterates `dictionaryRepresentation()`:
+    /// non-primitive values (Data, Date, Dictionary, mixed Array) that
+    /// aren't owned by Apple/system frameworks. The new app stores only
     /// Bool/Number/String through `IosPreferencesProvider`, so anything
     /// else under our control is detritus.
+    ///
+    /// Legacy `GDA*` keys are exempt — whatever type they hold, they are
+    /// the legacy app's settings and we leave them alone.
     ///
     /// Idempotent — runs on every launch so a future fix can land
     /// without resetting `LegacyMigrationDone`.
@@ -367,11 +367,7 @@ enum LegacyMigrator {
 
         for (key, value) in defaults.dictionaryRepresentation() {
             if preserved.contains(key) { continue }
-
-            if key.hasPrefix("GDA") {
-                defaults.removeObject(forKey: key)
-                continue
-            }
+            if key.hasPrefix("GDA") { continue }
 
             let isSystem = systemPrefixes.contains { key.hasPrefix($0) }
             if isSystem { continue }
@@ -382,30 +378,6 @@ enum LegacyMigrator {
             if let array = value as? [String] { _ = array; continue }
 
             defaults.removeObject(forKey: key)
-        }
-    }
-
-    // MARK: Cleanup
-
-    static func deleteLegacyArtefacts(documentsPath: String) {
-        let fm = FileManager.default
-        let realmFiles = [
-            documentsPath + "/database.realm",
-            documentsPath + "/database.realm.lock",
-            documentsPath + "/database.realm.note",
-            documentsPath + "/database.realm.management",
-        ]
-        for path in realmFiles {
-            try? fm.removeItem(atPath: path)
-        }
-
-        // Cache realms live in Library/cache.<n>.realm — POI cache, fully
-        // regenerable. Sweep them out so we don't waste space.
-        let libraryPath = NSHomeDirectory() + "/Library"
-        if let entries = try? fm.contentsOfDirectory(atPath: libraryPath) {
-            for entry in entries where entry.hasPrefix("cache.") && entry.contains(".realm") {
-                try? fm.removeItem(atPath: libraryPath + "/" + entry)
-            }
         }
     }
 }

--- a/iosApp/iosAppTests/LegacyMigratorDatabaseTests.swift
+++ b/iosApp/iosAppTests/LegacyMigratorDatabaseTests.swift
@@ -2,11 +2,12 @@
 //  LegacyMigratorDatabaseTests.swift
 //
 //  Unit tests for the parts of LegacyMigrator that LegacyMigratorTests.swift
-//  doesn't cover: the Realm→JSON payload builder, the legacy-file cleanup,
-//  and the runIfNeeded orchestration across its four branches (fresh
-//  install, successful import, failed import, already done). All of these
-//  run against in-memory Realm fixtures, temp directories and isolated
-//  UserDefaults suites — never the production Realm/Room/UserDefaults.standard.
+//  doesn't cover: the Realm→JSON payload builder, the copy-and-read step
+//  that keeps the legacy database intact, and the runIfNeeded orchestration
+//  across its four branches (fresh install, successful import, failed
+//  import, already done). All of these run against in-memory or temporary
+//  Realm fixtures, temp directories and isolated UserDefaults suites —
+//  never the production Realm/Room/UserDefaults.standard.
 //
 
 import XCTest
@@ -96,8 +97,8 @@ final class LegacyMigratorDatabaseTests: XCTestCase {
         return object
     }
 
-    private func createFile(at path: String) {
-        FileManager.default.createFile(atPath: path, contents: Data())
+    private func createFile(at path: String, contents: Data = Data()) {
+        FileManager.default.createFile(atPath: path, contents: contents)
     }
 
     // MARK: - buildLegacyPayload
@@ -240,51 +241,85 @@ final class LegacyMigratorDatabaseTests: XCTestCase {
         XCTAssertEqual((payload["routes"] as? [[String: Any]])?.count, 0)
     }
 
-    // MARK: - deleteLegacyArtefacts
+    // MARK: - buildPayloadPreservingOriginal
 
-    func testDeleteLegacyArtefactsRemovesAllFourRealmFiles() {
-        let suffixes = ["", ".lock", ".note", ".management"]
-        for suffix in suffixes {
-            createFile(at: documentsPath + "/database.realm" + suffix)
-        }
-
-        LegacyMigrator.deleteLegacyArtefacts(documentsPath: documentsPath)
-
-        for suffix in suffixes {
-            XCTAssertFalse(
-                FileManager.default.fileExists(atPath: documentsPath + "/database.realm" + suffix),
-                "Expected database.realm\(suffix) to be removed",
+    /// Writes a legacy-shaped realm to `path` and returns once it's closed,
+    /// so the caller can treat the file as a static on-disk fixture.
+    private func writeOnDiskLegacyRealm(at path: String, markerName: String) {
+        autoreleasepool {
+            let config = Realm.Configuration(
+                fileURL: URL(fileURLWithPath: path),
+                objectTypes: [LegacyReferenceEntity.self, LegacyRoute.self, LegacyRouteWaypoint.self],
             )
+            let realm = try! Realm(configuration: config)
+            addMarker(to: realm, id: "leg-1", nickname: markerName, latitude: 1, longitude: 2)
         }
     }
 
-    func testDeleteLegacyArtefactsToleratesMissingFiles() {
-        // Nothing created in documentsPath - must not throw or crash.
-        LegacyMigrator.deleteLegacyArtefacts(documentsPath: documentsPath)
+    func testBuildPayloadPreservingOriginalReadsMarkersFromDisk() {
+        let realmPath = documentsPath + "/database.realm"
+        writeOnDiskLegacyRealm(at: realmPath, markerName: "On disk")
+
+        let payload = decodePayload(LegacyMigrator.buildPayloadPreservingOriginal(at: realmPath))
+        let markers = payload["markers"] as? [[String: Any]]
+
+        XCTAssertEqual(markers?.count, 1)
+        XCTAssertEqual(markers?.first?["name"] as? String, "On disk")
     }
 
-    func testDeleteLegacyArtefactsLeavesUnrelatedFilesAlone() {
-        createFile(at: documentsPath + "/database.realm")
-        createFile(at: documentsPath + "/settings.json")
+    func testBuildPayloadPreservingOriginalLeavesTheLegacyFileByteIdentical() {
+        // The whole point of reading a copy: Realm would otherwise upgrade
+        // the on-disk format in place, and the legacy database has to stay
+        // usable by the legacy build.
+        let realmPath = documentsPath + "/database.realm"
+        writeOnDiskLegacyRealm(at: realmPath, markerName: "On disk")
+        let before = try! Data(contentsOf: URL(fileURLWithPath: realmPath))
 
-        LegacyMigrator.deleteLegacyArtefacts(documentsPath: documentsPath)
+        XCTAssertNotNil(LegacyMigrator.buildPayloadPreservingOriginal(at: realmPath))
 
-        XCTAssertTrue(FileManager.default.fileExists(atPath: documentsPath + "/settings.json"))
+        let after = try! Data(contentsOf: URL(fileURLWithPath: realmPath))
+        XCTAssertEqual(before, after)
     }
 
-    func testDeleteLegacyArtefactsSweepsCacheRealmsInLibrary() {
-        // deleteLegacyArtefacts hardcodes NSHomeDirectory()/Library for the
-        // cache-realm sweep (not parameterized), so this case isn't fully
-        // hermetic - it touches the real test-runner home Library, scoped to
-        // a uniquely-named file so it can't collide with anything real.
-        let libraryPath = NSHomeDirectory() + "/Library"
-        let cacheFile = libraryPath + "/cache.test-\(UUID().uuidString).realm"
-        createFile(at: cacheFile)
-        defer { try? FileManager.default.removeItem(atPath: cacheFile) }
+    func testBuildPayloadPreservingOriginalReturnsNilForAnUnreadableFile() {
+        // Bytes that are not a realm at all: Realm refuses to open the copy,
+        // so the import reports failure and gets retried on a later launch.
+        let realmPath = documentsPath + "/database.realm"
+        let garbage = Data("this is not a realm file".utf8)
+        createFile(at: realmPath, contents: garbage)
 
-        LegacyMigrator.deleteLegacyArtefacts(documentsPath: documentsPath)
+        XCTAssertNil(LegacyMigrator.buildPayloadPreservingOriginal(at: realmPath))
+        // Even a failed read leaves the file exactly as it was.
+        XCTAssertEqual(try? Data(contentsOf: URL(fileURLWithPath: realmPath)), garbage)
+    }
 
-        XCTAssertFalse(FileManager.default.fileExists(atPath: cacheFile))
+    func testBuildPayloadPreservingOriginalTreatsAnEmptyFileAsAnEmptyDatabase() {
+        // Realm initialises a zero-length file into a fresh empty realm
+        // rather than failing. That happens to the throwaway copy, so the
+        // import sees no markers or routes and the original stays empty.
+        let realmPath = documentsPath + "/database.realm"
+        createFile(at: realmPath)
+
+        let payload = decodePayload(LegacyMigrator.buildPayloadPreservingOriginal(at: realmPath))
+
+        XCTAssertEqual((payload["markers"] as? [[String: Any]])?.count, 0)
+        XCTAssertEqual((payload["routes"] as? [[String: Any]])?.count, 0)
+        XCTAssertEqual(try? Data(contentsOf: URL(fileURLWithPath: realmPath)), Data())
+    }
+
+    func testBuildPayloadPreservingOriginalCleansUpItsScratchCopy() {
+        let realmPath = documentsPath + "/database.realm"
+        writeOnDiskLegacyRealm(at: realmPath, markerName: "On disk")
+
+        let tempDirectory = NSTemporaryDirectory()
+        let before = Set((try? FileManager.default.contentsOfDirectory(atPath: tempDirectory)) ?? [])
+        XCTAssertNotNil(LegacyMigrator.buildPayloadPreservingOriginal(at: realmPath))
+        let after = Set((try? FileManager.default.contentsOfDirectory(atPath: tempDirectory)) ?? [])
+
+        XCTAssertTrue(
+            after.subtracting(before).filter { $0.hasPrefix("LegacyMigration-") }.isEmpty,
+            "Scratch copy left behind in \(tempDirectory)",
+        )
     }
 
     // MARK: - runIfNeeded orchestration
@@ -305,7 +340,7 @@ final class LegacyMigratorDatabaseTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "LegacyMigrationDone"))
     }
 
-    func testRunIfNeededSuccessfulImportRunsSettingsDeletesArtefactsAndSetsDone() {
+    func testRunIfNeededSuccessfulImportRunsSettingsKeepsLegacyDataAndSetsDone() {
         let realmPath = documentsPath + "/database.realm"
         createFile(at: realmPath)
         defaults.set(true, forKey: "GDASettingsMetric")
@@ -327,8 +362,9 @@ final class LegacyMigratorDatabaseTests: XCTestCase {
         XCTAssertEqual(capturedPath, realmPath)
         // migrateSettings ran.
         XCTAssertEqual(defaults.string(forKey: "MeasurementUnits"), "Metric")
-        // deleteLegacyArtefacts ran.
-        XCTAssertFalse(FileManager.default.fileExists(atPath: realmPath))
+        // ...and left the legacy database and settings behind.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: realmPath))
+        XCTAssertTrue(defaults.bool(forKey: "GDASettingsMetric"))
         XCTAssertTrue(defaults.bool(forKey: "LegacyMigrationDone"))
     }
 
@@ -364,27 +400,29 @@ final class LegacyMigratorDatabaseTests: XCTestCase {
     }
 
     func testRunIfNeededAlwaysRunsHygieneSweepRegardlessOfBranch() {
+        // A Date is one of the types the sweep still drops — GDA* keys are
+        // exempt now, so they can't be used as the marker any more.
         // Already-done branch: hygiene sweep still fires even though import is skipped.
         defaults.set(true, forKey: "LegacyMigrationDone")
-        defaults.set(true, forKey: "GDAStaleKey")
+        defaults.set(Date(), forKey: "StaleTimestamp")
         LegacyMigrator.runIfNeeded(
             defaults: defaults,
             documentsPath: documentsPath,
             importDatabase: { _ in 0 },
         )
-        XCTAssertNil(defaults.object(forKey: "GDAStaleKey"))
+        XCTAssertNil(defaults.object(forKey: "StaleTimestamp"))
 
         // Fresh-install branch (no database.realm at documentsPath): hygiene sweep still fires.
         let freshSuiteName = "LegacyMigratorDatabaseTests-fresh-" + UUID().uuidString
         let freshDefaults = UserDefaults(suiteName: freshSuiteName)!
         defer { freshDefaults.removePersistentDomain(forName: freshSuiteName) }
-        freshDefaults.set(true, forKey: "GDAStaleKey")
+        freshDefaults.set(Date(), forKey: "StaleTimestamp")
 
         LegacyMigrator.runIfNeeded(
             defaults: freshDefaults,
             documentsPath: documentsPath,
             importDatabase: { _ in 0 },
         )
-        XCTAssertNil(freshDefaults.object(forKey: "GDAStaleKey"))
+        XCTAssertNil(freshDefaults.object(forKey: "StaleTimestamp"))
     }
 }

--- a/iosApp/iosAppTests/LegacyMigratorTests.swift
+++ b/iosApp/iosAppTests/LegacyMigratorTests.swift
@@ -178,7 +178,9 @@ final class LegacyMigratorTests: XCTestCase {
         XCTAssertNil(defaults.object(forKey: "FirstLaunch"))
     }
 
-    func testTranslatedLegacyKeysAreRemoved() {
+    func testTranslatedLegacyKeysAreLeftInPlace() {
+        // Translation reads the legacy settings but never removes them —
+        // they stay behind for rollback to the legacy build and for support.
         defaults.set(true, forKey: "GDASettingsMetric")
         defaults.set(true, forKey: "GDAAudioSessionMixesWithOthers")
         defaults.set("V2Beacon", forKey: "GDASelectedBeaconName")
@@ -186,25 +188,31 @@ final class LegacyMigratorTests: XCTestCase {
 
         LegacyMigrator.migrateSettings(defaults: defaults)
 
-        XCTAssertNil(defaults.object(forKey: "GDASettingsMetric"))
-        XCTAssertNil(defaults.object(forKey: "GDAAudioSessionMixesWithOthers"))
-        XCTAssertNil(defaults.object(forKey: "GDASelectedBeaconName"))
-        XCTAssertNil(defaults.object(forKey: "GDASettingsAPNsDeviceToken"))
+        XCTAssertTrue(defaults.bool(forKey: "GDASettingsMetric"))
+        XCTAssertTrue(defaults.bool(forKey: "GDAAudioSessionMixesWithOthers"))
+        XCTAssertEqual(defaults.string(forKey: "GDASelectedBeaconName"), "V2Beacon")
+        XCTAssertTrue(defaults.bool(forKey: "GDASettingsAPNsDeviceToken"))
     }
 
     // MARK: - sweepIncompatibleDefaults
 
-    func testSweepRemovesAnyRemainingGDAKey() {
-        // Suffixed legacy keys (e.g., GDADidAddDevice_<type>) aren't on
-        // the explicit removal list in migrateSettings. The sweep should
-        // catch them on every launch.
+    func testSweepKeepsEveryGDAKeyWhateverItsType() {
+        // Legacy settings are left in place, including the ones holding
+        // types the sweep would otherwise drop.
         defaults.set(true, forKey: "GDADidAddDevice_BoseAR")
         defaults.set("ignored", forKey: "GDABannerDidDismissForKey_DeviceReachability_Foo")
+        defaults.set(Data([0x01, 0x02]), forKey: "GDASettingsAPNsDeviceToken")
+        defaults.set(Date(), forKey: "GDASomeTimestamp")
 
         LegacyMigrator.sweepIncompatibleDefaults(defaults: defaults)
 
-        XCTAssertNil(defaults.object(forKey: "GDADidAddDevice_BoseAR"))
-        XCTAssertNil(defaults.object(forKey: "GDABannerDidDismissForKey_DeviceReachability_Foo"))
+        XCTAssertTrue(defaults.bool(forKey: "GDADidAddDevice_BoseAR"))
+        XCTAssertEqual(
+            defaults.string(forKey: "GDABannerDidDismissForKey_DeviceReachability_Foo"),
+            "ignored",
+        )
+        XCTAssertNotNil(defaults.object(forKey: "GDASettingsAPNsDeviceToken"))
+        XCTAssertNotNil(defaults.object(forKey: "GDASomeTimestamp"))
     }
 
     func testSweepRemovesNonPrimitiveValues() {

--- a/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/screens/home/settings/SoundscapePreferenceFlow.ios.kt
+++ b/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/screens/home/settings/SoundscapePreferenceFlow.ios.kt
@@ -42,6 +42,7 @@ private fun NSUserDefaults.readSoundscapePreferences(): Preferences {
     return MapPreferences(
         buildMap {
             for ((key, value) in dictionary) {
+                if (key.isLegacyKey()) continue
                 val converted = value.toPreferenceValueOrNull() ?: continue
                 put(key, converted)
             }
@@ -53,11 +54,12 @@ private fun NSUserDefaults.writeSoundscapePreferences(preferences: Preferences) 
     val bundleId = NSBundle.mainBundle.bundleIdentifier ?: return
     // setPersistentDomain replaces the entire domain, so re-read it now and
     // keep any foreign keys (Firebase Crashlytics's cached remote settings
-    // dictionary, etc.) that we cannot represent in a Preferences map.
+    // dictionary, etc.) that we cannot represent in a Preferences map, plus
+    // the legacy app's keys, which have to survive verbatim.
     @Suppress("UNCHECKED_CAST")
     val foreign =
         ((persistentDomainForName(bundleId) as? Map<String, Any>).orEmpty())
-            .filterValues { it.toPreferenceValueOrNull() == null }
+            .filter { (key, value) -> key.isLegacyKey() || value.toPreferenceValueOrNull() == null }
     val converted =
         preferences.asMap().mapValues { (_, mapValue) ->
             @Suppress("CAST_NEVER_SUCCEEDS")
@@ -74,6 +76,14 @@ private fun NSUserDefaults.writeSoundscapePreferences(preferences: Preferences) 
         }
     setPersistentDomain(converted + foreign, bundleId)
 }
+
+// The legacy iOS app's settings, which LegacyMigrator translates once on
+// first launch and then leaves in place untouched. Excluding them from the
+// Preferences map keeps them out of the app's settings UI and, because the
+// write path then carries them across verbatim, stops a round-trip through
+// the preference types from rewriting them (a legacy double re-read as a
+// Float, say).
+private fun String.isLegacyKey(): Boolean = startsWith("GDA")
 
 // Values stored in NSUserDefaults by third-party SDKs (nested NSDictionary
 // from Firebase Crashlytics's settings cache, NSNumber with an objCType


### PR DESCRIPTION
The migration from the legacy iOS app now imports without destroying anything it read from.

Previously a successful import deleted Documents/database.realm and its sidecar files, swept the Library/cache.*.realm files, and removed the GDA* keys from NSUserDefaults. Now all of that stays behind, so a user who rolls back to the legacy build still has their data and support can see what the legacy app held if a translation turns out to be wrong.

The database is read from a throwaway copy. Opening the legacy realm read-write and bumping schemaVersion upgrades the on-disk format in place, which was harmless when the file was about to be deleted but would silently rewrite a file we now promise to preserve. The original comes out byte-identical, covered by a test that fails against the old implementation.

The iOS preference flow now excludes GDA* keys from the Preferences map and carries them across verbatim on write. setPersistentDomain replaces the whole domain, so without this a legacy Double would come back as a Float and a 64-bit int could truncate.

Keeping Data/Date-valued GDA keys in NSUserDefaults is safe since b0c768ea7 taught the preference flow to skip values it cannot classify; before that the sweep was what stood between those values and a crash.


Claude-Session: https://claude.ai/code/session_01XTmGjRcfwqybyVxTt6YQXz