### PR TITLE
Play the proximity beacon on iOS as the destination gets close

### DIFF
--- a/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/audio/BeaconPlayer.kt
+++ b/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/audio/BeaconPlayer.kt
@@ -3,6 +3,7 @@ package org.scottishtecharmy.soundscape.audio
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.get
 import kotlinx.cinterop.set
+import org.scottishtecharmy.soundscape.geoengine.utils.distance
 import platform.AVFAudio.AVAudioFile
 import platform.AVFAudio.AVAudioPCMBuffer
 import platform.AVFAudio.AVAudioPlayerNodeBufferInterrupts
@@ -20,6 +21,12 @@ class BeaconPlayer(
     private val beaconType: BeaconType,
     val beaconLatitude: Double,
     val beaconLongitude: Double,
+    /**
+     * Whether the beacon is positioned in the 3D environment. False for the proximity
+     * beacon, which conveys distance rather than direction and so plays flat, matching
+     * `isLocalized: false` in the original iOS app.
+     */
+    private val spatialised: Boolean = true,
 ) {
     val layer = AudioLayer()
     private val buffers = mutableMapOf<String, AVAudioPCMBuffer>()
@@ -77,7 +84,8 @@ class BeaconPlayer(
     fun updateForGeometry(
         listenerLatitude: Double,
         listenerLongitude: Double,
-        listenerHeading: Double?
+        listenerHeading: Double?,
+        proximityNear: Double
     ) {
         if (!isPlaying) return
 
@@ -86,10 +94,22 @@ class BeaconPlayer(
             beaconLatitude, beaconLongitude
         )
 
-        // Update 3D position based on bearing from listener to beacon
-        layer.position = bearingToPoint(poiBearing)
+        if (spatialised) {
+            // Update 3D position based on bearing from listener to beacon
+            layer.position = bearingToPoint(poiBearing)
+        }
 
-        val selection = beaconType.selector(listenerHeading, poiBearing)
+        val selection = beaconType.selector(
+            BeaconGeometry(
+                userHeading = listenerHeading,
+                poiBearing = poiBearing,
+                distance = distance(
+                    listenerLatitude, listenerLongitude,
+                    beaconLatitude, beaconLongitude
+                ),
+                proximityNear = proximityNear
+            )
+        )
         val newAssetName = if (selection != null) {
             beaconType.assets.getOrNull(selection.assetIndex)
         } else {

--- a/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/audio/BeaconTypes.kt
+++ b/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/audio/BeaconTypes.kt
@@ -13,10 +13,25 @@ package org.scottishtecharmy.soundscape.audio
 data class AssetSelection(val assetIndex: Int, val volume: Float)
 
 /**
- * Selector function type: takes user heading (nullable) and POI bearing,
- * returns which asset to play and at what volume, or null for silence.
+ * Everything a selector needs to pick an asset. The directional beacons use the angular
+ * relationship between the user and the beacon; the proximity beacon uses the distance.
  */
-typealias BeaconSelector = (userHeading: Double?, poiBearing: Double) -> AssetSelection?
+data class BeaconGeometry(
+    /** User heading in degrees, or null when the heading is unknown. */
+    val userHeading: Double?,
+    /** Bearing from the user to the beacon, in degrees. */
+    val poiBearing: Double,
+    /** Distance from the user to the beacon, in metres. */
+    val distance: Double,
+    /** Range within which the proximity beacon plays its "close" asset, in metres. */
+    val proximityNear: Double,
+)
+
+/**
+ * Selector function type: takes the current beacon geometry and returns which asset to
+ * play and at what volume, or null for silence.
+ */
+typealias BeaconSelector = (geometry: BeaconGeometry) -> AssetSelection?
 
 data class BeaconType(
     val name: String,
@@ -32,9 +47,9 @@ data class BeaconType(
  *   On-Axis:  central 45° window (337.5° to 22.5°) → asset[0]
  *   Off-Axis: remaining → asset[1]
  */
-private fun twoRegionSelector(userHeading: Double?, poiBearing: Double): AssetSelection? {
-    if (userHeading == null) return AssetSelection(1, 1f)
-    val angle = normalizeAngle(userHeading - poiBearing)
+private fun twoRegionSelector(geometry: BeaconGeometry): AssetSelection? {
+    val userHeading = geometry.userHeading ?: return AssetSelection(1, 1f)
+    val angle = normalizeAngle(userHeading - geometry.poiBearing)
     return if (angle >= 337.5 || angle <= 22.5) {
         AssetSelection(0, 1f)
     } else {
@@ -48,9 +63,9 @@ private fun twoRegionSelector(userHeading: Double?, poiBearing: Double): AssetSe
  *   A:      110° side windows (235°–345° or 15°–125°) → asset[1]
  *   Behind: remaining (125°–235°) → asset[2]
  */
-private fun threeRegionSelector(userHeading: Double?, poiBearing: Double): AssetSelection? {
-    if (userHeading == null) return AssetSelection(2, 1f)
-    val angle = normalizeAngle(userHeading - poiBearing)
+private fun threeRegionSelector(geometry: BeaconGeometry): AssetSelection? {
+    val userHeading = geometry.userHeading ?: return AssetSelection(2, 1f)
+    val angle = normalizeAngle(userHeading - geometry.poiBearing)
     return when {
         angle >= 345 || angle <= 15 -> AssetSelection(0, 1f)
         (angle in 235.0..345.0) || (angle in 15.0..125.0) -> AssetSelection(1, 1f)
@@ -65,15 +80,26 @@ private fun threeRegionSelector(userHeading: Double?, poiBearing: Double): Asset
  *   B:      70° side windows (235°–305° or 55°–125°) → asset[2]
  *   Behind: remaining (125°–235°) → asset[3]
  */
-private fun fourRegionSelector(userHeading: Double?, poiBearing: Double): AssetSelection? {
-    if (userHeading == null) return AssetSelection(3, 1f)
-    val angle = normalizeAngle(userHeading - poiBearing)
+private fun fourRegionSelector(geometry: BeaconGeometry): AssetSelection? {
+    val userHeading = geometry.userHeading ?: return AssetSelection(3, 1f)
+    val angle = normalizeAngle(userHeading - geometry.poiBearing)
     return when {
         angle >= 345 || angle <= 15 -> AssetSelection(0, 1f)
         (angle in 305.0..345.0) || (angle in 15.0..55.0) -> AssetSelection(1, 1f)
         (angle in 235.0..305.0) || (angle in 55.0..125.0) -> AssetSelection(2, 1f)
         else -> AssetSelection(3, 1f)
     }
+}
+
+/**
+ * Distance-based selector for the proximity beacon (ProximityBeacon in the original iOS
+ * app, msc_ProximityDescriptor on Android): the "close" asset within
+ * [BeaconGeometry.proximityNear], the "far" asset out to twice that, silence beyond.
+ */
+private fun proximitySelector(geometry: BeaconGeometry): AssetSelection? = when {
+    geometry.distance < geometry.proximityNear -> AssetSelection(0, 1f)
+    geometry.distance < (2 * geometry.proximityNear) -> AssetSelection(1, 1f)
+    else -> null
 }
 
 /** Normalize angle to [0, 360) range */
@@ -164,4 +190,16 @@ val BEACON_TYPES: Map<String, BeaconType> = mapOf(
         beatsInPhrase = 18,
         selector = ::threeRegionSelector
     ),
+)
+
+/**
+ * The second beacon that plays alongside the directional one whenever a destination
+ * beacon is set, telling the user how close they are getting. Unlike the directional
+ * beacons it is not spatialised — it is about distance, not direction.
+ */
+val PROXIMITY_BEACON_TYPE = BeaconType(
+    name = "Proximity",
+    assets = listOf("Proximity_Close", "Proximity_Far"),
+    beatsInPhrase = 6,
+    selector = ::proximitySelector
 )

--- a/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/audio/IosAudioEngine.kt
+++ b/shared/src/iosMain/kotlin/org/scottishtecharmy/soundscape/audio/IosAudioEngine.kt
@@ -42,6 +42,12 @@ private const val SESSION_ACTIVATION_TIMEOUT_MS = 2_000
 private const val SESSION_ACTIVATION_RETRY_INTERVAL_MS = 200
 
 /**
+ * Proximity range used until the first updateGeometry call supplies one. Matches the
+ * value IosSoundscapeService passes.
+ */
+private const val DEFAULT_PROXIMITY_NEAR = 15.0
+
+/**
  * iOS audio engine implementing the KMP AudioEngine interface.
  * Uses Apple's AVAudioEngine with AVAudioEnvironmentNode for HRTF spatial audio.
  * Ported from the original Soundscape iOS Swift implementation.
@@ -97,6 +103,11 @@ class IosAudioEngine : AudioEngine {
     private var currentBeaconType = "Current"
     private var beaconMuted = false
 
+    // Range within which the proximity beacon plays its "close" asset. Updated by
+    // updateGeometry; seeded so a beacon created before the first geometry update
+    // still uses a sensible range.
+    private var proximityNear = DEFAULT_PROXIMITY_NEAR
+
     // Media control target for remote commands
     var mediaControlTarget: MediaControlTarget? = null
 
@@ -119,7 +130,13 @@ class IosAudioEngine : AudioEngine {
 
     private sealed class PlayerEntry {
         class Discrete(val player: DiscretePlayer, val isTts: Boolean) : PlayerEntry()
-        class Beacon(val player: BeaconPlayer) : PlayerEntry()
+        class Beacon(
+            val player: BeaconPlayer,
+            /** The distance beacon that plays alongside [player]; null for heading-only beacons. */
+            val proximityPlayer: BeaconPlayer?
+        ) : PlayerEntry() {
+            val players: List<BeaconPlayer> get() = listOfNotNull(player, proximityPlayer)
+        }
     }
 
     private inline fun <T> withActivePlayersLock(block: () -> T): T {
@@ -558,17 +575,52 @@ class IosAudioEngine : AudioEngine {
         player.startPlaying()
         player.setMuted(beaconMuted)
 
-        // Apply initial geometry
-        player.updateForGeometry(listenerLatitude, listenerLongitude, listenerHeading)
+        // The distance beacon plays alongside the directional one, telling the user how
+        // close the destination is. A heading-only beacon (the settings preview) has no
+        // real destination to be close to, so it gets none.
+        val proximityPlayer = if (headingOnly) null else createProximityPlayer(location)
 
-        withActivePlayersLock { activePlayers[handle] = PlayerEntry.Beacon(player) }
+        // Apply initial geometry
+        player.updateForGeometry(
+            listenerLatitude, listenerLongitude, listenerHeading, proximityNear
+        )
+        proximityPlayer?.updateForGeometry(
+            listenerLatitude, listenerLongitude, listenerHeading, proximityNear
+        )
+
+        withActivePlayersLock {
+            activePlayers[handle] = PlayerEntry.Beacon(player, proximityPlayer)
+        }
         return handle
+    }
+
+    /**
+     * Create and start the non-spatialised distance beacon. Returns null if its assets
+     * can't be loaded — the directional beacon is still worth playing on its own.
+     */
+    private fun createProximityPlayer(location: LngLatAlt): BeaconPlayer? {
+        val player = BeaconPlayer(
+            PROXIMITY_BEACON_TYPE,
+            location.latitude,
+            location.longitude,
+            spatialised = false
+        )
+        if (!player.loadAssets()) {
+            println("IosAudioEngine: Failed to load proximity beacon assets")
+            return null
+        }
+
+        player.layer.attach(engine)
+        player.layer.connect(engine.mainMixerNode)
+        player.startPlaying()
+        player.setMuted(beaconMuted)
+        return player
     }
 
     override fun destroyBeacon(beaconHandle: Long) {
         val entry = withActivePlayersLock { activePlayers.remove(beaconHandle) }
         if (entry is PlayerEntry.Beacon) {
-            entry.player.stop()
+            entry.players.forEach { it.stop() }
         }
     }
 
@@ -578,7 +630,7 @@ class IosAudioEngine : AudioEngine {
             activePlayers.values.filterIsInstance<PlayerEntry.Beacon>()
         }
         for (entry in beacons) {
-            entry.player.setMuted(beaconMuted)
+            entry.players.forEach { it.setMuted(beaconMuted) }
         }
         return beaconMuted
     }
@@ -596,6 +648,7 @@ class IosAudioEngine : AudioEngine {
         this.listenerLatitude = listenerLatitude
         this.listenerLongitude = listenerLongitude
         this.listenerHeading = listenerHeading
+        this.proximityNear = proximityNear
 
         // Update listener orientation on all environment nodes
         if (listenerHeading != null) {
@@ -616,9 +669,11 @@ class IosAudioEngine : AudioEngine {
             activePlayers.values.filterIsInstance<PlayerEntry.Beacon>()
         }
         for (entry in beacons) {
-            entry.player.updateForGeometry(
-                listenerLatitude, listenerLongitude, this.listenerHeading
-            )
+            entry.players.forEach {
+                it.updateForGeometry(
+                    listenerLatitude, listenerLongitude, this.listenerHeading, proximityNear
+                )
+            }
         }
     }
 

--- a/shared/src/iosTest/kotlin/org/scottishtecharmy/soundscape/audio/ProximityBeaconTest.kt
+++ b/shared/src/iosTest/kotlin/org/scottishtecharmy/soundscape/audio/ProximityBeaconTest.kt
@@ -1,0 +1,75 @@
+package org.scottishtecharmy.soundscape.audio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The proximity beacon plays alongside the directional one and tells the user how close
+ * the destination is. Its asset choice is purely a function of distance, so it can be
+ * checked without any audio hardware.
+ */
+class ProximityBeaconTest {
+
+    private fun selectAt(distance: Double, proximityNear: Double = 15.0) =
+        PROXIMITY_BEACON_TYPE.selector(
+            BeaconGeometry(
+                userHeading = 0.0,
+                poiBearing = 0.0,
+                distance = distance,
+                proximityNear = proximityNear
+            )
+        )
+
+    private fun assetAt(distance: Double, proximityNear: Double = 15.0) =
+        selectAt(distance, proximityNear)?.let {
+            PROXIMITY_BEACON_TYPE.assets[it.assetIndex]
+        }
+
+    @Test
+    fun closeAssetInsideProximityNear() {
+        assertEquals("Proximity_Close", assetAt(0.0))
+        assertEquals("Proximity_Close", assetAt(14.9))
+    }
+
+    @Test
+    fun farAssetOutToTwiceProximityNear() {
+        assertEquals("Proximity_Far", assetAt(15.0))
+        assertEquals("Proximity_Far", assetAt(29.9))
+    }
+
+    @Test
+    fun silentBeyondTwiceProximityNear() {
+        assertNull(selectAt(30.0))
+        assertNull(selectAt(1000.0))
+    }
+
+    @Test
+    fun thresholdsScaleWithProximityNear() {
+        assertEquals("Proximity_Close", assetAt(19.0, proximityNear = 20.0))
+        assertEquals("Proximity_Far", assetAt(35.0, proximityNear = 20.0))
+        assertNull(selectAt(41.0, proximityNear = 20.0))
+    }
+
+    @Test
+    fun directionalBeaconsIgnoreDistance() {
+        val type = BEACON_TYPES.getValue("Current")
+        val near = type.selector(
+            BeaconGeometry(
+                userHeading = 0.0,
+                poiBearing = 0.0,
+                distance = 1.0,
+                proximityNear = 15.0
+            )
+        )
+        val far = type.selector(
+            BeaconGeometry(
+                userHeading = 0.0,
+                poiBearing = 0.0,
+                distance = 5000.0,
+                proximityNear = 15.0
+            )
+        )
+        assertEquals(near, far)
+    }
+}


### PR DESCRIPTION
The iOS engine only ever created the directional beacon. Android's BeaconWithProximity, and the original iOS app's ProximityBeacon, also run a second beacon alongside it whose asset is chosen by distance: Proximity_Close inside proximityNear, Proximity_Far out to twice that, silence beyond. So IosAudioEngine took a proximityNear argument in updateGeometry and threw it away, and ignored headingOnly in createBeacon.

Selectors now take a BeaconGeometry (heading, bearing, distance, proximityNear) rather than heading and bearing alone, which is what lets a selector be driven by distance instead of angle. The proximity beacon is not spatialised - it is about distance, not direction - so it connects straight to mainMixerNode. That is required rather than merely tidier: the bundled Proximity_*.wav files are stereo, and AVAudioEnvironmentNode only accepts mono.

The WAVs are already in the iOS bundle via the Sounds folder reference in project.yml. Not compile-checked: iOS targets are gated to macOS in shared/build.gradle.kts.


Claude-Session: https://claude.ai/code/session_01DQyoTtPL9ENAf6PiJKmhXf