### PR TITLE
Bundle the geography resources in the iOS app

### DIFF
--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -50,6 +50,8 @@ targets:
       - path: iosApp
       - path: ../shared/src/commonMain/resources/address
         type: folder
+      - path: ../shared/src/commonMain/resources/geography
+        type: folder
       - path: ../app/src/main/assets/open_source_licenses.json
         buildPhase: resources
       - path: ../app/src/main/assets/osm-liberty-accessible


### PR DESCRIPTION
countries.geojson never made it into the app bundle - project.yml only listed the sibling address folder - so CountryBoundaries threw "Resource not found: geography/countries.geojson" from its lazy initialiser. That escaped into the Compose measure pass via PlacesNearbyList -> LocationDescription.process -> addressCountryCode and took the app down.

Android is unaffected as the shared module puts the whole src/commonMain/resources directory on its resource path.


Claude-Session: https://claude.ai/code/session_01PXwNUHaa9gxUhFYgwnz74M