### PR TITLE
Add --stacktrace to the iOS shared-test compile step

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -360,7 +360,7 @@ jobs:
       # maplibre-compose's embedded linker flags. xcodebuild archive below
       # builds via the Xcode/SPM toolchain that resolves MapLibre.
       - name: Compile shared Kotlin/Native tests for iOS simulator
-        run: ./gradlew :shared:compileTestKotlinIosSimulatorArm64
+        run: ./gradlew :shared:compileTestKotlinIosSimulatorArm64 --stacktrace
 
       - name: Setup iOS signing
         uses: ./.github/actions/setup-ios-signing


### PR DESCRIPTION
The ios-build job fails with "A problem occurred configuring project ':app' > java.lang.NullPointerException (no error message)", and the failure does not reproduce by hand on the runner — same command, same workspace, same account, config cache on, all succeed. Without a stack trace there is nothing identifying the class that threw.


Claude-Session: https://claude.ai/code/session_01DDy7qSUt3v4L6m8DgLiDHn