### PR TITLE
Name migrated markers from tile data, on a screen of their own

### DIFF
--- a/docs/ios-upgrade-from-legacy.md
+++ b/docs/ios-upgrade-from-legacy.md
@@ -16,18 +16,31 @@ changed or are not yet present.
 
 ## What carries over
 
-When you launch the new build for the first time, a one-shot migration runs
-silently in the background. It reads the legacy database and preferences out of
-the app's existing container and writes them into the new app's storage. It
-copies rather than moves: the legacy database and settings are left exactly
-where they were, untouched, so nothing is lost if you go back to the legacy
-build or if support needs to look at them later.
+When you launch the new build for the first time, a one-shot migration reads the
+legacy database and preferences out of the app's existing container and writes
+them into the new app's storage. It copies rather than moves: the legacy
+database and settings are left exactly where they were, untouched, so nothing
+is lost if you go back to the legacy build or if support needs to look at them
+later.
+
+Your markers and routes are imported on a screen shown once, just after the app
+opens, with a progress count. **You'll need an internet connection for this**,
+or an offline map covering the places you saved: the old app didn't store a name
+for markers you created from a place on the map — it looked the name up each
+time it drew the list — so the new app has to look those names up too. If it
+can't, nothing is imported and you're offered a "Try again". You can also skip
+it with "Not now" and be asked again the next time you open Soundscape; your
+saved data stays where it is in the meantime.
 
 Migrated automatically:
 
-- **All saved markers** — name, address, latitude/longitude. Temporary "audio
-  beacon" markers (the ones the old app created when you started a beacon) are
-  not migrated; only the markers you explicitly saved.
+- **All saved markers** — name, address, latitude/longitude. Markers you gave
+  your own name to keep it. Markers you saved from a place on the map are named
+  from current map data instead, so a few may come across under a slightly
+  different name than before — the underlying map has moved on since the old
+  app's data was frozen. Temporary "audio beacon" markers (the ones the old app
+  created when you started a beacon) are not migrated; only the markers you
+  explicitly saved.
 - **All saved routes** — name, description, and waypoint order. Each waypoint
   is reconnected to its underlying marker.
 - **Most preferences** with a direct equivalent in the new app:
@@ -40,8 +53,10 @@ Migrated automatically:
   - Marker sort preference (distance / alphabetical)
 
 The migration runs only once, and never deletes anything belonging to the
-legacy app. If something goes wrong (e.g. a damaged database file), it tries
-again on the next launch rather than discarding anything.
+legacy app. If something goes wrong (e.g. a damaged database file, or no
+connection to look place names up with), it imports nothing at all and tries
+again on the next launch rather than discarding anything or leaving you with a
+half-finished set of markers.
 
 ## What's new
 

--- a/iosApp/iosApp/LegacyMigrator.swift
+++ b/iosApp/iosApp/LegacyMigrator.swift
@@ -9,8 +9,12 @@
 //
 //  This file:
 //    1. Reads markers and routes from the legacy Realm database.
-//    2. Hands them to the Kotlin side (LegacyMigrationKt.runLegacyMigrationImport)
-//       which writes them into the new Room database.
+//    2. Stages them as JSON for the Kotlin side (LegacyMigrationKt) to write
+//       into the new Room database. The write itself deliberately does NOT
+//       happen here: markers the legacy app never stored a name for have to
+//       be looked up in map tiles, and blocking app launch on the network is
+//       how an app gets killed by the watchdog. It runs from the migration
+//       screen instead - see LegacyMigration.kt and LegacyMigrationScreen.kt.
 //    3. Migrates a curated subset of the GDA* preferences into their new
 //       PreferenceKeys equivalents.
 //    4. Sets a `LegacyMigrationDone` flag so subsequent launches no-op.
@@ -23,8 +27,9 @@
 //  that opening it can't upgrade the on-disk format underneath the legacy
 //  app.
 //
-//  Migration aborts (without setting the done flag) on any error during
-//  database import, so a failed import is retried on the next launch.
+//  Migration aborts (without setting the done flag) on any error while
+//  reading or staging the legacy database, so a failed attempt is retried on
+//  the next launch.
 //  Settings translation is best-effort — individual key failures are
 //  tolerated.
 //
