### PR TITLE
Stop stale Gradle daemons in every self-hosted iOS job

### DIFF
--- a/.github/actions/setup-ios-toolchain/action.yml
+++ b/.github/actions/setup-ios-toolchain/action.yml
@@ -48,6 +48,15 @@ runs:
     - name: Setup JDK + Gradle
       uses: ./.github/actions/setup-jdk-gradle
 
+    - name: Stop stale Gradle daemons on self-hosted
+      # A self-hosted runner is a persistent machine, so a Gradle daemon left
+      # running (or stuck) by an earlier job can get reused by this one and
+      # blow up project configuration. Kill any before the job does its own
+      # Gradle work.
+      if: runner.environment == 'self-hosted'
+      shell: bash
+      run: ./gradlew --stop
+
     - name: Ensure ANDROID_HOME on self-hosted
       # The shared Kotlin Multiplatform module has an `android` target, so the
       # Xcode pre-build script that invokes Gradle needs the SDK location.

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -167,13 +167,6 @@ jobs:
       - name: Setup iOS toolchain
         uses: ./.github/actions/setup-ios-toolchain
 
-      # This runner is a single persistent self-hosted Mac, so a Gradle daemon
-      # left running (or stuck) by a previous job on this machine can get
-      # reused here and blow up project configuration. Kill any daemons
-      # before we start a build of our own.
-      - name: Stop stale Gradle daemons
-        run: ./gradlew --stop
-
       # As with Android, secrets won't be available on fork-triggered PRs.
       # iOS tests that require provider URLs check at runtime, so an empty
       # Local.xcconfig is acceptable.


### PR DESCRIPTION
Only run-tests' ios-test job stopped leftover Gradle daemons on the persistent Mac runner; the nightly and build-app iOS jobs didn't. Move the step into setup-ios-toolchain so every self-hosted job that uses it gets it.


Claude-Session: https://claude.ai/code/session_01MFRb7hjeHp4B378UzBUc1H