### PR TITLE
Don't configure :app in the self-hosted iOS jobs

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -360,7 +360,7 @@ jobs:
       # maplibre-compose's embedded linker flags. xcodebuild archive below
       # builds via the Xcode/SPM toolchain that resolves MapLibre.
       - name: Compile shared Kotlin/Native tests for iOS simulator
-        run: ./gradlew :shared:compileTestKotlinIosSimulatorArm64 --stacktrace
+        run: ./gradlew --configure-on-demand :shared:compileTestKotlinIosSimulatorArm64
 
       - name: Setup iOS signing
         uses: ./.github/actions/setup-ios-signing
@@ -562,7 +562,7 @@ jobs:
       # maplibre-compose's embedded linker flags. xcodebuild below builds via
       # the Xcode/SPM toolchain that resolves MapLibre.
       - name: Compile shared Kotlin/Native tests for iOS device
-        run: ./gradlew :shared:compileTestKotlinIosArm64
+        run: ./gradlew --configure-on-demand :shared:compileTestKotlinIosArm64
 
       - name: Setup iOS signing
         uses: ./.github/actions/setup-ios-signing


### PR DESCRIPTION
ios-build and ios-firebase only need :shared, but Gradle configures every project by default, so both were configuring :app. On the self-hosted Mac that runs AGP's NdkLocator, where File.list() on $ANDROID_HOME/ndk returns null and AGP dereferences it unguarded:

  java.lang.NullPointerException
    at ...cxx.configure.NdkLocatorKt.getNdkVersionedFolders(NdkLocator.kt:326)

The Android jobs build on ubuntu-latest and are unaffected, so nothing that needs the NDK relies on this path. run-tests' ios-test has never hit the bug because it already passes --configure-on-demand.

Verified with an init script logging beforeProject: without the flag Gradle
configures :, :app and :shared; with it, only : and :shared.


Claude-Session: https://claude.ai/code/session_01DDy7qSUt3v4L6m8DgLiDHn