@@ -82,21 +87,22 @@ final class LegacyRoute: Object {
 enum LegacyMigrator {
     private static let doneKey = "LegacyMigrationDone"
 
-    /// One-shot legacy import + always-on UserDefaults hygiene. The import
-    /// half (database read + settings translation) is gated by
-    /// `LegacyMigrationDone` and runs at most once per install.
+
+    /// One-shot legacy read + always-on UserDefaults hygiene. The read half
+    /// (legacy database → staged payload, plus settings translation) is gated
+    /// by `LegacyMigrationDone` and runs at most once per install.
     /// The hygiene sweep runs on every launch — it's a fast no-op for
     /// already-clean defaults and lets us ship later fixes without needing
     /// to reset the done flag. Synchronous so the caller can be sure
     /// preferences are settled before the Compose UI reads them.
     ///
-    /// `defaults`, `documentsPath` and `importDatabase` default to the real
+    /// `defaults`, `documentsPath` and `stageDatabase` default to the real
     /// production values/behaviour; tests override them to drive each
     /// branch deterministically without touching real Realm/Room state.
     static func runIfNeeded(
         defaults: UserDefaults = .standard,
         documentsPath: String = NSHomeDirectory() + "/Documents",
-        importDatabase: (String) -> Int32 = { importLegacyDatabase(at: $0) }
+        stageDatabase: (String) -> Int32 = { stageLegacyDatabase(at: $0) }
     ) {
         if !defaults.bool(forKey: doneKey) {
             let legacyRealmPath = documentsPath + "/database.realm"
@@ -106,15 +112,16 @@ enum LegacyMigrator {
                 // never probe again.
                 defaults.set(true, forKey: doneKey)
             } else {
-                let importedCount = importDatabase(legacyRealmPath)
-                if importedCount < 0 {
-                    // Database import failed. Retry on next launch (or once
-                    // we can ship a fix). Do NOT set the done flag.
-                    print("[LegacyMigrator] database import failed; will retry on next launch")
+                let stagedCount = stageDatabase(legacyRealmPath)
+                if stagedCount < 0 {
+                    // Couldn't read or stage the legacy database. Retry on the
+                    // next launch (or once we can ship a fix). Do NOT set the
+                    // done flag.
+                    print("[LegacyMigrator] staging failed; will retry on next launch")
                 } else {
                     migrateSettings(defaults: defaults)
                     defaults.set(true, forKey: doneKey)
-                    print("[LegacyMigrator] migrated \(importedCount) markers + routes")
+                    print("[LegacyMigrator] staged \(stagedCount) markers + routes for import")
                 }
             }
         }
@@ -125,7 +132,11 @@ enum LegacyMigrator {
     // MARK: Database import
 
     /// Reads markers and routes out of an already-open legacy `realm` and
-    /// encodes them as the JSON payload the Kotlin importer expects. Pure —
+    /// encodes them as the JSON payload the Kotlin importer expects.
+    ///
+    /// `name` carries the legacy nickname and is empty for the many markers
+    /// that never had one; naming those from `entityKey` is the Kotlin
+    /// side's job, since that's where the tile data lives. Pure —
     /// no file I/O, no Kotlin/Room call — so tests can exercise it against
     /// an in-memory fixture Realm without touching the production database.
     /// Returns nil only if the payload can't be JSON-encoded.
@@ -135,16 +146,17 @@ enum LegacyMigrator {
         markersJson.reserveCapacity(savedReferences.count)
 
         for ref in savedReferences {
-            let name = ref.nickname?.nonEmpty
-                ?? ref.estimatedAddress?.nonEmpty
-                ?? ref.entityKey?.nonEmpty
-                ?? "Unnamed"
+            // Only the nickname is a name the legacy app actually stored. Everything else it
+            // showed was looked up from `entityKey` against tile data each time it drew the
+            // marker list, so we pass the key through and let the Kotlin importer do the same
+            // lookup against our own tiles — see LegacyMarkerNamer.kt.
             markersJson.append([
                 "legacyId": ref.id,
-                "name": name,
+                "name": ref.nickname?.nonEmpty ?? "",
                 "latitude": ref.latitude,
                 "longitude": ref.longitude,
                 "fullAddress": ref.estimatedAddress ?? "",
+                "entityKey": ref.entityKey ?? "",
             ])
         }
 
@@ -175,14 +187,33 @@ enum LegacyMigrator {
         return String(data: data, encoding: .utf8)
     }
 
-    /// Reads the legacy Realm at `realmPath` and hands the resulting JSON
-    /// payload to the Kotlin side to write into the production Room
-    /// database. Returns the Kotlin importer's count, or -1 if the legacy
-    /// database couldn't be read.
-    private static func importLegacyDatabase(at realmPath: String) -> Int32 {
+    /// Reads the legacy Realm at `realmPath` and stages the resulting JSON
+    /// payload for the migration screen to import.
+    ///
+    /// Returns the number of markers and routes staged, or -1 if the legacy
+    /// database couldn't be read or the payload couldn't be written. Nothing
+    /// is staged for a legacy install that has no markers or routes at all —
+    /// there would be nothing for the migration screen to show.
+    private static func stageLegacyDatabase(at realmPath: String) -> Int32 {
         guard let json = buildPayloadPreservingOriginal(at: realmPath) else { return -1 }
 
-        return LegacyMigrationKt.runLegacyMigrationImport(payloadJson: json)
+        let count = stagedItemCount(in: json)
+        guard count > 0 else { return 0 }
+
+        guard LegacyMigrationKt.stageLegacyMigrationPayload(payloadJson: json) else { return -1 }
+        return count
+    }
+
+    /// How many markers and routes a payload holds, or 0 if it can't be read
+    /// back — in which case there's nothing worth showing a screen for.
+    private static func stagedItemCount(in json: String) -> Int32 {
+        guard let data = json.data(using: .utf8),
+              let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return 0 }
+
+        let markers = (payload["markers"] as? [Any])?.count ?? 0
+        let routes = (payload["routes"] as? [Any])?.count ?? 0
+        return Int32(markers + routes)
     }
 
     /// Builds the JSON payload from the legacy database at `realmPath`

--- a/iosApp/iosApp/iosApp.entitlements
+++ b/iosApp/iosApp/iosApp.entitlements
@@ -6,5 +6,7 @@
 	<array>
 		<string>applinks:links.soundscape.scottishtecharmy.org</string>
 	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 </dict>
 </plist>

--- a/iosApp/iosAppTests/LegacyMigratorDatabaseTests.swift
+++ b/iosApp/iosAppTests/LegacyMigratorDatabaseTests.swift
@@ -124,6 +124,7 @@ final class LegacyMigratorDatabaseTests: XCTestCase {
         XCTAssertEqual(marker?["latitude"] as? Double, 55.95)
         XCTAssertEqual(marker?["longitude"] as? Double, -3.19)
         XCTAssertEqual(marker?["fullAddress"] as? String, "1 Royal Mile")
+        XCTAssertEqual(marker?["entityKey"] as? String, "")
     }
 
     func testBuildPayloadExcludesTempMarkers() {
@@ -138,40 +139,50 @@ final class LegacyMigratorDatabaseTests: XCTestCase {
         XCTAssertEqual(markers?.first?["legacyId"] as? String, "saved-1")
     }
 
-    func testBuildPayloadNameFallsBackToNicknameWhenPresent() {
+    func testBuildPayloadSendsNicknameAsTheName() {
         let realm = makeInMemoryRealm()
-        addMarker(to: realm, id: "m1", nickname: "Nickname", estimatedAddress: "Address", entityKey: "EntityKey")
+        addMarker(to: realm, id: "m1", nickname: "Nickname", estimatedAddress: "Address", entityKey: "ft-123")
 
         let payload = decodePayload(LegacyMigrator.buildLegacyPayload(realm: realm))
         let marker = (payload["markers"] as? [[String: Any]])?.first
         XCTAssertEqual(marker?["name"] as? String, "Nickname")
+        XCTAssertEqual(marker?["entityKey"] as? String, "ft-123")
     }
 
-    func testBuildPayloadNameFallsBackToAddressWhenNoNickname() {
+    /// A marker with no nickname is sent with an empty name and its entity
+    /// key, which is what the Kotlin importer names it from. The address is
+    /// still sent, as the fallback for when that lookup finds nothing.
+    func testBuildPayloadSendsEmptyNameAndEntityKeyWhenThereIsNoNickname() {
         let realm = makeInMemoryRealm()
-        addMarker(to: realm, id: "m1", nickname: nil, estimatedAddress: "Address", entityKey: "EntityKey")
+        addMarker(to: realm, id: "m1", nickname: nil, estimatedAddress: "Address", entityKey: "ft-123")
 
         let payload = decodePayload(LegacyMigrator.buildLegacyPayload(realm: realm))
         let marker = (payload["markers"] as? [[String: Any]])?.first
-        XCTAssertEqual(marker?["name"] as? String, "Address")
+        XCTAssertEqual(marker?["name"] as? String, "")
+        XCTAssertEqual(marker?["entityKey"] as? String, "ft-123")
+        XCTAssertEqual(marker?["fullAddress"] as? String, "Address")
     }
 
-    func testBuildPayloadNameFallsBackToEntityKeyWhenNoNicknameOrAddress() {
-        let realm = makeInMemoryRealm()
-        addMarker(to: realm, id: "m1", nickname: nil, estimatedAddress: nil, entityKey: "EntityKey")
-
-        let payload = decodePayload(LegacyMigrator.buildLegacyPayload(realm: realm))
-        let marker = (payload["markers"] as? [[String: Any]])?.first
-        XCTAssertEqual(marker?["name"] as? String, "EntityKey")
-    }
-
-    func testBuildPayloadNameFallsBackToUnnamedWhenAllFallbacksMissing() {
+    func testBuildPayloadSendsEmptyStringsWhenNicknameAndEntityKeyAreMissing() {
         let realm = makeInMemoryRealm()
         addMarker(to: realm, id: "m1", nickname: nil, estimatedAddress: nil, entityKey: nil)
 
         let payload = decodePayload(LegacyMigrator.buildLegacyPayload(realm: realm))
         let marker = (payload["markers"] as? [[String: Any]])?.first
-        XCTAssertEqual(marker?["name"] as? String, "Unnamed")
+        XCTAssertEqual(marker?["name"] as? String, "")
+        XCTAssertEqual(marker?["entityKey"] as? String, "")
+        XCTAssertEqual(marker?["fullAddress"] as? String, "")
+    }
+
+    /// An empty nickname on disk is the same as no nickname: it must not
+    /// suppress the entity-key lookup by arriving as a usable name.
+    func testBuildPayloadTreatsEmptyNicknameAsAbsent() {
+        let realm = makeInMemoryRealm()
+        addMarker(to: realm, id: "m1", nickname: "", estimatedAddress: "Address", entityKey: "ft-123")
+
+        let payload = decodePayload(LegacyMigrator.buildLegacyPayload(realm: realm))
+        let marker = (payload["markers"] as? [[String: Any]])?.first
+        XCTAssertEqual(marker?["name"] as? String, "")
     }
 
     func testBuildPayloadOrdersRouteWaypointsByIndexRegardlessOfInsertionOrder() {
@@ -324,23 +335,23 @@ final class LegacyMigratorDatabaseTests: XCTestCase {
 
     // MARK: - runIfNeeded orchestration
 
-    func testRunIfNeededFreshInstallNoRealmFileSetsDoneFlagWithoutImporting() {
-        var importCalled = false
+    func testRunIfNeededFreshInstallNoRealmFileSetsDoneFlagWithoutStaging() {
+        var stagingCalled = false
 
         LegacyMigrator.runIfNeeded(
             defaults: defaults,
             documentsPath: documentsPath,
-            importDatabase: { _ in
-                importCalled = true
+            stageDatabase: { _ in
+                stagingCalled = true
                 return 0
             },
         )
 
-        XCTAssertFalse(importCalled)
+        XCTAssertFalse(stagingCalled)
         XCTAssertTrue(defaults.bool(forKey: "LegacyMigrationDone"))
     }
 
-    func testRunIfNeededSuccessfulImportRunsSettingsKeepsLegacyDataAndSetsDone() {
+    func testRunIfNeededSuccessfulStagingRunsSettingsKeepsLegacyDataAndSetsDone() {
         let realmPath = documentsPath + "/database.realm"
         createFile(at: realmPath)
         defaults.set(true, forKey: "GDASettingsMetric")
@@ -351,7 +362,7 @@ final class LegacyMigratorDatabaseTests: XCTestCase {
         LegacyMigrator.runIfNeeded(
             defaults: defaults,
             documentsPath: documentsPath,
-            importDatabase: { path in
+            stageDatabase: { path in
                 callCount += 1
                 capturedPath = path
                 return 2
@@ -368,14 +379,14 @@ final class LegacyMigratorDatabaseTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "LegacyMigrationDone"))
     }
 
-    func testRunIfNeededFailedImportLeavesArtefactsAndDoesNotSetDone() {
+    func testRunIfNeededFailedStagingLeavesArtefactsAndDoesNotSetDone() {
         let realmPath = documentsPath + "/database.realm"
         createFile(at: realmPath)
 
         LegacyMigrator.runIfNeeded(
             defaults: defaults,
             documentsPath: documentsPath,
-            importDatabase: { _ in -1 },
+            stageDatabase: { _ in -1 },
         )
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: realmPath))
@@ -385,30 +396,30 @@ final class LegacyMigratorDatabaseTests: XCTestCase {
     func testRunIfNeededAlreadyDoneIsNoOp() {
         defaults.set(true, forKey: "LegacyMigrationDone")
         createFile(at: documentsPath + "/database.realm")
-        var importCalled = false
+        var stagingCalled = false
 
         LegacyMigrator.runIfNeeded(
             defaults: defaults,
             documentsPath: documentsPath,
-            importDatabase: { _ in
-                importCalled = true
+            stageDatabase: { _ in
+                stagingCalled = true
                 return 0
             },
         )
 
-        XCTAssertFalse(importCalled)
+        XCTAssertFalse(stagingCalled)
     }
 
     func testRunIfNeededAlwaysRunsHygieneSweepRegardlessOfBranch() {
         // A Date is one of the types the sweep still drops — GDA* keys are
         // exempt now, so they can't be used as the marker any more.
-        // Already-done branch: hygiene sweep still fires even though import is skipped.
+        // Already-done branch: hygiene sweep still fires even though staging is skipped.
         defaults.set(true, forKey: "LegacyMigrationDone")
         defaults.set(Date(), forKey: "StaleTimestamp")
         LegacyMigrator.runIfNeeded(
             defaults: defaults,
             documentsPath: documentsPath,
-            importDatabase: { _ in 0 },
+            stageDatabase: { _ in 0 },
         )
         XCTAssertNil(defaults.object(forKey: "StaleTimestamp"))
 
@@ -421,7 +432,7 @@ final class LegacyMigratorDatabaseTests: XCTestCase {
         LegacyMigrator.runIfNeeded(
             defaults: freshDefaults,
             documentsPath: documentsPath,
-            importDatabase: { _ in 0 },
+            stageDatabase: { _ in 0 },
         )
         XCTAssertNil(freshDefaults.object(forKey: "StaleTimestamp"))
     }

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -2964,4 +2964,30 @@ Please continue to report any problems, however small, through Contact Support i
     <!-- Spoken when an assistant command arrives while Soundscape is not running, and the
          command needs the running app rather than just its saved data. -->
     <string name="action_service_not_running">Open Soundscape first</string>
+    <!-- Title of the screen shown once, on the first run after upgrading from the old
+         version of Soundscape, while the markers and routes saved in it are brought
+         across. -->
+    <string name="legacy_migration_title">Importing your saved data</string>
+    <!-- Explains what is happening on the import screen, and why it isn't instant: markers
+         the old app didn't store a name for have to be looked up in the map data. -->
+    <string name="legacy_migration_description">Your markers and routes are being brought across from your previous version of Soundscape. Looking up the places they refer to can take a moment.</string>
+    <!-- Progress on the import screen. %1$s is the number imported so far, %2$s the total,
+         e.g. "8 of 23 imported". -->
+    <string name="legacy_migration_progress">%1$s of %2$s imported</string>
+    <!-- Shown on the import screen once every marker and route has been imported. -->
+    <string name="legacy_migration_complete">Your markers and routes are ready to use.</string>
+    <!-- Shown on the import screen when there is no map data to name the saved places
+         with: no internet connection, and no offline map covering them. Nothing has been
+         imported and nothing is lost - the data from the old app is still there. -->
+    <string name="legacy_migration_needs_map_data">Soundscape needs an internet connection to look up the places you saved. Connect and try again, or come back to it the next time you open Soundscape.</string>
+    <!-- Button that starts the import over, after connecting to the internet. -->
+    <string name="legacy_migration_try_again">Try again</string>
+    <!-- Button that leaves the import for later and carries on into the app. The import is
+         offered again the next time Soundscape is opened. -->
+    <string name="legacy_migration_not_now">Not now</string>
+    <!-- Shown on the import screen when the saved data couldn't be read at all. Rare, and
+         not worth retrying, so the user is pointed at support instead. -->
+    <string name="legacy_migration_failed">Your data couldn\'t be imported. Your previous version of Soundscape still has it — please contact support from Settings, Help.</string>
+    <!-- Button that leaves the import screen for the rest of the app. -->
+    <string name="legacy_migration_continue">Continue</string>
 </resources>

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/App.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/App.kt
@@ -18,6 +18,7 @@ import org.scottishtecharmy.soundscape.intents.IncomingIntent
 import org.scottishtecharmy.soundscape.locationprovider.DeviceDirection
 import org.scottishtecharmy.soundscape.locationprovider.LocationProvider
 import org.scottishtecharmy.soundscape.locationprovider.SoundscapeLocation
+import org.scottishtecharmy.soundscape.migration.LegacyImportResult
 import org.scottishtecharmy.soundscape.navigation.NavigationStateHolder
 import org.scottishtecharmy.soundscape.navigation.SharedNavHost
 import org.scottishtecharmy.soundscape.navigation.SharedRoutes
@@ -130,6 +131,15 @@ data class AppCallbacks(
      * themselves; the drawer hides the "Exit Soundscape" item when null.
      */
     val onExitApp: (() -> Unit)? = null,
+    /**
+     * Imports the markers and routes staged by the legacy iOS app, reporting progress as
+     * (done so far, total) and saying how it finished. Driven by
+     * [SharedRoutes.LEGACY_MIGRATION], which the platform only makes the start destination
+     * when there is something staged to import. Null on Android, which has no legacy app to
+     * upgrade from.
+     */
+    val onRunLegacyMigration:
+        (suspend ((done: Int, total: Int) -> Unit) -> LegacyImportResult)? = null,
 )
 
 data class AppFlows(

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/migration/LegacyMarkerNamer.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/migration/LegacyMarkerNamer.kt
@@ -1,0 +1,266 @@
+package org.scottishtecharmy.soundscape.migration
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.withContext
+import org.scottishtecharmy.soundscape.geoengine.GridState
+import org.scottishtecharmy.soundscape.geoengine.MOBILITY_KEY
+import org.scottishtecharmy.soundscape.geoengine.PLACES_AND_LANDMARKS_KEY
+import org.scottishtecharmy.soundscape.geoengine.TreeId
+import org.scottishtecharmy.soundscape.geoengine.mvttranslation.MvtFeature
+import org.scottishtecharmy.soundscape.geoengine.utils.getDistanceToFeature
+import org.scottishtecharmy.soundscape.geoengine.utils.rulers.CheapRuler
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+import org.scottishtecharmy.soundscape.i18n.LocalizedStrings
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+/** What a name lookup came back with. */
+sealed interface LegacyMarkerNameResult {
+    /**
+     * A name, along with how we arrived at it. [source] exists for logging and support: "matched
+     * OSM id" and "nearest POI, 34m away" are very different levels of confidence in the same
+     * string.
+     */
+    data class Named(val name: String, val source: String) : LegacyMarkerNameResult
+
+    /**
+     * The map data for this location was searched and holds nothing that matches. The marker
+     * falls back to the address the legacy app geocoded for it - the best answer available, and
+     * no amount of retrying will improve it.
+     */
+    data object NotFound : LegacyMarkerNameResult
+
+    /**
+     * There is no map data for this location to search: no network and no offline map covering
+     * it. Unlike [NotFound] this says nothing about the marker, so the import stops rather than
+     * name it wrongly - see [importLegacyPayload].
+     */
+    data object NoTileData : LegacyMarkerNameResult
+}
+
+/**
+ * Names a legacy marker that has no nickname of its own.
+ *
+ * Split out from [importLegacyPayload] as an interface so that the importer's tests don't need a
+ * tile server, and so the iOS entry point can decide how the tile data gets loaded.
+ */
+interface LegacyMarkerNameResolver {
+    suspend fun resolve(entityKey: String, location: LngLatAlt): LegacyMarkerNameResult
+}
+
+/**
+ * Works out what a legacy marker was called by looking up the feature it was placed on in the
+ * current tile data.
+ *
+ * ## Why this is needed
+ *
+ * The legacy app didn't store a name for a marker created from a POI - only the POI's key, e.g.
+ * `ft-443758688`. It resolved that key against its own cache of the (now retired) Soundscape tile
+ * service every time it drew the marker list, so the name never had to be persisted. We can't
+ * follow that path: the service is gone and the cache realm holding the POIs it returned may have
+ * been cleared, or may never have covered the marker in the first place. So instead we fetch the
+ * current tiles for the marker's location and look the feature up there.
+ *
+ * ## Matching by OSM id
+ *
+ * The legacy key is `ft-` followed by an OSM id, e.g. `ft-443758688`. Our tiles are built by
+ * planetiler, which encodes an OSM object as `osm_id * 10 + type`, type being 1 for a node, 2 for
+ * a way and 3 for a relation. The legacy key doesn't say which of those it was, so both the node
+ * and the way candidate are tried; within one tile grid a wrong-type collision is vanishingly
+ * unlikely. Relations aren't tried: matching against them found nothing in practice, and every
+ * marker that does match is a node or a way.
+ *
+ * OSM ids are not stable forever, though - an object that gets deleted and redrawn comes back with
+ * a new id, and the legacy data was frozen years before the tiles we fetch now. So a miss is
+ * expected often enough to need a fallback, which is [nearestNamedPoi]: the marker's coordinates
+ * are the POI's own coordinates, so whatever named feature sits at that spot today is almost
+ * always the thing the user saved.
+ */
+class TileLegacyMarkerNamer(
+    private val gridState: GridState,
+    private val strings: LocalizedStrings?,
+    private val log: (String) -> Unit = {},
+    /**
+     * Total wall-clock this namer is allowed across the whole import.
+     *
+     * Each new area costs a round of tile fetches, so a user with markers scattered across a
+     * country could otherwise be held on the migration screen for a very long time. Once the
+     * budget is gone the remaining markers fall back to their estimated address, which is what
+     * they'd have got without this lookup anyway. The screen shows progress throughout, so this
+     * is a cap on patience rather than a guard against the launch watchdog.
+     */
+    private val budget: Duration = DEFAULT_BUDGET,
+) : LegacyMarkerNameResolver {
+
+    private val started = TimeSource.Monotonic.markNow()
+    private var budgetReported = false
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override suspend fun resolve(entityKey: String, location: LngLatAlt): LegacyMarkerNameResult {
+        val spent = started.elapsedNow()
+        // A location already inside the loaded grid costs nothing but a tree search, so it's
+        // allowed through even once the budget for fetching new areas has gone. Running out of
+        // budget is [NotFound] rather than [NoTileData]: it's us giving up, not the map being
+        // unavailable, and retrying the whole import wouldn't make it finish any sooner.
+        if (spent > budget && !gridState.isLocationWithinGrid(location)) {
+            if (!budgetReported) {
+                budgetReported = true
+                log("$budget budget spent after $spent - naming the rest from their addresses")
+            }
+            return LegacyMarkerNameResult.NotFound
+        }
+
+        if (!ensureGridCovers(location)) {
+            log("no tile data for $location (offline, or outside the map) - can't name $entityKey")
+            return LegacyMarkerNameResult.NoTileData
+        }
+
+        val candidateIds = protomapsIdsForLegacyEntityKey(entityKey)
+        log("$entityKey -> protomaps id candidates $candidateIds")
+
+        return withContext(gridState.treeContext) {
+            matchByOsmId(candidateIds)
+                ?: nearestNamedPoi(location)
+                ?: LegacyMarkerNameResult.NotFound
+        }
+    }
+
+    /**
+     * Loads the tile grid around [location] if it isn't already loaded. Markers are processed in
+     * whatever order they come out of the legacy database, so consecutive markers in the same town
+     * reuse a grid and only the first of them pays for the tile fetches.
+     */
+    private suspend fun ensureGridCovers(location: LngLatAlt): Boolean {
+        if (gridState.isLocationWithinGrid(location)) return true
+
+        gridState.locationUpdate(location, ALL_CATEGORIES, strings)
+        return gridState.isLocationWithinGrid(location)
+    }
+
+    /** Must be called from within [GridState.treeContext]. */
+    private fun matchByOsmId(candidateIds: List<Long>): LegacyMarkerNameResult.Named? {
+        if (candidateIds.isEmpty()) return null
+
+        for (treeId in ID_MATCH_TREES) {
+            for (feature in gridState.getFeatureCollection(treeId)) {
+                val mvtFeature = feature as? MvtFeature ?: continue
+                if (mvtFeature.osmId !in candidateIds) continue
+
+                val text = mvtFeature.getText(strings).text
+                log("matched osmId ${mvtFeature.osmId} in ${treeId.description}: \"$text\"")
+                if (text.isNotBlank()) {
+                    return LegacyMarkerNameResult.Named(text, "OSM id matched in ${treeId.description}")
+                }
+            }
+        }
+        return null
+    }
+
+    /**
+     * Falls back to whatever named feature is at the marker's coordinates - first a polygon the
+     * marker sits inside (a park, a building), then the nearest named POI.
+     *
+     * Must be called from within [GridState.treeContext].
+     */
+    private fun nearestNamedPoi(location: LngLatAlt): LegacyMarkerNameResult.Named? {
+        val ruler = CheapRuler(location.latitude)
+        val poiTree = gridState.getFeatureTree(TreeId.POIS)
+
+        for (feature in poiTree.getContainingPolygons(location)) {
+            val mvtFeature = feature as? MvtFeature ?: continue
+            if (mvtFeature.name.isNullOrEmpty()) continue
+
+            val text = mvtFeature.getText(strings).text
+            if (text.isNotBlank()) {
+                log("no OSM id match; marker is inside \"$text\"")
+                return LegacyMarkerNameResult.Named(text, "inside named POI")
+            }
+        }
+
+        val nearby = poiTree.getNearestCollection(
+            location,
+            NEAREST_POI_SEARCH_METRES,
+            NEAREST_POI_LOG_COUNT,
+            ruler,
+            include = { !(it as MvtFeature).name.isNullOrEmpty() },
+        )
+        if (nearby.features.isEmpty()) {
+            log("no OSM id match and no named POI within ${NEAREST_POI_SEARCH_METRES}m")
+            return null
+        }
+
+        // Log the runners-up as well as the winner: when a marker comes out with the wrong name
+        // this is the list that says whether the right one was even a candidate.
+        for ((index, feature) in nearby.features.withIndex()) {
+            val distance = getDistanceToFeature(location, feature, ruler).distance
+            log(
+                "  nearby[$index] ${distance.toInt()}m ${(feature as MvtFeature).getText(strings).text}",
+            )
+        }
+
+        val nearest = nearby.features.first()
+        val distance = getDistanceToFeature(location, nearest, ruler).distance
+        val text = (nearest as MvtFeature).getText(strings).text
+        if (text.isBlank()) return null
+
+        if (distance > NEAREST_POI_ACCEPT_METRES) {
+            log("nearest named POI \"$text\" is ${distance.toInt()}m away - too far to trust")
+            return null
+        }
+
+        return LegacyMarkerNameResult.Named(text, "nearest POI, ${distance.toInt()}m away")
+    }
+
+    companion object {
+        /**
+         * Everything the grid can hold, so that a marker on a mobility POI is found even if the
+         * user has that category switched off for callouts.
+         */
+        private val ALL_CATEGORIES = setOf(PLACES_AND_LANDMARKS_KEY, MOBILITY_KEY)
+
+        /**
+         * Trees searched for an OSM id match, in order. POIs first because that's what a marker is
+         * normally placed on (transit stops are folded into that tree), then ways, for a marker
+         * saved on a road, path or waterway.
+         */
+        private val ID_MATCH_TREES = listOf(TreeId.POIS, TreeId.ROADS_AND_PATHS)
+
+        /** How far out to look for a named POI when the OSM id doesn't match anything. */
+        const val NEAREST_POI_SEARCH_METRES = 250.0
+
+        /**
+         * How close that POI has to be before we'll use its name. A marker created from a POI was
+         * stored at the POI's own coordinates, so a genuine match is metres away, not hundreds -
+         * anything further is more likely to be a different place entirely, and the marker is
+         * better off falling back to its estimated address.
+         */
+        const val NEAREST_POI_ACCEPT_METRES = 50.0
+
+        /** How many of the nearby POIs to log; only the first is ever used. */
+        private const val NEAREST_POI_LOG_COUNT = 5
+
+        /** See [budget]. */
+        val DEFAULT_BUDGET = 60.seconds
+    }
+}
+
+/**
+ * Translates a legacy `ft-<osmId>` entity key into the feature ids planetiler would have given the
+ * same OSM object as a node and as a way.
+ *
+ * Returns an empty list for keys that aren't OSM-backed at all - legacy `Address` and generic
+ * location keys are UUIDs, and there is nothing in a tile to match them against.
+ */
+internal fun protomapsIdsForLegacyEntityKey(entityKey: String): List<Long> {
+    if (!entityKey.startsWith(LEGACY_OSM_KEY_PREFIX)) return emptyList()
+    val legacyId = entityKey.removePrefix(LEGACY_OSM_KEY_PREFIX).toLongOrNull() ?: return emptyList()
+    return listOf(legacyId * 10 + PLANETILER_NODE, legacyId * 10 + PLANETILER_WAY)
+}
+
+private const val LEGACY_OSM_KEY_PREFIX = "ft-"
+
+// planetiler encodes the OSM element type in the last digit of the feature id. 3, for a relation,
+// is deliberately absent - see the note on matching in TileLegacyMarkerNamer.
+private const val PLANETILER_NODE = 1L
+private const val PLANETILER_WAY = 2L

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/migration/LegacyMigration.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/migration/LegacyMigration.kt
@@ -12,6 +12,7 @@ import org.scottishtecharmy.soundscape.database.local.dao.RouteDao
 import org.scottishtecharmy.soundscape.database.local.model.MarkerEntity
 import org.scottishtecharmy.soundscape.database.local.model.RouteEntity
 import org.scottishtecharmy.soundscape.database.local.model.RouteMarkerCrossRef
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 
 /**
  * Imports legacy markers and routes (read by the platform layer from the
@@ -22,13 +23,21 @@ import org.scottishtecharmy.soundscape.database.local.model.RouteMarkerCrossRef
  *   {
  *     "markers": [
  *       {"legacyId": "...uuid...", "name": "...", "latitude": 0.0,
- *        "longitude": 0.0, "fullAddress": "..."}
+ *        "longitude": 0.0, "fullAddress": "...", "entityKey": "ft-443758688"}
  *     ],
  *     "routes": [
  *       {"name": "...", "description": "...",
  *        "waypointLegacyIds": ["uuid1", "uuid2", ...]}
  *     ]
  *   }
+ *
+ * `name` is the legacy marker's nickname and is often empty: the legacy app
+ * only stored a name for a marker the user typed one for, and looked
+ * everything else up from `entityKey` against tile data each time it drew
+ * the list. So when there's no nickname, [resolver] is asked to name the
+ * marker from the feature that key refers to - see [TileLegacyMarkerNamer].
+ * Failing that we fall back to the estimated address the legacy app
+ * geocoded when the marker was created, and finally to "Unnamed".
  *
  * Inserts every marker, mapping its legacy UUID to the freshly generated
  * `marker_id` in a local map, then inserts each route and connects its
@@ -40,40 +49,64 @@ import org.scottishtecharmy.soundscape.database.local.model.RouteMarkerCrossRef
  * parse failure. The platform caller uses a non-negative return as the
  * cue to delete the legacy artefacts.
  */
-suspend fun importLegacyPayload(payloadJson: String, dao: RouteDao): Int {
+suspend fun importLegacyPayload(
+    payloadJson: String,
+    dao: RouteDao,
+    resolver: LegacyMarkerNameResolver? = null,
+    onProgress: ((done: Int, total: Int) -> Unit)? = null,
+): LegacyImportResult {
     val root = try {
         Json.parseToJsonElement(payloadJson).jsonObject
     } catch (t: Throwable) {
-        return -1
+        return LegacyImportResult.Unreadable
     }
 
     val markers = (root["markers"] as? JsonArray) ?: JsonArray(emptyList())
     val routes = (root["routes"] as? JsonArray) ?: JsonArray(emptyList())
 
+    // Markers can take a second or two each to name, so the screen driving this needs to know
+    // how much there is in total before the first one lands.
+    val total = markers.size + routes.size
+    onProgress?.invoke(0, total)
+
+    // Naming comes first, and in full, before anything is written. It is the only part that can
+    // fail for a reason worth retrying - a marker the legacy app never named can only be named
+    // from map data - and a half-imported database is not something we can pick up from later:
+    // re-running would duplicate whatever did land. So if the map data isn't there, nothing is
+    // written at all and the user is asked to try again once they're back online.
+    val named = mutableListOf<NamedLegacyMarker>()
+    for ((index, element) in markers.withIndex()) {
+        val marker = (element as? JsonObject)?.let(::readLegacyMarker) ?: continue
+
+        val name = when (val result = nameForMarker(marker, resolver)) {
+            is LegacyMarkerNameResult.Named -> result.name
+            LegacyMarkerNameResult.NoTileData -> return LegacyImportResult.NeedsMapData
+            LegacyMarkerNameResult.NotFound -> marker.fullAddress.ifBlank { UNNAMED }
+        }
+
+        named.add(NamedLegacyMarker(marker, name))
+        onProgress?.invoke(index + 1, total)
+    }
+
     val legacyToNewMarkerId = mutableMapOf<String, Long>()
     var imported = 0
 
-    for (element in markers) {
-        val obj = element as? JsonObject ?: continue
-        val legacyId = obj["legacyId"]?.jsonPrimitive?.contentOrNull ?: continue
-        val name = obj["name"]?.jsonPrimitive?.contentOrNull ?: continue
-        val latitude = obj["latitude"]?.jsonPrimitive?.doubleOrNull ?: continue
-        val longitude = obj["longitude"]?.jsonPrimitive?.doubleOrNull ?: continue
-        val fullAddress = obj["fullAddress"]?.jsonPrimitive?.contentOrNull ?: ""
-
+    for ((marker, name) in named) {
         val newId = dao.insertMarker(
             MarkerEntity(
                 name = name,
-                longitude = longitude,
-                latitude = latitude,
-                fullAddress = fullAddress,
+                longitude = marker.longitude,
+                latitude = marker.latitude,
+                fullAddress = marker.fullAddress,
             ),
         )
-        legacyToNewMarkerId[legacyId] = newId
+        legacyToNewMarkerId[marker.legacyId] = newId
         imported++
     }
 
-    for (element in routes) {
+    for ((index, element) in routes.withIndex()) {
+        onProgress?.invoke(markers.size + index + 1, total)
+
         val obj = element as? JsonObject ?: continue
         val name = obj["name"]?.jsonPrimitive?.contentOrNull ?: continue
         val description = obj["description"]?.jsonPrimitive?.contentOrNull ?: ""
@@ -91,17 +124,87 @@ suspend fun importLegacyPayload(payloadJson: String, dao: RouteDao): Int {
         val newRouteId = dao.insertRoute(
             RouteEntity(name = name, description = description),
         )
-        resolvedMarkerIds.forEachIndexed { index, markerId ->
+        resolvedMarkerIds.forEachIndexed { order, markerId ->
             dao.addMarkerToRoute(
                 RouteMarkerCrossRef(
                     routeId = newRouteId,
                     markerId = markerId,
-                    markerOrder = index,
+                    markerOrder = order,
                 ),
             )
         }
         imported++
     }
 
-    return imported
+    onProgress?.invoke(total, total)
+    return LegacyImportResult.Imported(imported)
 }
+
+/** How [importLegacyPayload] finished. */
+sealed interface LegacyImportResult {
+    /** Everything staged is now in the database. [count] is the markers plus routes written. */
+    data class Imported(val count: Int) : LegacyImportResult
+
+    /**
+     * Nothing was written, because markers needing a name couldn't be looked up: no network and
+     * no offline map covering them. Worth retrying once the user is back online.
+     */
+    data object NeedsMapData : LegacyImportResult
+
+    /** The staged payload isn't valid JSON. Retrying won't help. */
+    data object Unreadable : LegacyImportResult
+}
+
+/** A marker as the legacy app stored it, before we work out what to call it. */
+private data class LegacyMarker(
+    val legacyId: String,
+    val nickname: String,
+    val latitude: Double,
+    val longitude: Double,
+    val fullAddress: String,
+    val entityKey: String,
+)
+
+private data class NamedLegacyMarker(val marker: LegacyMarker, val name: String)
+
+/** Reads one marker out of the payload, or null if it's missing a field we can't do without. */
+private fun readLegacyMarker(obj: JsonObject): LegacyMarker? = LegacyMarker(
+    legacyId = obj["legacyId"]?.jsonPrimitive?.contentOrNull ?: return null,
+    nickname = obj["name"]?.jsonPrimitive?.contentOrNull ?: return null,
+    latitude = obj["latitude"]?.jsonPrimitive?.doubleOrNull ?: return null,
+    longitude = obj["longitude"]?.jsonPrimitive?.doubleOrNull ?: return null,
+    fullAddress = obj["fullAddress"]?.jsonPrimitive?.contentOrNull ?: "",
+    entityKey = obj["entityKey"]?.jsonPrimitive?.contentOrNull ?: "",
+)
+
+/**
+ * Works out what to call an imported marker.
+ *
+ * The legacy nickname wins whenever there is one - it's what the user typed. Otherwise the marker
+ * was created from a POI and named by lookup, so we ask [resolver] to do the same lookup against
+ * current tile data. Markers with no `entityKey` were plain coordinates in the legacy app and have
+ * no feature to look up, so there is nothing to ask about.
+ */
+private suspend fun nameForMarker(
+    marker: LegacyMarker,
+    resolver: LegacyMarkerNameResolver?,
+): LegacyMarkerNameResult {
+    if (marker.nickname.isNotBlank()) {
+        return LegacyMarkerNameResult.Named(marker.nickname, "legacy nickname")
+    }
+
+    if (marker.entityKey.isBlank() || resolver == null) {
+        return LegacyMarkerNameResult.NotFound
+    }
+
+    return try {
+        resolver.resolve(marker.entityKey, LngLatAlt(marker.longitude, marker.latitude))
+    } catch (t: Throwable) {
+        // A lookup that breaks isn't a lookup that couldn't reach the map - treat it as this one
+        // marker having no name rather than stopping the whole import on it.
+        println("LegacyMigration: naming ${marker.entityKey} failed: $t")
+        LegacyMarkerNameResult.NotFound
+    }
+}
+
+private const val UNNAMED = "Unnamed"

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/navigation/SharedNavGraph.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/navigation/SharedNavGraph.kt
@@ -66,6 +66,7 @@ import org.scottishtecharmy.soundscape.screens.markers_routes.screens.addandedit
 import org.scottishtecharmy.soundscape.screens.markers_routes.screens.markersscreen.MarkersScreen
 import org.scottishtecharmy.soundscape.screens.markers_routes.screens.routedetailsscreen.SharedRouteDetailsScreen
 import org.scottishtecharmy.soundscape.screens.markers_routes.screens.routesscreen.RoutesScreen
+import org.scottishtecharmy.soundscape.screens.migration.LegacyMigrationScreen
 import org.scottishtecharmy.soundscape.screens.onboarding.SharedOnboardingNavHost
 import org.scottishtecharmy.soundscape.screens.onboarding.welcome.Welcome
 
@@ -152,6 +153,20 @@ fun SharedNavHost(
                         preferencesProvider.putBoolean(PreferenceKeys.FIRST_LAUNCH, false)
                         navController.navigate(SharedRoutes.HOME) {
                             popUpTo(SharedRoutes.ONBOARDING) { inclusive = true }
+                        }
+                    },
+                )
+            }
+        }
+
+        composable(SharedRoutes.LEGACY_MIGRATION) {
+            val runImport = callbacks.onRunLegacyMigration
+            if (runImport != null) {
+                LegacyMigrationScreen(
+                    runImport = runImport,
+                    onContinue = {
+                        navController.navigate(SharedRoutes.HOME) {
+                            popUpTo(SharedRoutes.LEGACY_MIGRATION) { inclusive = true }
                         }
                     },
                 )

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/navigation/SharedRoutes.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/navigation/SharedRoutes.kt
@@ -18,6 +18,13 @@ object SharedRoutes {
     const val EDIT_ROUTE = "edit_route"
     const val OFFLINE_MAPS = "offline_maps"
     const val ONBOARDING = "onboarding"
+
+    /**
+     * One-shot screen shown on the first run after upgrading from the legacy iOS app, while
+     * its markers and routes are imported. Not part of onboarding: an upgrading user has
+     * already been through that and never sees it again.
+     */
+    const val LEGACY_MIGRATION = "legacy_migration"
     const val SLEEP = "sleep_screen"
     const val HELP = "help_screen"
     const val OPEN_SOURCE_LICENSES = "open_source_licenses"

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/home/home/AdvancedMarkersAndRoutesSettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/home/home/AdvancedMarkersAndRoutesSettingsViewModel.kt
@@ -6,12 +6,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.scottishtecharmy.soundscape.database.local.dao.RouteDao
-import org.scottishtecharmy.soundscape.database.local.model.MarkerEntity
-import org.scottishtecharmy.soundscape.database.local.model.RouteEntity
-import org.scottishtecharmy.soundscape.database.local.model.RouteWithMarkers
+import org.scottishtecharmy.soundscape.utils.GLOBAL_MARKERS_FILE_ROOT
 import org.scottishtecharmy.soundscape.utils.MarkersAndRoutesIo
-import org.scottishtecharmy.soundscape.utils.NamedGpx
-import org.scottishtecharmy.soundscape.utils.parseGpxFile
+import org.scottishtecharmy.soundscape.utils.buildMarkersAndRoutesArchive
+import org.scottishtecharmy.soundscape.utils.restoreMarkersAndRoutesArchive
 
 open class AdvancedMarkersAndRoutesSettingsViewModel(
     private val routeDao: RouteDao,
@@ -30,25 +28,11 @@ open class AdvancedMarkersAndRoutesSettingsViewModel(
 
     fun exportMarkersAndRoutes(shareTitle: String) {
         viewModelScope.launch {
-            // Export a zip containing one GPX per route plus a single GPX with
-            // all standalone markers, so users can inspect the data in other
-            // tools rather than dealing with an opaque database file.
-            val routes = routeDao.getAllRoutesWithMarkers()
-            val markers = routeDao.getAllMarkers()
-            val allMarkersRoute = RouteWithMarkers(
-                route = RouteEntity(0, GLOBAL_MARKERS_NAME, ""),
-                markers = markers,
-            )
-
-            val files = mutableListOf<NamedGpx>()
-            val usedNames = mutableMapOf<String, Int>()
-            files += namedGpxFor(allMarkersRoute, usedNames)
-            for (route in routes) {
-                files += namedGpxFor(route, usedNames)
-            }
-
+            // The archive is a zip of GPX rather than an opaque database file so users can
+            // inspect and edit their data in other tools. Building it is shared with the iCloud
+            // backup, which stores the same archive by a different route.
             io.exportGpxZip(
-                files = files,
+                files = buildMarkersAndRoutesArchive(routeDao),
                 suggestedFilename = "soundscape-routes-export",
                 shareTitle = shareTitle,
             )
@@ -65,40 +49,8 @@ open class AdvancedMarkersAndRoutesSettingsViewModel(
             }
             if (files == null) return@launch
             try {
-                var routeCount = 0
-                for (file in files) {
-                    val parsed = parseGpxFile(file.content) ?: continue
-                    if (file.filename.contains(GLOBAL_MARKERS_NAME)) {
-                        // Merge standalone markers first so per-route imports
-                        // can reuse them via insertRouteWithNewMarkers below.
-                        for (it in parsed.markers) {
-                            val existingMarker =
-                                routeDao.getMarkerByLocation(it.longitude, it.latitude)
-                            if (existingMarker == null) {
-                                routeDao.insertMarker(it)
-                            } else {
-                                routeDao.updateMarker(
-                                    MarkerEntity(
-                                        markerId = existingMarker.markerId,
-                                        name = it.name,
-                                        fullAddress = it.fullAddress,
-                                        longitude = existingMarker.longitude,
-                                        latitude = existingMarker.latitude,
-                                    ),
-                                )
-                            }
-                        }
-                        if (parsed.markers.isNotEmpty()) routeCount += 1
-                    } else {
-                        val newRoute = RouteEntity(
-                            name = parsed.route.name,
-                            description = parsed.route.description,
-                        )
-                        routeDao.insertRouteWithNewMarkers(newRoute, parsed.markers)
-                        if (parsed.markers.isNotEmpty()) routeCount += 1
-                    }
-                }
-                _userFeedback.value = if (routeCount > 0) successString else failureString
+                val restored = restoreMarkersAndRoutesArchive(files, routeDao)
+                _userFeedback.value = if (restored > 0) successString else failureString
             } catch (e: Exception) {
                 println("Failed to import zip: ${e.message}")
                 _userFeedback.value = failureString
@@ -110,43 +62,11 @@ open class AdvancedMarkersAndRoutesSettingsViewModel(
         _userFeedback.value = ""
     }
 
-    private fun namedGpxFor(
-        route: RouteWithMarkers,
-        usedNames: MutableMap<String, Int>,
-    ): NamedGpx {
-        var fileRoot = sanitizeFilename(route.route.name)
-        val current = usedNames[fileRoot]
-        if (current == null) {
-            usedNames[fileRoot] = 0
-        } else {
-            usedNames[fileRoot] = current + 1
-            fileRoot = "${fileRoot}_${current + 1}"
-        }
-        return NamedGpx(filename = "$fileRoot.gpx", content = generateGpxString(route))
-    }
-
-    private fun generateGpxString(route: RouteWithMarkers): String = buildString {
-        append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
-        append("<gpx version=\"1.1\" creator=\"Soundscape\">\n")
-        append("  <metadata>\n")
-        append("    <name>${route.route.name}</name>\n")
-        append("    <desc>${route.route.description}</desc>\n")
-        append("  </metadata>\n")
-        for (marker in route.markers) {
-            append("      <wpt lat=\"${marker.latitude}\" lon=\"${marker.longitude}\">\n")
-            append("        <name>${marker.name}</name>\n")
-            append("        <desc>${marker.fullAddress}</desc>\n")
-            append("      </wpt>\n")
-        }
-        append("</gpx>")
-    }
-
     companion object {
-        const val GLOBAL_MARKERS_NAME = "AllSoundscapeDatabaseMarkersInASingleRoute"
+        /**
+         * Kept as an alias of [GLOBAL_MARKERS_FILE_ROOT] so callers and tests that already refer
+         * to it here don't have to move.
+         */
+        const val GLOBAL_MARKERS_NAME = GLOBAL_MARKERS_FILE_ROOT
     }
 }
-
-private val INVALID_FILENAME_CHARS = Regex("[/\\\\:*?\"<>|\\x00]")
-
-private fun sanitizeFilename(name: String): String =
-    name.replace(INVALID_FILENAME_CHARS, "_").take(100)

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/migration/LegacyMigrationScreen.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/screens/migration/LegacyMigrationScreen.kt
@@ -1,0 +1,242 @@
+package org.scottishtecharmy.soundscape.screens.migration
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import org.jetbrains.compose.resources.stringResource
+import org.scottishtecharmy.soundscape.components.OnboardButton
+import org.scottishtecharmy.soundscape.migration.LegacyImportResult
+import org.scottishtecharmy.soundscape.resources.Res
+import org.scottishtecharmy.soundscape.resources.legacy_migration_complete
+import org.scottishtecharmy.soundscape.resources.legacy_migration_continue
+import org.scottishtecharmy.soundscape.resources.legacy_migration_description
+import org.scottishtecharmy.soundscape.resources.legacy_migration_failed
+import org.scottishtecharmy.soundscape.resources.legacy_migration_needs_map_data
+import org.scottishtecharmy.soundscape.resources.legacy_migration_not_now
+import org.scottishtecharmy.soundscape.resources.legacy_migration_progress
+import org.scottishtecharmy.soundscape.resources.legacy_migration_title
+import org.scottishtecharmy.soundscape.resources.legacy_migration_try_again
+import org.scottishtecharmy.soundscape.screens.onboarding.component.BoxWithGradientBackground
+import org.scottishtecharmy.soundscape.ui.theme.spacing
+
+/** What the import is doing, as far as the screen is concerned. */
+sealed interface LegacyMigrationUiState {
+    data class Running(val done: Int, val total: Int) : LegacyMigrationUiState
+
+    data class Finished(val imported: Int) : LegacyMigrationUiState
+
+    /** Nothing was imported for want of map data; offer to try again. */
+    data object NeedsMapData : LegacyMigrationUiState
+
+    data object Failed : LegacyMigrationUiState
+}
+
+/**
+ * Shown once, on the first run after an upgrade from the legacy iOS app, while its markers and
+ * routes are imported.
+ *
+ * The import used to run inside the app's `init()`, before any UI existed. That was fine while it
+ * was a local database copy, but naming markers means fetching map tiles for each area the user
+ * saved something in, and blocking launch on the network is how an app gets killed by the
+ * watchdog. So it happens here instead, where it can take the time it needs and say what it's
+ * doing.
+ *
+ * Deliberately not part of onboarding, which an upgrading user has already completed and will
+ * never be shown again.
+ *
+ * [runImport] reports progress as it goes and says how it finished. Naming a marker needs map
+ * data, and when there is none to be had the import writes nothing at all rather than save a pile
+ * of markers under the wrong names - a half-import can't be resumed later without duplicating
+ * what already landed. That case offers the user a retry once they're connected, and stays on
+ * offer the next time they open the app.
+ */
+@Composable
+fun LegacyMigrationScreen(
+    runImport: suspend ((done: Int, total: Int) -> Unit) -> LegacyImportResult,
+    onContinue: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var state by remember {
+        mutableStateOf<LegacyMigrationUiState>(LegacyMigrationUiState.Running(0, 0))
+    }
+    var attempt by remember { mutableStateOf(0) }
+
+    LaunchedEffect(attempt) {
+        state = LegacyMigrationUiState.Running(0, 0)
+        state = when (val result = runImport { done, total ->
+            state = LegacyMigrationUiState.Running(done, total)
+        }) {
+            is LegacyImportResult.Imported -> LegacyMigrationUiState.Finished(result.count)
+            LegacyImportResult.NeedsMapData -> LegacyMigrationUiState.NeedsMapData
+            LegacyImportResult.Unreadable -> LegacyMigrationUiState.Failed
+        }
+    }
+
+    LegacyMigrationScreenContent(
+        state = state,
+        onRetry = { attempt++ },
+        onContinue = onContinue,
+        modifier = modifier,
+    )
+}
+
+/**
+ * The screen itself, separated from running the import so it can be previewed and tested in each
+ * of its states.
+ */
+@Composable
+fun LegacyMigrationScreenContent(
+    state: LegacyMigrationUiState,
+    onRetry: () -> Unit,
+    onContinue: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val titleFocusRequester = remember { FocusRequester() }
+    val continueFocusRequester = remember { FocusRequester() }
+
+    BoxWithGradientBackground(color = MaterialTheme.colorScheme.surface) {
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .fillMaxHeight()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = spacing.large),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Text(
+                text = stringResource(Res.string.legacy_migration_title),
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.focusRequester(titleFocusRequester).focusable(),
+            )
+
+            Spacer(modifier = Modifier.height(spacing.small))
+
+            Text(
+                text = stringResource(Res.string.legacy_migration_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.focusable(),
+            )
+
+            Spacer(modifier = Modifier.height(spacing.large))
+
+            // One live region covering whichever line of status applies, so a screen reader
+            // announces the outcome without the user having to go looking for it. Progress
+            // counts up as markers are imported, and the same region then reads the result.
+            val status = when (state) {
+                is LegacyMigrationUiState.Running -> stringResource(
+                    Res.string.legacy_migration_progress,
+                    state.done.toString(),
+                    state.total.toString(),
+                )
+
+                is LegacyMigrationUiState.Finished ->
+                    stringResource(Res.string.legacy_migration_complete)
+
+                LegacyMigrationUiState.NeedsMapData ->
+                    stringResource(Res.string.legacy_migration_needs_map_data)
+
+                LegacyMigrationUiState.Failed -> stringResource(Res.string.legacy_migration_failed)
+            }
+
+            if (state is LegacyMigrationUiState.Running) {
+                CircularProgressIndicator(color = MaterialTheme.colorScheme.onSurface)
+                Spacer(modifier = Modifier.height(spacing.medium))
+            }
+
+            Text(
+                text = status,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .semantics { liveRegion = LiveRegionMode.Polite }
+                    .focusable()
+                    .testTag("legacyMigrationStatus"),
+            )
+
+            if (state !is LegacyMigrationUiState.Running) {
+                Spacer(modifier = Modifier.height(spacing.large))
+
+                if (state is LegacyMigrationUiState.NeedsMapData) {
+                    OnboardButton(
+                        text = stringResource(Res.string.legacy_migration_try_again),
+                        onClick = onRetry,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .focusRequester(continueFocusRequester)
+                            .focusable()
+                            .testTag("legacyMigrationRetryButton"),
+                    )
+
+                    Spacer(modifier = Modifier.height(spacing.small))
+                }
+
+                // Leaving without importing is always allowed. Being held on this screen with no
+                // way past it would lock a user out of the app entirely for as long as they have
+                // no signal - and the import is still waiting for them next time either way.
+                OnboardButton(
+                    text = if (state is LegacyMigrationUiState.NeedsMapData) {
+                        stringResource(Res.string.legacy_migration_not_now)
+                    } else {
+                        stringResource(Res.string.legacy_migration_continue)
+                    },
+                    onClick = onContinue,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .then(
+                            if (state is LegacyMigrationUiState.NeedsMapData) {
+                                Modifier
+                            } else {
+                                Modifier.focusRequester(continueFocusRequester)
+                            },
+                        )
+                        .focusable()
+                        .testTag("legacyMigrationContinueButton"),
+                )
+
+                // Move focus onto the first button as soon as it appears, so a screen reader user
+                // isn't left on a progress line that has stopped changing.
+                LaunchedEffect(state) {
+                    withFrameNanos { }
+                    continueFocusRequester.requestFocus()
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        withFrameNanos { }
+        titleFocusRequester.requestFocus()
+    }
+}

--- a/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/utils/MarkersAndRoutesArchive.kt
+++ b/shared/src/commonMain/kotlin/org/scottishtecharmy/soundscape/utils/MarkersAndRoutesArchive.kt
@@ -1,0 +1,204 @@
+package org.scottishtecharmy.soundscape.utils
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.scottishtecharmy.soundscape.database.local.dao.RouteDao
+import org.scottishtecharmy.soundscape.database.local.model.MarkerEntity
+import org.scottishtecharmy.soundscape.database.local.model.RouteEntity
+import org.scottishtecharmy.soundscape.database.local.model.RouteWithMarkers
+
+/**
+ * The user's whole marker and route library as a set of GPX documents: one per route, plus one
+ * holding every marker that isn't on a route.
+ *
+ * GPX rather than a database dump so users can open their data in other tools, and because it is
+ * the format the app already imports. This is the archive itself - how it reaches its destination
+ * is somebody else's problem. Settings → Advanced markers and routes zips it and hands it to a
+ * share sheet; the iCloud backup wraps the same archive in a JSON envelope and stores it as a
+ * single key.
+ */
+const val GLOBAL_MARKERS_FILE_ROOT = "AllSoundscapeDatabaseMarkersInASingleRoute"
+
+/** Reads the whole library out of [dao] as GPX documents. */
+suspend fun buildMarkersAndRoutesArchive(dao: RouteDao): List<NamedGpx> {
+    val routes = dao.getAllRoutesWithMarkers()
+    val markers = dao.getAllMarkers()
+    val allMarkersRoute = RouteWithMarkers(
+        route = RouteEntity(0, GLOBAL_MARKERS_FILE_ROOT, ""),
+        markers = markers,
+    )
+
+    val files = mutableListOf<NamedGpx>()
+    val usedNames = mutableMapOf<String, Int>()
+    files += namedGpxFor(allMarkersRoute, usedNames)
+    for (route in routes) {
+        files += namedGpxFor(route, usedNames)
+    }
+    return files
+}
+
+/**
+ * Writes an archive back into [dao], returning the number of GPX documents that contributed
+ * anything.
+ *
+ * Markers are merged by location rather than duplicated, so re-importing an archive over a library
+ * that already holds some of it updates those markers instead of doubling them up. Documents that
+ * don't parse are skipped - recovering most of an archive beats recovering none of it.
+ */
+suspend fun restoreMarkersAndRoutesArchive(files: List<NamedGpx>, dao: RouteDao): Int {
+    var restored = 0
+    for (file in files) {
+        val parsed = parseGpxFile(file.content) ?: continue
+        if (file.filename.contains(GLOBAL_MARKERS_FILE_ROOT)) {
+            // Standalone markers are merged first so the per-route documents below can reuse
+            // them via insertRouteWithNewMarkers.
+            for (marker in parsed.markers) {
+                val existingMarker = dao.getMarkerByLocation(marker.longitude, marker.latitude)
+                if (existingMarker == null) {
+                    dao.insertMarker(marker)
+                } else {
+                    dao.updateMarker(
+                        MarkerEntity(
+                            markerId = existingMarker.markerId,
+                            name = marker.name,
+                            fullAddress = marker.fullAddress,
+                            longitude = existingMarker.longitude,
+                            latitude = existingMarker.latitude,
+                        ),
+                    )
+                }
+            }
+            if (parsed.markers.isNotEmpty()) restored += 1
+        } else {
+            val newRoute = RouteEntity(
+                name = parsed.route.name,
+                description = parsed.route.description,
+            )
+            dao.insertRouteWithNewMarkers(newRoute, parsed.markers)
+            if (parsed.markers.isNotEmpty()) restored += 1
+        }
+    }
+    return restored
+}
+
+private fun namedGpxFor(
+    route: RouteWithMarkers,
+    usedNames: MutableMap<String, Int>,
+): NamedGpx {
+    var fileRoot = sanitizeFilename(route.route.name)
+    val current = usedNames[fileRoot]
+    if (current == null) {
+        usedNames[fileRoot] = 0
+    } else {
+        usedNames[fileRoot] = current + 1
+        fileRoot = "${fileRoot}_${current + 1}"
+    }
+    return NamedGpx(filename = "$fileRoot.gpx", content = generateGpxString(route))
+}
+
+internal fun generateGpxString(route: RouteWithMarkers): String = buildString {
+    append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+    append("<gpx version=\"1.1\" creator=\"Soundscape\">\n")
+    append("  <metadata>\n")
+    append("    <name>${escapeXml(route.route.name)}</name>\n")
+    append("    <desc>${escapeXml(route.route.description)}</desc>\n")
+    append("  </metadata>\n")
+    for (marker in route.markers) {
+        append("      <wpt lat=\"${marker.latitude}\" lon=\"${marker.longitude}\">\n")
+        append("        <name>${escapeXml(marker.name)}</name>\n")
+        append("        <desc>${escapeXml(marker.fullAddress)}</desc>\n")
+        append("      </wpt>\n")
+    }
+    append("</gpx>")
+}
+
+/**
+ * Escapes text going into a GPX element.
+ *
+ * Markers are named by the user and by map data, so "Bob & Alice" and "<no name>" both turn up.
+ * Without this they produce a document that isn't XML at all, which the parser rejects on the way
+ * back in - the marker isn't mangled, the whole file is lost.
+ */
+private fun escapeXml(text: String): String = buildString(text.length) {
+    for (character in text) {
+        when (character) {
+            '&' -> append("&amp;")
+            '<' -> append("&lt;")
+            '>' -> append("&gt;")
+            else -> append(character)
+        }
+    }
+}
+
+private val INVALID_FILENAME_CHARS = Regex("[/\\\\:*?\"<>|\\x00]")
+
+private fun sanitizeFilename(name: String): String =
+    name.replace(INVALID_FILENAME_CHARS, "_").take(100)
+
+/**
+ * Packs an archive into a single string, for destinations that store one value rather than a
+ * folder of files - the iCloud key-value store, principally.
+ *
+ * A JSON envelope around the GPX rather than a zip because the destination wants text and because
+ * the archives involved are tens of kilobytes; compressing them would buy little and cost the
+ * ability to read a backup by eye when diagnosing one.
+ */
+fun encodeArchiveEnvelope(files: List<NamedGpx>): String {
+    val document = buildJsonObject {
+        put(ENVELOPE_KEY_VERSION, ARCHIVE_ENVELOPE_VERSION)
+        put(
+            ENVELOPE_KEY_FILES,
+            buildJsonArray {
+                for (file in files) {
+                    add(
+                        buildJsonObject {
+                            put(ENVELOPE_KEY_FILENAME, file.filename)
+                            put(ENVELOPE_KEY_GPX, file.content)
+                        },
+                    )
+                }
+            },
+        )
+    }
+    return document.toString()
+}
+
+/** Unpacks [encodeArchiveEnvelope], or returns null if the string isn't one. */
+fun decodeArchiveEnvelope(json: String): List<NamedGpx>? {
+    val root = try {
+        Json.parseToJsonElement(json) as? JsonObject ?: return null
+    } catch (t: Throwable) {
+        return null
+    }
+
+    val version = root[ENVELOPE_KEY_VERSION]?.jsonPrimitive?.intOrNull ?: return null
+    if (version > ARCHIVE_ENVELOPE_VERSION) {
+        // Written by a newer version of the app. Restoring the parts we understand would quietly
+        // drop whatever it added, so refuse rather than half-restore.
+        return null
+    }
+
+    val files = root[ENVELOPE_KEY_FILES] as? JsonArray ?: return null
+    return files.mapNotNull { element ->
+        val obj = element as? JsonObject ?: return@mapNotNull null
+        NamedGpx(
+            filename = obj[ENVELOPE_KEY_FILENAME]?.jsonPrimitive?.contentOrNull
+                ?: return@mapNotNull null,
+            content = obj[ENVELOPE_KEY_GPX]?.jsonPrimitive?.contentOrNull
+                ?: return@mapNotNull null,
+        )
+    }
+}
+
+private const val ARCHIVE_ENVELOPE_VERSION = 1
+private const val ENVELOPE_KEY_VERSION = "version"
+private const val ENVELOPE_KEY_FILES = "files"
+private const val ENVELOPE_KEY_FILENAME = "filename"
+private const val ENVELOPE_KEY_GPX = "gpx"

--- a/shared/src/commonTest/kotlin/org/scottishtecharmy/soundscape/database/local/dao/FakeRouteDao.kt
+++ b/shared/src/commonTest/kotlin/org/scottishtecharmy/soundscape/database/local/dao/FakeRouteDao.kt
@@ -1,0 +1,91 @@
+package org.scottishtecharmy.soundscape.database.local.dao
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.scottishtecharmy.soundscape.database.local.model.MarkerEntity
+import org.scottishtecharmy.soundscape.database.local.model.RouteEntity
+import org.scottishtecharmy.soundscape.database.local.model.RouteMarkerCrossRef
+
+/**
+ * In-memory [RouteDao] for tests that need a database without having one. Shared by the advanced
+ * settings tests and the archive round-trip tests, which both drive whole libraries through it.
+ */
+internal class FakeRouteDao : RouteDao {
+    private var nextMarkerId = 1L
+    private var nextRouteId = 1L
+
+    val markersFlow = MutableStateFlow<List<MarkerEntity>>(emptyList())
+    val routesFlow = MutableStateFlow<List<RouteEntity>>(emptyList())
+    val crossRefs = mutableListOf<RouteMarkerCrossRef>()
+
+    override suspend fun insertMarker(marker: MarkerEntity): Long {
+        val id = if (marker.markerId != 0L) marker.markerId else nextMarkerId++
+        val stored = MarkerEntity(id, marker.name, marker.longitude, marker.latitude, marker.fullAddress)
+        markersFlow.value = markersFlow.value.filterNot { it.markerId == id } + stored
+        return id
+    }
+
+    override suspend fun updateMarker(marker: MarkerEntity) {
+        markersFlow.value = markersFlow.value.map { if (it.markerId == marker.markerId) marker else it }
+    }
+
+    override suspend fun getMarkerById(markerId: Long): MarkerEntity? =
+        markersFlow.value.find { it.markerId == markerId }
+
+    override suspend fun getMarkerByLocation(longitude: Double, latitude: Double): MarkerEntity? =
+        markersFlow.value.find { it.longitude == longitude && it.latitude == latitude }
+
+    override suspend fun getAllMarkers(): List<MarkerEntity> = markersFlow.value
+
+    override fun getAllMarkersFlow(): Flow<List<MarkerEntity>> = markersFlow
+
+    override suspend fun insertRoute(route: RouteEntity): Long {
+        val id = if (route.routeId != 0L) route.routeId else nextRouteId++
+        val stored = RouteEntity(id, route.name, route.description)
+        routesFlow.value = routesFlow.value.filterNot { it.routeId == id } + stored
+        return id
+    }
+
+    override suspend fun addMarkerToRoute(crossRef: RouteMarkerCrossRef) {
+        crossRefs.add(crossRef)
+    }
+
+    override suspend fun removeMarkerFromRoute(routeId: Long, markerId: Long) {
+        crossRefs.removeAll { it.routeId == routeId && it.markerId == markerId }
+    }
+
+    override suspend fun removeMarkersForRoute(routeId: Long) {
+        crossRefs.removeAll { it.routeId == routeId }
+    }
+
+    override suspend fun getAllRoutes(): List<RouteEntity> = routesFlow.value
+
+    override suspend fun getRouteById(routeId: Long): RouteEntity? =
+        routesFlow.value.find { it.routeId == routeId }
+
+    override suspend fun getMarkerCrossReference(routeId: Long): List<RouteMarkerCrossRef> =
+        crossRefs.filter { it.routeId == routeId }
+
+    override fun getAllRoutesFlow(): Flow<List<RouteEntity>> = routesFlow
+
+    override suspend fun removeRoute(routeId: Long) {
+        routesFlow.value = routesFlow.value.filterNot { it.routeId == routeId }
+        crossRefs.removeAll { it.routeId == routeId }
+    }
+
+    override suspend fun removeMarker(markerId: Long) {
+        markersFlow.value = markersFlow.value.filterNot { it.markerId == markerId }
+    }
+
+    override suspend fun deleteAllRouteMarkerCrossRefs() {
+        crossRefs.clear()
+    }
+
+    override suspend fun deleteAllMarkers() {
+        markersFlow.value = emptyList()
+    }
+
+    override suspend fun deleteAllRoutes() {
+        routesFlow.value = emptyList()
+    }
+}

--- a/shared/src/commonTest/kotlin/org/scottishtecharmy/soundscape/migration/LegacyMigrationTest.kt
+++ b/shared/src/commonTest/kotlin/org/scottishtecharmy/soundscape/migration/LegacyMigrationTest.kt
@@ -8,10 +8,13 @@ import org.scottishtecharmy.soundscape.database.local.model.MarkerEntity
 import org.scottishtecharmy.soundscape.database.local.model.RouteEntity
 import org.scottishtecharmy.soundscape.database.local.model.RouteMarkerCrossRef
 import org.scottishtecharmy.soundscape.database.local.model.RouteWithMarkers
+import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 /**
  * Exercises [importLegacyPayload] against a hand-rolled in-memory
@@ -43,7 +46,7 @@ class LegacyMigrationTest {
             }
         """.trimIndent()
 
-        val count = importLegacyPayload(json, dao)
+        val count = importedCount(json, dao)
 
         assertEquals(2, count)
         val markers = dao.getAllMarkers().sortedBy { it.name }
@@ -70,7 +73,7 @@ class LegacyMigrationTest {
             }
         """.trimIndent()
 
-        val count = importLegacyPayload(json, dao)
+        val count = importedCount(json, dao)
 
         // 3 markers + 1 route
         assertEquals(4, count)
@@ -125,7 +128,7 @@ class LegacyMigrationTest {
             }
         """.trimIndent()
 
-        val count = importLegacyPayload(json, dao)
+        val count = importedCount(json, dao)
 
         // 1 marker + 1 successful route. The "Broken" route is dropped.
         assertEquals(2, count)
@@ -136,7 +139,7 @@ class LegacyMigrationTest {
 
     @Test
     fun emptyPayloadIsAcceptedAndImportsNothing() = runTest {
-        val count = importLegacyPayload("""{"markers":[], "routes":[]}""", dao)
+        val count = importedCount("""{"markers":[], "routes":[]}""", dao)
         assertEquals(0, count)
         assertEquals(0, dao.getAllMarkers().size)
         assertEquals(0, dao.routesById.size)
@@ -144,14 +147,13 @@ class LegacyMigrationTest {
 
     @Test
     fun missingMarkersOrRoutesArrayDefaultsToEmpty() = runTest {
-        val count = importLegacyPayload("""{}""", dao)
+        val count = importedCount("""{}""", dao)
         assertEquals(0, count)
     }
 
     @Test
-    fun malformedJsonReturnsNegativeOne() = runTest {
-        val count = importLegacyPayload("not json", dao)
-        assertEquals(-1, count)
+    fun malformedJsonIsReportedAsUnreadable() = runTest {
+        assertEquals(LegacyImportResult.Unreadable, importLegacyPayload("not json", dao))
     }
 
     @Test
@@ -167,13 +169,243 @@ class LegacyMigrationTest {
             }
         """.trimIndent()
 
-        val count = importLegacyPayload(json, dao)
+        val count = importedCount(json, dao)
 
         // Only the well-formed marker is imported; partial rows are dropped.
         assertEquals(1, count)
         val all = dao.getAllMarkers()
         assertEquals(1, all.size)
         assertNotNull(all.firstOrNull { it.name == "ok" })
+    }
+
+    // MARK: naming markers the legacy app never stored a name for
+
+    @Test
+    fun markerWithoutNicknameIsNamedByTheResolver() = runTest {
+        val resolver = FakeNameResolver("ft-443758688" to "Kilmardinny Loch")
+        val json = """
+            {
+              "markers": [
+                {"legacyId": "m1", "name": "", "latitude": 55.93, "longitude": -4.33,
+                 "fullAddress": "Near Milngavie Road", "entityKey": "ft-443758688"}
+              ],
+              "routes": []
+            }
+        """.trimIndent()
+
+        importLegacyPayload(json, dao, resolver)
+
+        assertEquals(listOf("Kilmardinny Loch"), dao.getAllMarkers().map { it.name })
+        // The resolver is asked about the marker's own coordinates, since that's where the
+        // feature it refers to should be.
+        assertEquals(listOf("ft-443758688" to LngLatAlt(-4.33, 55.93)), resolver.asked)
+    }
+
+    @Test
+    fun nicknameWinsAndTheResolverIsNotAsked() = runTest {
+        val resolver = FakeNameResolver("ft-1" to "Some POI")
+        val json = """
+            {
+              "markers": [
+                {"legacyId": "m1", "name": "Home", "latitude": 0.0, "longitude": 0.0,
+                 "fullAddress": "", "entityKey": "ft-1"}
+              ],
+              "routes": []
+            }
+        """.trimIndent()
+
+        importLegacyPayload(json, dao, resolver)
+
+        assertEquals(listOf("Home"), dao.getAllMarkers().map { it.name })
+        assertTrue(resolver.asked.isEmpty())
+    }
+
+    @Test
+    fun unresolvableEntityKeyFallsBackToTheEstimatedAddress() = runTest {
+        val resolver = FakeNameResolver()
+        val json = """
+            {
+              "markers": [
+                {"legacyId": "m1", "name": "", "latitude": 0.0, "longitude": 0.0,
+                 "fullAddress": "12 Roman Road", "entityKey": "ft-999"}
+              ],
+              "routes": []
+            }
+        """.trimIndent()
+
+        importLegacyPayload(json, dao, resolver)
+
+        assertEquals(listOf("12 Roman Road"), dao.getAllMarkers().map { it.name })
+    }
+
+    @Test
+    fun markerWithNothingToGoOnBecomesUnnamed() = runTest {
+        val json = """
+            {
+              "markers": [
+                {"legacyId": "m1", "name": "", "latitude": 0.0, "longitude": 0.0,
+                 "fullAddress": "", "entityKey": ""}
+              ],
+              "routes": []
+            }
+        """.trimIndent()
+
+        importLegacyPayload(json, dao, FakeNameResolver())
+
+        assertEquals(listOf("Unnamed"), dao.getAllMarkers().map { it.name })
+    }
+
+    @Test
+    fun markerWithoutAnEntityKeyIsNotLookedUp() = runTest {
+        val resolver = FakeNameResolver()
+        val json = """
+            {
+              "markers": [
+                {"legacyId": "m1", "name": "", "latitude": 0.0, "longitude": 0.0,
+                 "fullAddress": "12 Roman Road"}
+              ],
+              "routes": []
+            }
+        """.trimIndent()
+
+        importLegacyPayload(json, dao, resolver)
+
+        assertEquals(listOf("12 Roman Road"), dao.getAllMarkers().map { it.name })
+        assertTrue(resolver.asked.isEmpty())
+    }
+
+    @Test
+    fun aResolverThatThrowsDoesNotFailTheImport() = runTest {
+        val json = """
+            {
+              "markers": [
+                {"legacyId": "m1", "name": "", "latitude": 0.0, "longitude": 0.0,
+                 "fullAddress": "12 Roman Road", "entityKey": "ft-1"}
+              ],
+              "routes": []
+            }
+        """.trimIndent()
+
+        val count = importedCount(
+            json,
+            dao,
+            object : LegacyMarkerNameResolver {
+                override suspend fun resolve(
+                    entityKey: String,
+                    location: LngLatAlt,
+                ): LegacyMarkerNameResult = throw IllegalStateException("broken")
+            },
+        )
+
+        assertEquals(1, count)
+        assertEquals(listOf("12 Roman Road"), dao.getAllMarkers().map { it.name })
+    }
+
+    // MARK: no map data to name markers with
+
+    @Test
+    fun noMapDataImportsNothingAtAll() = runTest {
+        val json = """
+            {
+              "markers": [
+                {"legacyId": "m1", "name": "Home", "latitude": 0.0, "longitude": 0.0,
+                 "fullAddress": "", "entityKey": ""},
+                {"legacyId": "m2", "name": "", "latitude": 55.93, "longitude": -4.33,
+                 "fullAddress": "Near Milngavie Road", "entityKey": "ft-443758688"}
+              ],
+              "routes": [
+                {"name": "Loop", "description": "", "waypointLegacyIds": ["m1", "m2"]}
+              ]
+            }
+        """.trimIndent()
+
+        val result = importLegacyPayload(json, dao, NoMapDataResolver)
+
+        assertEquals(LegacyImportResult.NeedsMapData, result)
+        // Not even the marker that was already named, nor the route: a half-imported database
+        // can't be resumed without duplicating whatever landed, so the retry has to start clean.
+        assertEquals(0, dao.getAllMarkers().size)
+        assertEquals(0, dao.routesById.size)
+    }
+
+    @Test
+    fun retryingAfterNoMapDataImportsEverythingExactlyOnce() = runTest {
+        val json = """
+            {
+              "markers": [
+                {"legacyId": "m1", "name": "", "latitude": 55.93, "longitude": -4.33,
+                 "fullAddress": "Near Milngavie Road", "entityKey": "ft-443758688"}
+              ],
+              "routes": []
+            }
+        """.trimIndent()
+
+        assertEquals(LegacyImportResult.NeedsMapData, importLegacyPayload(json, dao, NoMapDataResolver))
+
+        val connected = FakeNameResolver("ft-443758688" to "Kilmardinny Loch")
+        assertEquals(1, importedCount(json, dao, connected))
+        assertEquals(listOf("Kilmardinny Loch"), dao.getAllMarkers().map { it.name })
+    }
+
+    @Test
+    fun markersThatNeedNoLookupImportWithNoMapDataAtAll() = runTest {
+        // Nothing asks the resolver anything, so being offline is neither here nor there.
+        val json = """
+            {
+              "markers": [
+                {"legacyId": "m1", "name": "Home", "latitude": 0.0, "longitude": 0.0,
+                 "fullAddress": "", "entityKey": ""},
+                {"legacyId": "m2", "name": "", "latitude": 0.0, "longitude": 0.0,
+                 "fullAddress": "12 Roman Road", "entityKey": ""}
+              ],
+              "routes": []
+            }
+        """.trimIndent()
+
+        assertEquals(2, importedCount(json, dao, NoMapDataResolver))
+        assertEquals(listOf("12 Roman Road", "Home"), dao.getAllMarkers().map { it.name }.sorted())
+    }
+
+    @Test
+    fun aKeyThatIsSimplyNotInTheMapDataFallsBackInsteadOfStopping() = runTest {
+        // NotFound is the map data answering "no such thing", which no retry will change - unlike
+        // NoTileData, which is not having asked at all.
+        val json = """
+            {
+              "markers": [
+                {"legacyId": "m1", "name": "", "latitude": 0.0, "longitude": 0.0,
+                 "fullAddress": "12 Roman Road", "entityKey": "ft-1"}
+              ],
+              "routes": []
+            }
+        """.trimIndent()
+
+        assertEquals(1, importedCount(json, dao, FakeNameResolver()))
+        assertEquals(listOf("12 Roman Road"), dao.getAllMarkers().map { it.name })
+    }
+
+    // MARK: legacy entity key -> planetiler feature id
+
+    @Test
+    fun aLegacyKeyBecomesItsNodeAndWayCandidates() {
+        // planetiler encodes an OSM object as id * 10 + type (1 node, 2 way). The legacy key
+        // doesn't record which the object was, so both are tried.
+        assertEquals(listOf(4437586881L, 4437586882L), protomapsIdsForLegacyEntityKey("ft-443758688"))
+    }
+
+    @Test
+    fun keysThatArentOsmIdsHaveNoCandidates() {
+        // Legacy Address and generic-location keys are UUIDs, with nothing in a tile to match.
+        assertEquals(emptyList(), protomapsIdsForLegacyEntityKey("6E7B9A00-0000-0000-0000-000000000000"))
+        assertEquals(emptyList(), protomapsIdsForLegacyEntityKey("ft-notanumber"))
+        assertEquals(emptyList(), protomapsIdsForLegacyEntityKey(""))
+    }
+
+    @Test
+    fun theDashIsPartOfThePrefix() {
+        // "ft" alone isn't the prefix: without the dash the remainder parses as a negative id
+        // and every candidate would be wrong.
+        assertEquals(emptyList(), protomapsIdsForLegacyEntityKey("ft443758688"))
     }
 
     @Test
@@ -189,10 +421,49 @@ class LegacyMigrationTest {
             }
         """.trimIndent()
 
-        val count = importLegacyPayload(json, dao)
+        val count = importedCount(json, dao)
 
         assertEquals(1, count) // marker only
         assertEquals(0, dao.routesById.size)
+    }
+}
+
+/**
+ * Runs the import and asserts it succeeded, returning the count. Most tests are about what lands
+ * in the database rather than how the import reports itself finishing.
+ */
+private suspend fun importedCount(
+    payloadJson: String,
+    dao: RouteDao,
+    resolver: LegacyMarkerNameResolver? = null,
+): Int = assertIs<LegacyImportResult.Imported>(
+    importLegacyPayload(payloadJson, dao, resolver),
+).count
+
+/** A resolver for a device with no connection and no offline map. */
+private object NoMapDataResolver : LegacyMarkerNameResolver {
+    override suspend fun resolve(entityKey: String, location: LngLatAlt) =
+        LegacyMarkerNameResult.NoTileData
+}
+
+/**
+ * Stands in for the tile lookup. Answers from a fixed map of entity key to name and records
+ * what it was asked, so tests can assert that the importer only reaches for it when there's no
+ * nickname to use.
+ */
+private class FakeNameResolver(
+    private vararg val names: Pair<String, String>,
+) : LegacyMarkerNameResolver {
+    val asked = mutableListOf<Pair<String, LngLatAlt>>()
+
+    override suspend fun resolve(
+        entityKey: String,
+        location: LngLatAlt,
+    ): LegacyMarkerNameResult {
+        asked.add(entityKey to location)
+        val name = names.firstOrNull { it.first == entityKey }?.second
+            ?: return LegacyMarkerNameResult.NotFound
+        return LegacyMarkerNameResult.Named(name, "fake")
     }
 }
 

--- a/shared/src/commonTest/kotlin/org/scottishtecharmy/soundscape/screens/home/home/AdvancedMarkersAndRoutesSettingsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/org/scottishtecharmy/soundscape/screens/home/home/AdvancedMarkersAndRoutesSettingsViewModelTest.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import org.scottishtecharmy.soundscape.database.local.dao.RouteDao
+import org.scottishtecharmy.soundscape.database.local.dao.FakeRouteDao
 import org.scottishtecharmy.soundscape.database.local.model.MarkerEntity
 import org.scottishtecharmy.soundscape.database.local.model.RouteEntity
 import org.scottishtecharmy.soundscape.database.local.model.RouteMarkerCrossRef
@@ -21,85 +21,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-private class FakeRouteDao : RouteDao {
-    private var nextMarkerId = 1L
-    private var nextRouteId = 1L
-
-    val markersFlow = MutableStateFlow<List<MarkerEntity>>(emptyList())
-    val routesFlow = MutableStateFlow<List<RouteEntity>>(emptyList())
-    val crossRefs = mutableListOf<RouteMarkerCrossRef>()
-
-    override suspend fun insertMarker(marker: MarkerEntity): Long {
-        val id = if (marker.markerId != 0L) marker.markerId else nextMarkerId++
-        val stored = MarkerEntity(id, marker.name, marker.longitude, marker.latitude, marker.fullAddress)
-        markersFlow.value = markersFlow.value.filterNot { it.markerId == id } + stored
-        return id
-    }
-
-    override suspend fun updateMarker(marker: MarkerEntity) {
-        markersFlow.value = markersFlow.value.map { if (it.markerId == marker.markerId) marker else it }
-    }
-
-    override suspend fun getMarkerById(markerId: Long): MarkerEntity? =
-        markersFlow.value.find { it.markerId == markerId }
-
-    override suspend fun getMarkerByLocation(longitude: Double, latitude: Double): MarkerEntity? =
-        markersFlow.value.find { it.longitude == longitude && it.latitude == latitude }
-
-    override suspend fun getAllMarkers(): List<MarkerEntity> = markersFlow.value
-
-    override fun getAllMarkersFlow(): Flow<List<MarkerEntity>> = markersFlow
-
-    override suspend fun insertRoute(route: RouteEntity): Long {
-        val id = if (route.routeId != 0L) route.routeId else nextRouteId++
-        val stored = RouteEntity(id, route.name, route.description)
-        routesFlow.value = routesFlow.value.filterNot { it.routeId == id } + stored
-        return id
-    }
-
-    override suspend fun addMarkerToRoute(crossRef: RouteMarkerCrossRef) {
-        crossRefs.add(crossRef)
-    }
-
-    override suspend fun removeMarkerFromRoute(routeId: Long, markerId: Long) {
-        crossRefs.removeAll { it.routeId == routeId && it.markerId == markerId }
-    }
-
-    override suspend fun removeMarkersForRoute(routeId: Long) {
-        crossRefs.removeAll { it.routeId == routeId }
-    }
-
-    override suspend fun getAllRoutes(): List<RouteEntity> = routesFlow.value
-
-    override suspend fun getRouteById(routeId: Long): RouteEntity? =
-        routesFlow.value.find { it.routeId == routeId }
-
-    override suspend fun getMarkerCrossReference(routeId: Long): List<RouteMarkerCrossRef> =
-        crossRefs.filter { it.routeId == routeId }
-
-    override fun getAllRoutesFlow(): Flow<List<RouteEntity>> = routesFlow
-
-    override suspend fun removeRoute(routeId: Long) {
-        routesFlow.value = routesFlow.value.filterNot { it.routeId == routeId }
-        crossRefs.removeAll { it.routeId == routeId }
-    }
-
-    override suspend fun removeMarker(markerId: Long) {
-        markersFlow.value = markersFlow.value.filterNot { it.markerId == markerId }
-    }
-
-    override suspend fun deleteAllRouteMarkerCrossRefs() {
-        crossRefs.clear()
-    }
-
-    override suspend fun deleteAllMarkers() {
-        markersFlow.value = emptyList()
-    }
-
-    override suspend fun deleteAllRoutes() {
-        routesFlow.value = emptyList()
-    }
-}
 
 private class FakeMarkersAndRoutesIo : MarkersAndRoutesIo {
     var exportedFiles: List<NamedGpx>? = null

--- a/shared/src/commonTest/kotlin/org/scottishtecharmy/soundscape/utils/MarkersAndRoutesArchiveTest.kt
+++ b/shared/src/commonTest/kotlin/org/scottishtecharmy/soundscape/utils/MarkersAndRoutesArchiveTest.kt
@@ -1,0 +1,163 @@
+package org.scottishtecharmy.soundscape.utils
+
+import kotlinx.coroutines.test.runTest
+import org.scottishtecharmy.soundscape.database.local.model.MarkerEntity
+import org.scottishtecharmy.soundscape.database.local.model.RouteEntity
+import org.scottishtecharmy.soundscape.database.local.model.RouteMarkerCrossRef
+import org.scottishtecharmy.soundscape.database.local.dao.FakeRouteDao
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The archive is what both Settings → Advanced markers and routes and the iCloud backup store, so
+ * what matters is that a library survives the round trip intact.
+ */
+class MarkersAndRoutesArchiveTest {
+
+    @Test
+    fun aLibrarySurvivesTheRoundTrip() = runTest {
+        val source = FakeRouteDao()
+        val stop = source.insertMarker(
+            MarkerEntity(name = "Stop 1", longitude = 1.0, latitude = 2.0, fullAddress = "A road"),
+        )
+        val routeId = source.insertRoute(RouteEntity(name = "Loop", description = "scenic"))
+        source.addMarkerToRoute(RouteMarkerCrossRef(routeId, stop, 0))
+        source.insertMarker(MarkerEntity(name = "Standalone", longitude = 3.0, latitude = 4.0))
+
+        val restored = FakeRouteDao()
+        restoreMarkersAndRoutesArchive(buildMarkersAndRoutesArchive(source), restored)
+
+        assertEquals(
+            listOf("Standalone", "Stop 1"),
+            restored.getAllMarkers().map { it.name }.sorted(),
+        )
+        val route = restored.getAllRoutesWithMarkers().single()
+        assertEquals("Loop", route.route.name)
+        assertEquals("scenic", route.route.description)
+        assertEquals(listOf("Stop 1"), route.markers.map { it.name })
+        assertEquals("A road", restored.getAllMarkers().first { it.name == "Stop 1" }.fullAddress)
+    }
+
+    @Test
+    fun waypointOrderIsPreserved() = runTest {
+        val source = FakeRouteDao()
+        val first = source.insertMarker(MarkerEntity(name = "First", longitude = 1.0, latitude = 1.0))
+        val second = source.insertMarker(MarkerEntity(name = "Second", longitude = 2.0, latitude = 2.0))
+        val third = source.insertMarker(MarkerEntity(name = "Third", longitude = 3.0, latitude = 3.0))
+        val routeId = source.insertRoute(RouteEntity(name = "Ordered", description = ""))
+        source.addMarkerToRoute(RouteMarkerCrossRef(routeId, third, 2))
+        source.addMarkerToRoute(RouteMarkerCrossRef(routeId, first, 0))
+        source.addMarkerToRoute(RouteMarkerCrossRef(routeId, second, 1))
+
+        val restored = FakeRouteDao()
+        restoreMarkersAndRoutesArchive(buildMarkersAndRoutesArchive(source), restored)
+
+        assertEquals(
+            listOf("First", "Second", "Third"),
+            restored.getAllRoutesWithMarkers().single().markers.map { it.name },
+        )
+    }
+
+    /**
+     * Users name markers, and so does map data - "Marks & Spencer" is a real shop. Unescaped, the
+     * ampersand makes the GPX invalid and the parser drops the entire document, taking every other
+     * marker in it with it.
+     */
+    @Test
+    fun namesWithXmlSyntaxInThemSurviveTheRoundTrip() = runTest {
+        val source = FakeRouteDao()
+        source.insertMarker(
+            MarkerEntity(
+                name = "Marks & Spencer",
+                longitude = 1.0,
+                latitude = 2.0,
+                fullAddress = "<no address> \"quoted\"",
+            ),
+        )
+        source.insertMarker(MarkerEntity(name = "Ordinary", longitude = 3.0, latitude = 4.0))
+
+        val restored = FakeRouteDao()
+        restoreMarkersAndRoutesArchive(buildMarkersAndRoutesArchive(source), restored)
+
+        val markers = restored.getAllMarkers()
+        assertEquals(2, markers.size, "the whole document is lost if one name breaks the XML")
+        val awkward = markers.first { it.name.startsWith("Marks") }
+        assertEquals("Marks & Spencer", awkward.name)
+        assertEquals("<no address> \"quoted\"", awkward.fullAddress)
+    }
+
+    @Test
+    fun anEmptyLibraryRoundTripsToAnEmptyOne() = runTest {
+        val restored = FakeRouteDao()
+        restoreMarkersAndRoutesArchive(buildMarkersAndRoutesArchive(FakeRouteDao()), restored)
+
+        assertEquals(0, restored.getAllMarkers().size)
+        assertEquals(0, restored.getAllRoutes().size)
+    }
+
+    // MARK: the single-string envelope the iCloud backup stores
+
+    @Test
+    fun theEnvelopeRoundTripsAnArchive() = runTest {
+        val source = FakeRouteDao()
+        source.insertMarker(MarkerEntity(name = "Home", longitude = 1.0, latitude = 2.0))
+        val archive = buildMarkersAndRoutesArchive(source)
+
+        val decoded = decodeArchiveEnvelope(encodeArchiveEnvelope(archive))
+
+        assertNotNull(decoded)
+        assertEquals(archive.map { it.filename }, decoded.map { it.filename })
+        assertEquals(archive.map { it.content }, decoded.map { it.content })
+    }
+
+    @Test
+    fun aLibraryRestoresFromItsEnvelope() = runTest {
+        val source = FakeRouteDao()
+        source.insertMarker(MarkerEntity(name = "Home", longitude = 1.0, latitude = 2.0))
+
+        val envelope = encodeArchiveEnvelope(buildMarkersAndRoutesArchive(source))
+        val restored = FakeRouteDao()
+        restoreMarkersAndRoutesArchive(assertNotNull(decodeArchiveEnvelope(envelope)), restored)
+
+        assertEquals(listOf("Home"), restored.getAllMarkers().map { it.name })
+    }
+
+    @Test
+    fun somethingThatIsntAnEnvelopeIsRejected() {
+        assertNull(decodeArchiveEnvelope("not json"))
+        assertNull(decodeArchiveEnvelope("{}"))
+        assertNull(decodeArchiveEnvelope("""{"version": 1}"""))
+    }
+
+    @Test
+    fun anEnvelopeFromANewerAppIsRefusedRatherThanHalfRestored() {
+        // Restoring only the parts this version understands would quietly drop whatever the newer
+        // one added, and the user would have no way of knowing.
+        assertNull(decodeArchiveEnvelope("""{"version": 99, "files": []}"""))
+    }
+
+    @Test
+    fun theEnvelopeIsSmallEnoughForICloud() = runTest {
+        // iCloud allows 1 MB per key. This is the ceiling that governs how large a library can be
+        // backed up, so it's worth knowing roughly where it sits.
+        val source = FakeRouteDao()
+        repeat(1000) { index ->
+            source.insertMarker(
+                MarkerEntity(
+                    name = "Marker number $index",
+                    longitude = index.toDouble(),
+                    latitude = index.toDouble(),
+                    fullAddress = "$index Some Reasonably Long Street Name, A Town",
+                ),
+            )
+        }
+
+        val bytes = encodeArchiveEnvelope(buildMarkersAndRoutesArchive(source))
+            .encodeToByteArray().size
+
+        assertTrue(bytes < 900 * 1024, "1000 markers came to $bytes bytes")
+    }
+}

--- a/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/IosSoundscapeService.kt
+++ b/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/IosSoundscapeService.kt
@@ -13,6 +13,8 @@ import org.scottishtecharmy.soundscape.actions.ActionResult
 import org.scottishtecharmy.soundscape.actions.SoundscapeAction
 import org.scottishtecharmy.soundscape.actions.SoundscapeActionExecutor
 import org.scottishtecharmy.soundscape.audio.AudioTour
+import org.scottishtecharmy.soundscape.backup.IosCloudBackup
+import org.scottishtecharmy.soundscape.migration.hasPendingLegacyMigration
 import org.scottishtecharmy.soundscape.audio.AudioTourHost
 import org.scottishtecharmy.soundscape.audio.BeaconPreviewController
 import org.scottishtecharmy.soundscape.audio.AudioType
@@ -212,6 +214,32 @@ class IosSoundscapeService : GeoEngineListener, MediaControllableService, Servic
     var onMarkersOrRoutesChanged: (() -> Unit)? = null
 
     /**
+     * Keeps the user's markers and routes in iCloud so that deleting the app or replacing a phone
+     * doesn't lose them. See [IosCloudBackup] for what it does and doesn't promise.
+     */
+    private val cloudBackup = IosCloudBackup(
+        dao = routeDao,
+        scope = scope,
+        // The legacy import fills an empty library too, from a payload staged before the app
+        // opened. Whichever of the two would go first, letting both run gives the user two of
+        // everything, so the backup stands aside until the import has been dealt with.
+        canRestore = { !hasPendingLegacyMigration() },
+        onRestored = { onMarkersOrRoutesChanged?.invoke() },
+    )
+
+    /**
+     * Announces that the user's markers or routes have changed: tells Swift, so it can rebuild the
+     * vocabulary Siri matches names against, and refreshes the iCloud backup.
+     *
+     * Everything that writes markers or routes goes through here rather than calling the two
+     * separately, so a new write path can't quietly stop being backed up.
+     */
+    private suspend fun markersOrRoutesChanged() {
+        onMarkersOrRoutesChanged?.invoke()
+        cloudBackup.backupNow()
+    }
+
+    /**
      * Runs an action and drops the result. For the AppCallbacks lambdas, which are
      * plain (String) -> Unit with no scope of their own — this keeps them off a
      * freshly-allocated CoroutineScope per call. Swift's App Intents await
@@ -355,6 +383,7 @@ class IosSoundscapeService : GeoEngineListener, MediaControllableService, Servic
         geoEngine.setHeadTrackingProvider(headTrackingProvider)
         applyHeadTrackingEnabled()
         observeAppLifecycle()
+        cloudBackup.start()
     }
 
     private fun observeAppLifecycle() {
@@ -519,7 +548,7 @@ class IosSoundscapeService : GeoEngineListener, MediaControllableService, Servic
                 } else {
                     routeDao.insertRouteWithNewMarkers(route, markers)
                 }
-                onMarkersOrRoutesChanged?.invoke()
+                markersOrRoutesChanged()
                 audioEngine.createEarcon(
                     "file:///android_asset/Sounds/sense_poi.wav",
                     org.scottishtecharmy.soundscape.audio.AudioType.STANDARD
@@ -554,7 +583,7 @@ class IosSoundscapeService : GeoEngineListener, MediaControllableService, Servic
             try {
                 routeDao.removeMarkersForRoute(routeId)
                 routeDao.removeRoute(routeId)
-                onMarkersOrRoutesChanged?.invoke()
+                markersOrRoutesChanged()
             } catch (e: Exception) {
                 println("IosSoundscapeService: Failed to delete route: ${e.message}")
             }
@@ -582,7 +611,7 @@ class IosSoundscapeService : GeoEngineListener, MediaControllableService, Servic
                 } else {
                     routeDao.insertMarker(marker)
                 }
-                onMarkersOrRoutesChanged?.invoke()
+                markersOrRoutesChanged()
                 audioEngine.createEarcon(
                     "file:///android_asset/Sounds/sense_poi.wav",
                     org.scottishtecharmy.soundscape.audio.AudioType.STANDARD
@@ -597,7 +626,7 @@ class IosSoundscapeService : GeoEngineListener, MediaControllableService, Servic
         scope.launch {
             try {
                 routeDao.removeMarker(markerId)
-                onMarkersOrRoutesChanged?.invoke()
+                markersOrRoutesChanged()
             } catch (e: Exception) {
                 println("IosSoundscapeService: Failed to delete marker: ${e.message}")
             }

--- a/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/MainViewController.kt
+++ b/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/MainViewController.kt
@@ -15,6 +15,8 @@ import org.scottishtecharmy.soundscape.actions.SoundscapeAction
 import org.scottishtecharmy.soundscape.audio.TourButton
 import org.scottishtecharmy.soundscape.audio.availableTtsVoicesForCurrentLanguage
 import org.scottishtecharmy.soundscape.geojsonparser.geojson.LngLatAlt
+import org.scottishtecharmy.soundscape.migration.hasPendingLegacyMigration
+import org.scottishtecharmy.soundscape.migration.runPendingLegacyMigration
 import org.scottishtecharmy.soundscape.navigation.SharedRoutes
 import org.scottishtecharmy.soundscape.platform.readResourceText
 import org.scottishtecharmy.soundscape.preferences.PreferenceDefaults
@@ -56,7 +58,16 @@ fun MainViewController() = ComposeUIViewController {
     val isFirstLaunch = remember {
         prefs.getBoolean(PreferenceKeys.FIRST_LAUNCH, PreferenceDefaults.FIRST_LAUNCH)
     }
-    val startDestination = if (isFirstLaunch) SharedRoutes.ONBOARDING else SharedRoutes.HOME
+    // An upgrade from the legacy app takes precedence over both: the user has markers and routes
+    // waiting to be imported, and importing them needs the network, so it gets a screen of its own
+    // rather than blocking launch. They aren't a first-launch user - onboarding was completed in
+    // the old app - so this is the only extra screen they ever see. See LegacyMigration.kt.
+    val hasLegacyImport = remember { hasPendingLegacyMigration() }
+    val startDestination = when {
+        hasLegacyImport -> SharedRoutes.LEGACY_MIGRATION
+        isFirstLaunch -> SharedRoutes.ONBOARDING
+        else -> SharedRoutes.HOME
+    }
 
     // First-launch users grant location permission from the onboarding permissions screen.
     // For returning users, ask now so the location provider can resume — iOS no-ops if the
@@ -318,6 +329,7 @@ fun MainViewController() = ComposeUIViewController {
             onBeaconPreviewStop = { commit, chosen ->
                 service.stopBeaconPreview(commit, chosen)
             },
+            onRunLegacyMigration = { onProgress -> runPendingLegacyMigration(onProgress) },
         ),
         startDestination = startDestination,
         audioEngine = service.audioEngine,

--- a/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/backup/IosCloudBackup.kt
+++ b/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/backup/IosCloudBackup.kt
@@ -1,0 +1,151 @@
+package org.scottishtecharmy.soundscape.backup
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.scottishtecharmy.soundscape.database.local.dao.RouteDao
+import org.scottishtecharmy.soundscape.utils.buildMarkersAndRoutesArchive
+import org.scottishtecharmy.soundscape.utils.decodeArchiveEnvelope
+import org.scottishtecharmy.soundscape.utils.encodeArchiveEnvelope
+import org.scottishtecharmy.soundscape.utils.restoreMarkersAndRoutesArchive
+import platform.Foundation.NSNotification
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSOperationQueue
+import platform.Foundation.NSUbiquitousKeyValueStore
+import platform.Foundation.NSUbiquitousKeyValueStoreDidChangeExternallyNotification
+
+/**
+ * Keeps a copy of the user's markers and routes in iCloud, so that deleting the app, replacing a
+ * phone or restoring a device doesn't lose them.
+ *
+ * Backup rather than sync. The document is the same archive Settings → Advanced markers and routes
+ * exports - see `buildMarkersAndRoutesArchive` - wrapped in a JSON envelope and stored under one
+ * key. It is rewritten whole every time anything changes, so a deleted marker is gone from the
+ * next backup without any deletion bookkeeping.
+ *
+ * The whole-document approach only works because Soundscape is a single-device app in practice.
+ * Two devices editing between backups would have one overwrite the other's changes wholesale.
+ * Making that safe means per-record identity and a merge, which is a great deal of machinery for a
+ * case we don't have.
+ *
+ * ## Restoring
+ *
+ * Only ever into an empty library, and never over data the user can see. That rule is what makes
+ * this safe to run automatically: the worst case is that a restore doesn't happen, not that it
+ * overwrites something.
+ *
+ * The initial download from iCloud is asynchronous and usually lands *after* launch, so a fresh
+ * install typically finds nothing on the first look. [start] therefore also listens for the
+ * store's change notification and tries again when the data arrives.
+ */
+class IosCloudBackup(
+    private val dao: RouteDao,
+    private val scope: CoroutineScope,
+    private val store: NSUbiquitousKeyValueStore = NSUbiquitousKeyValueStore.defaultStore,
+    /**
+     * Whether restoring is allowed at all right now. The legacy import also fills an empty
+     * library, from data staged before the app opened, so the two must not both run - the user
+     * would end up with each marker twice.
+     */
+    private val canRestore: () -> Boolean = { true },
+    private val onRestored: (Int) -> Unit = {},
+) {
+    private var observer: Any? = null
+
+    /**
+     * Starts watching iCloud, and restores now if there is something there and nothing here.
+     *
+     * Safe to call when the user has no iCloud account: the store just stays empty, reads return
+     * null and writes go nowhere.
+     */
+    fun start() {
+        observer = NSNotificationCenter.defaultCenter.addObserverForName(
+            name = NSUbiquitousKeyValueStoreDidChangeExternallyNotification,
+            `object` = store,
+            queue = NSOperationQueue.mainQueue,
+        ) { _: NSNotification? ->
+            // Anything arriving from iCloud is either the initial download on a new install or
+            // another device's backup. Either way the only thing we do with it is restore into an
+            // empty library.
+            scope.launch { restoreIfLibraryEmpty() }
+        }
+
+        store.synchronize()
+        scope.launch { restoreIfLibraryEmpty() }
+    }
+
+    fun stop() {
+        observer?.let { NSNotificationCenter.defaultCenter.removeObserver(it) }
+        observer = null
+    }
+
+    /**
+     * Replaces the backup with the library as it stands. Called whenever markers or routes change.
+     */
+    suspend fun backupNow() {
+        val archive = try {
+            encodeArchiveEnvelope(buildMarkersAndRoutesArchive(dao))
+        } catch (t: Throwable) {
+            println("IosCloudBackup: could not build archive: $t")
+            return
+        }
+
+        val size = archive.encodeToByteArray().size
+        if (size > MAX_VALUE_BYTES) {
+            // iCloud's per-key ceiling is 1 MB and it rejects the write outright, so there is
+            // nothing to do but say so. It takes thousands of markers to get here.
+            println("IosCloudBackup: archive is $size bytes, over the ${MAX_VALUE_BYTES} limit - not backed up")
+            return
+        }
+
+        store.setString(archive, forKey = ARCHIVE_KEY)
+        store.synchronize()
+        println("IosCloudBackup: backed up $size bytes")
+    }
+
+    /**
+     * Restores the backup if there is one and the library is empty, returning how many GPX
+     * documents were restored.
+     *
+     * The emptiness check is deliberately of the database rather than of a "have I restored yet"
+     * flag: a flag can be lost or wrong, whereas an empty library is the actual condition under
+     * which restoring can't destroy anything.
+     */
+    suspend fun restoreIfLibraryEmpty(): Int {
+        val json = store.stringForKey(ARCHIVE_KEY) ?: return 0
+
+        if (!canRestore()) return 0
+        if (dao.getAllMarkers().isNotEmpty() || dao.getAllRoutes().isNotEmpty()) return 0
+
+        val files = decodeArchiveEnvelope(json)
+        if (files == null) {
+            println("IosCloudBackup: backup could not be read")
+            return 0
+        }
+
+        val restored = try {
+            restoreMarkersAndRoutesArchive(files, dao)
+        } catch (t: Throwable) {
+            println("IosCloudBackup: restore failed: $t")
+            return 0
+        }
+
+        if (restored > 0) {
+            println("IosCloudBackup: restored $restored documents from iCloud")
+            onRestored(restored)
+        }
+        return restored
+    }
+
+    private companion object {
+        /**
+         * Deliberately unlike the legacy app's `marker.*` and `route.*` keys. We share a bundle
+         * identifier with it and may therefore share its key-value store, and overwriting the
+         * legacy app's own backup would break a rollback - the one thing the whole migration is
+         * careful not to do.
+         */
+        const val ARCHIVE_KEY = "soundscape.markersAndRoutes.archive"
+
+        /** iCloud allows 1 MB per key; stay under it with room for the store's own overhead. */
+        const val MAX_VALUE_BYTES = 900 * 1024
+    }
+}

--- a/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/migration/LegacyMigration.kt
+++ b/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/migration/LegacyMigration.kt
@@ -1,18 +1,145 @@
 package org.scottishtecharmy.soundscape.migration
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.newSingleThreadContext
+import okio.FileSystem
+import okio.Path.Companion.toPath
 import org.scottishtecharmy.soundscape.database.local.MarkersAndRoutesDatabaseProvider
+import org.scottishtecharmy.soundscape.geoengine.ProtomapsGridState
+import org.scottishtecharmy.soundscape.i18n.ComposeLocalizedStrings
+import org.scottishtecharmy.soundscape.network.createIosVectorTileClient
+import platform.Foundation.NSBundle
+import platform.Foundation.NSHomeDirectory
 
 /**
- * Swift entry point for the legacy data migration. The full description
- * of the JSON contract and import semantics lives on
- * `importLegacyPayload` in commonMain.
+ * The legacy import, in two halves.
  *
- * Wraps the suspend importer in `runBlocking` so the Swift caller can
- * sequence cleanup of the legacy Realm files only after a successful
- * return.
+ * Reading the legacy Realm database is quick and entirely local, so LegacyMigrator.swift still
+ * does it during app launch and hands the result here to be [staged][stageLegacyMigrationPayload]
+ * as a file. Writing it into Room is not quick: markers the legacy app never stored a name for
+ * have to be looked up in map tiles, which means the network. That half runs later, from the
+ * migration screen, where it can take its time and tell the user what it's doing - see
+ * [runPendingLegacyMigration] and `LegacyMigrationScreen`.
+ *
+ * The staged file is the record of work outstanding: it is written before the import and deleted
+ * only once the import has been written to the database, so an app killed midway through launch
+ * still has everything it needs to try again.
  */
-fun runLegacyMigrationImport(payloadJson: String): Int = runBlocking {
+private val payloadPath
+    get() = (NSHomeDirectory() + "/Documents/" + PAYLOAD_FILE_NAME).toPath()
+
+/** Where an unparseable payload is parked, so it stops being retried but is still recoverable. */
+private val failedPayloadPath
+    get() = (NSHomeDirectory() + "/Documents/" + FAILED_PAYLOAD_FILE_NAME).toPath()
+
+private const val PAYLOAD_FILE_NAME = "legacy-migration-payload.json"
+private const val FAILED_PAYLOAD_FILE_NAME = "legacy-migration-payload.failed.json"
+
+/**
+ * Records the markers and routes read out of the legacy database, for the migration screen to
+ * import. Returns false if the file couldn't be written, in which case the caller should leave its
+ * "migration done" flag unset so the whole thing is retried on the next launch.
+ */
+fun stageLegacyMigrationPayload(payloadJson: String): Boolean =
+    try {
+        FileSystem.SYSTEM.write(payloadPath) { writeUtf8(payloadJson) }
+        println("LegacyMigration: staged ${payloadJson.length} chars at $payloadPath")
+        true
+    } catch (t: Throwable) {
+        println("LegacyMigration: could not stage payload: $t")
+        false
+    }
+
+/** Whether there is a staged import waiting, i.e. whether to show the migration screen. */
+fun hasPendingLegacyMigration(): Boolean = FileSystem.SYSTEM.exists(payloadPath)
+
+/**
+ * Imports the staged markers and routes into Room, naming the ones the legacy app didn't store a
+ * name for from current map tiles (see [TileLegacyMarkerNamer]).
+ *
+ * Reports progress as (done so far, total). The staged payload is left in place unless the import
+ * actually reached the database, so a run that stops for want of map data can simply be tried
+ * again - the import writes nothing at all in that case, because a half-imported database can't
+ * be resumed without duplicating whatever did land.
+ */
+@OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
+suspend fun runPendingLegacyMigration(
+    onProgress: (done: Int, total: Int) -> Unit,
+): LegacyImportResult {
+    val payloadJson = try {
+        FileSystem.SYSTEM.read(payloadPath) { readUtf8() }
+    } catch (t: Throwable) {
+        println("LegacyMigration: could not read staged payload: $t")
+        return LegacyImportResult.Unreadable
+    }
+
     val dao = MarkersAndRoutesDatabaseProvider.getInstance().routeDao()
-    importLegacyPayload(payloadJson, dao)
+
+    // A grid of our own rather than the geo engine's: this runs before the engine starts, and
+    // tearing it down afterwards keeps its tile readers and worker thread from outliving the
+    // import.
+    val treeContext = newSingleThreadContext("TreeContext")
+    val gridState = ProtomapsGridState(passedInTreeContext = treeContext)
+    gridState.tileClient = createIosVectorTileClient(baseUrl = tileProviderUrl())
+    // Offline map extracts live alongside the databases in Documents, so a user who has
+    // downloaded their area can be migrated with no network connection at all.
+    gridState.start(NSHomeDirectory() + "/Documents")
+
+    val namer = TileLegacyMarkerNamer(
+        gridState = gridState,
+        strings = ComposeLocalizedStrings(),
+        log = { message -> println("LegacyMarkerNamer: $message") },
+    )
+
+    val result = try {
+        importLegacyPayload(payloadJson, dao, namer, onProgress)
+    } catch (t: Throwable) {
+        println("LegacyMigration: import failed: $t")
+        LegacyImportResult.Unreadable
+    } finally {
+        gridState.stop()
+        treeContext.close()
+    }
+
+    when (result) {
+        is LegacyImportResult.Imported -> {
+            // Written to the database, so the staged copy has done its job. The legacy Realm
+            // itself is still there - we never delete anything belonging to the old app.
+            println("LegacyMigration: imported ${result.count} markers + routes")
+            try {
+                FileSystem.SYSTEM.delete(payloadPath)
+            } catch (t: Throwable) {
+                println("LegacyMigration: imported, but could not delete staged payload: $t")
+            }
+        }
+
+        LegacyImportResult.NeedsMapData -> {
+            // Nothing was written. Leave the payload staged so the screen can offer to try again,
+            // now or on the next launch.
+            println("LegacyMigration: no map data available; import not started")
+        }
+
+        LegacyImportResult.Unreadable -> {
+            // Retrying is pointless, so park the payload under another name rather than leave the
+            // migration screen greeting the user on every launch from here on. The file stays on
+            // disk for support, and the legacy database it was built from is untouched.
+            println("LegacyMigration: staged payload could not be used")
+            try {
+                FileSystem.SYSTEM.atomicMove(payloadPath, failedPayloadPath)
+            } catch (t: Throwable) {
+                println("LegacyMigration: could not park unusable payload: $t")
+            }
+        }
+    }
+
+    return result
 }
+
+/**
+ * The tile server, read from Info.plist where the build writes it (values come from the gitignored
+ * Local.xcconfig). Read here rather than borrowed from IosSoundscapeService because the migration
+ * runs before that service exists.
+ */
+private fun tileProviderUrl(): String =
+    NSBundle.mainBundle.objectForInfoDictionaryKey("TileProviderURL") as? String ?: ""

--- a/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/preferences/IosPreferencesProvider.kt
+++ b/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/preferences/IosPreferencesProvider.kt
@@ -57,10 +57,18 @@ class IosPreferencesProvider : PreferencesProvider {
         // Drop every key in the app domain. NSUserDefaults posts a single
         // change notification, so any registered listeners will be notified
         // for each key that actually changed via notifyChangedKeys().
+        //
+        // Except the legacy app's own settings. We share a bundle identifier
+        // with it, so its GDA* keys sit in the same domain as ours - but they
+        // are not ours to reset. LegacyMigrator copies them rather than moving
+        // them precisely so that a user who rolls back to the legacy build
+        // still has their settings, and so the migration can be re-run or
+        // corrected later; deleting them here would quietly break both.
         @Suppress("UNCHECKED_CAST")
         val keys = (defaults.dictionaryRepresentation() as? Map<String, Any?>)?.keys
             ?: emptySet()
         for (key in keys) {
+            if (key.startsWith(LEGACY_KEY_PREFIX)) continue
             defaults.removeObjectForKey(key)
         }
     }
@@ -91,5 +99,14 @@ class IosPreferencesProvider : PreferencesProvider {
             }
         }
         previousSnapshot = current
+    }
+
+    private companion object {
+        /**
+         * Prefix on every setting belonging to the legacy Microsoft Soundscape iOS app, which
+         * shares our bundle identifier and therefore our UserDefaults domain. See LegacyMigrator
+         * in the iOS app target.
+         */
+        const val LEGACY_KEY_PREFIX = "GDA"
     }
 }


### PR DESCRIPTION
Markers imported from the legacy iOS app were arriving with names like "ft-443758688". The legacy app never stored a name for a marker created from a place on the map - it kept only the POI's key and resolved it against its own cache of the retired Soundscape tile service each time it drew the list. Our importer fell back to that raw key when there was no nickname.

We can't follow the legacy path: the service is gone and its cache realm may have been cleared or may never have covered the marker. So look the key up in the tiles we serve now instead. The key is "ft-" plus an OSM id; planetiler encodes the same object as osm_id * 10 + type, so both the node and the way candidate are tried. Ids don't live forever, so a miss falls back to the named polygon the marker sits inside, then the nearest named POI within 50m - a marker made from a POI was stored at that POI's own coordinates, and anything further away is more likely a different place than the one the user saved - and finally to the address the legacy app geocoded.

That means fetching tiles, which is why the import no longer runs during app launch: blocking init() on the network is how an app gets killed by the watchdog. LegacyMigrator now only reads the legacy Realm, which is quick and local, and stages the result as JSON. A new one-shot screen after the splash does the import with a progress count. It isn't part of onboarding, which an upgrading user has already completed and would never see.

When there is no map data at all - no network, no offline extract - nothing is written and the user is offered a retry. A half-import can't be resumed later without duplicating whatever landed, so naming happens in full before the first row is inserted. The staged payload survives until the import reaches the database, so a retry, or the next launch, starts clean. "Not now" is always available: being held on this screen with no signal would lock a user out of the app entirely.

Also stop IosPreferencesProvider.clearAll() deleting the legacy app's GDA* settings. We share a bundle identifier with it, so its keys sit in our domain, but the migrator copies rather than moves them precisely so that a rollback or a corrected re-migration still has them - and "reset settings to defaults" was destroying them permanently.


Claude-Session: https://claude.ai/code/session_01MM5Zz72Thbg4QQTejNqvw3